### PR TITLE
Fix crates.io dependency versions

### DIFF
--- a/aws/Cargo.toml
+++ b/aws/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["aws", "dynamodb", "sqs", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services" }
-skyzen-s3 = { path = "../s3", optional = true }
+skyzen-services = { path = "../services", version = "0.1.0" }
+skyzen-s3 = { path = "../s3", version = "0.1.0", optional = true }
 aws-config = "1"
 # Disable the SDK default `rustls` feature: it pulls the legacy `tls-rustls` connector
 # (rustls 0.21 / hyper-rustls 0.24), which is redundant with the modern `default-https-client`

--- a/azure/Cargo.toml
+++ b/azure/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["azure", "cosmos", "blob", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services" }
+skyzen-services = { path = "../services", version = "0.1.0" }
 azure_data_cosmos = { version = "0.36", optional = true }
 azure_messaging_servicebus = { version = "0.21", optional = true }
 opendal = { version = "0.58", default-features = false, features = ["executors-tokio", "http-transport-reqwest-rustls", "services-azblob"], optional = true }

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["cloudflare", "workers", "skyzen", "services"]
 categories = ["web-programming::http-server", "wasm"]
 
 [dependencies]
-skyzen = { path = "..", default-features = false, features = ["ws"] }
-skyzen-services = { path = "../services" }
+skyzen = { path = "..", version = "0.1.1", default-features = false, features = ["ws"] }
+skyzen-services = { path = "../services", version = "0.1.0" }
 worker-sys = { version = "0.7", features = ["d1", "queue"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["redis", "key-value", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services" }
+skyzen-services = { path = "../services", version = "0.1.0" }
 redis = { version = "1", default-features = false, features = ["aio", "connection-manager", "smol-comp"] }
 
 [features]

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["s3", "object-storage", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services" }
+skyzen-services = { path = "../services", version = "0.1.0" }
 # Disable the SDK default `rustls` feature: it pulls the legacy `tls-rustls` connector
 # (rustls 0.21 / hyper-rustls 0.24), which is redundant with the modern `default-https-client`
 # (rustls-aws-lc) and carries unpatched RustSec advisories. The default HTTPS client is unaffected.

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["http", "web", "framework", "services"]
 categories = ["web-programming::http-server"]
 
 [dependencies]
-skyzen-core = { path = "../core" }
+skyzen-core = { path = "../core", version = "0.1.1" }
 http-kit.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Adds crates.io version requirements to every internal path dependency used by publishable workspace crates. Verified with cargo package --workspace --allow-dirty --no-verify.