### PR TITLE
fix(openapi)!: require a schema where a schema is the contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,11 @@ futures-core = { version = "0.3.32" }
 futures-channel = { version = "0.3.32", optional = true }
 multer = { version = "3.1", optional = true }
 http = "1.4"
-utoipa = { version = "5.4", default-features = false }
+# `macros` is named here rather than inherited from `skyzen-core`: `skyzen::ToSchema` re-exports
+# utoipa's *derive*, and a payload carried by `Json`/`Form`/`Query` is now required to implement
+# the trait, so the derive is part of this crate's own public surface and cannot depend on another
+# crate happening to switch it on.
+utoipa = { version = "5.4", default-features = false, features = ["macros"] }
 utoipa-redoc = "6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -278,15 +278,17 @@ use skyzen::{
     extract::{Path, Query},
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Result,
+    Result, ToSchema,
 };
 
-#[derive(Serialize)]
+// A payload carried by `Json`, `Form` or `Query` derives `ToSchema` alongside its serde derive:
+// one says how it goes on the wire, the other how the OpenAPI document describes it.
+#[derive(Serialize, ToSchema)]
 struct MessageResponse {
     message: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 struct GreetingQuery {
     prefix: Option<String>,
 }
@@ -419,9 +421,9 @@ async fn update_profile(
 
 | Extractor | Path | Description |
 |---|---|---|
-| `Json<T>` | `skyzen::utils::Json` | Deserializes a JSON request body |
-| `Query<T>` | `skyzen::extract::Query` | Deserializes the query string, repeated keys included |
-| `Form<T>` | `skyzen::utils::Form` | Deserializes `application/x-www-form-urlencoded` |
+| `Json<T>` | `skyzen::utils::Json` | Deserializes a JSON request body (`T: ToSchema`) |
+| `Query<T>` | `skyzen::extract::Query` | Deserializes the query string, repeated keys included (`T: ToSchema`) |
+| `Form<T>` | `skyzen::utils::Form` | Deserializes `application/x-www-form-urlencoded` (`T: ToSchema`) |
 | `Path<T>` | `skyzen::extract::Path` | Deserializes the captured `{name}` segments into a struct, tuple or primitive |
 | `Params` | `skyzen::routing::Params` | Path parameters by name at runtime (`params.get("id")?`) |
 | `Multipart` | `skyzen::utils::Multipart` | Streams multipart form data and file uploads |
@@ -436,12 +438,23 @@ async fn update_profile(
 | `RequestBodyLimit` | `skyzen::RequestBodyLimit` | The body cap in force, so a handler can size its own reads |
 | `Option<T>`, `Result<T, _>` | — | Wrap any extractor to make its failure recoverable |
 
+A body payload carries `T: ToSchema` so that what the endpoint documents is what it actually
+serializes — the bound is what makes the generated document trustworthy rather than best-effort.
+`#[derive(ToSchema)]` beside the serde derive is the whole cost, and every primitive, collection
+and `serde_json::Value` already has one. The derive expands to `::utoipa::…` paths, so an
+application declares `utoipa = "5"` alongside `skyzen` (`skyzen new` does this for you);
+`skyzen::ToSchema` re-exports the trait the bound is written against.
+
+`Path<T>` is the exception and takes no bound: the route pattern names its parameters, and
+`Path<(String, u32)>` for a multi-segment route has no schema to give. `#[skyzen::openapi]` types
+those parameters by probing the payload at the handler's own call site instead.
+
 ### Built-in Responders
 
 | Responder | Description |
 |---|---|
 | `&'static str`, `String`, `Bytes` | Plain text or raw bytes |
-| `Json<T>` / `PrettyJson<T>` | Serializes `T` to `application/json` |
+| `Json<T>` / `PrettyJson<T>` | Serializes `T` to `application/json` (`T: ToSchema`) |
 | `Html<T>` | Sends its payload as `text/html; charset=utf-8` |
 | `StatusCode` | An empty response with that status |
 | `Redirect` | `to` (302), `see_other` (303), `temporary` (307), `permanent` (308), or `with_status` |

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -204,12 +204,20 @@ pub const fn dependencies(template: Template) -> &'static [DependencySpec] {
         name: "futures-util",
         features: &[],
     };
+    /// A payload carried by `Json`, `Form` or `Query` has to implement `ToSchema`, and utoipa's
+    /// derive expands to `::utoipa::…` paths — so the crate that writes `#[derive(ToSchema)]`
+    /// needs the dependency itself. `skyzen::ToSchema` re-exports the trait, which is what the
+    /// bound is written against; it cannot re-export the crate the expansion names.
+    const UTOIPA: DependencySpec = DependencySpec {
+        name: "utoipa",
+        features: &[],
+    };
 
     match template {
         Template::Minimal => &[SKYZEN],
         // The api template declares a portable KV service, so it needs the wrappers, the
         // in-process backend `[native.service.cache]` names, and the Cloudflare one.
-        Template::Api => &[SKYZEN, SERVICES, TEST, CLOUDFLARE, SERDE],
+        Template::Api => &[SKYZEN, SERVICES, TEST, CLOUDFLARE, SERDE, UTOIPA],
         Template::ServerlessEvents => &[SKYZEN, SERVICES, CLOUDFLARE, SERDE, TRACING],
         Template::DurableRealtime => &[SKYZEN_WS, CLOUDFLARE, SERDE, FUTURES],
     }

--- a/cli/templates/api/Cargo.toml.tmpl
+++ b/cli/templates/api/Cargo.toml.tmpl
@@ -15,3 +15,9 @@ crate-type = ["cdylib", "rlib"]
 # restores agreement after upgrading the CLI.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "={{ ctx.wasm_bindgen_version }}"
+
+[package.metadata.cargo-machete]
+# `utoipa` is reached only through what `#[derive(ToSchema)]` EXPANDS to — `::utoipa::…` paths —
+# so no source line names the crate and an unused-dependency check cannot see the use. Removing it
+# breaks the derive.
+ignored = ["utoipa"]

--- a/cli/templates/api/src/app.rs.tmpl
+++ b/cli/templates/api/src/app.rs.tmpl
@@ -3,10 +3,12 @@ use serde::Serialize;
 use skyzen::{
     routing::{CreateRouteNode, Params, Route, Router},
     utils::Json,
-    Result,
+    Result, ToSchema,
 };
 
-#[derive(Serialize)]
+/// A payload carried by `Json` derives `ToSchema` as well as `Serialize`: the first says how it
+/// is written to the wire, the second how the generated OpenAPI document describes it.
+#[derive(Serialize, ToSchema)]
 struct Greeting {
     name: String,
     seen_before: bool,

--- a/examples/embed_hyper.rs
+++ b/examples/embed_hyper.rs
@@ -49,10 +49,10 @@ use skyzen::{
     hyper::Hyper,
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Server,
+    Server, ToSchema,
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 struct StatusResponse {
     status: &'static str,
     runtime: &'static str,

--- a/examples/native.rs
+++ b/examples/native.rs
@@ -6,14 +6,15 @@ use skyzen::{
     extract::{Path, Query},
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
+    ToSchema,
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct Greeting {
     message: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 struct GreetingQuery {
     name: Option<String>,
     excited: Option<bool>,

--- a/examples/queue-consumer/Cargo.toml
+++ b/examples/queue-consumer/Cargo.toml
@@ -16,9 +16,16 @@ skyzen-services = { path = "../../services" }
 # The `backend = "memory"` wiring in Skyzen.toml expands to `skyzen_test`'s in-process mock.
 skyzen-test = { path = "../../test" }
 serde = { version = "1", features = ["derive"] }
+# utoipa's `ToSchema` derive expands to `::utoipa::…`, so the crate deriving it needs the
+# dependency; `skyzen::ToSchema` re-exports the trait, not the crate the expansion names.
+utoipa = "5"
 tracing = "0.1"
 
 [package.metadata.cargo-machete]
+# `utoipa` is reached only through what `#[derive(ToSchema)]` EXPANDS to — `::utoipa::…` paths —
+# so no source line names the crate and machete cannot see the use. The dependency is load-bearing
+# regardless: without it the derive does not resolve.
+#
 # Consumed by the code `#[skyzen::main]` GENERATES for `backend = "memory"`, which
 # cargo-machete cannot see in the source text.
-ignored = ["skyzen-test"]
+ignored = ["skyzen-test", "utoipa"]

--- a/examples/queue-consumer/src/main.rs
+++ b/examples/queue-consumer/src/main.rs
@@ -22,12 +22,15 @@ use serde::{Deserialize, Serialize};
 use skyzen::{
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Result,
+    Result, ToSchema,
 };
 use skyzen_services::{QueueBatch, QueueBatchDisposition, QueueMessageDisposition, QueueRetry};
 
 /// One unit of work, as it travels through the queue.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+///
+/// `ToSchema` rides along with the serde derives because the job arrives as a `Json<Job>` body:
+/// the payload of a body extractor is what the generated OpenAPI document describes.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 struct Job {
     /// Caller-assigned identity, echoed in the logs.
     id: String,

--- a/examples/services.rs
+++ b/examples/services.rs
@@ -17,18 +17,18 @@ use skyzen::{
     extract::Path,
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Result as SkyResult,
+    Result as SkyResult, ToSchema,
 };
 use skyzen_services::{Kv, Storage};
 use skyzen_test::mock::{InMemoryKv, InMemoryStorage};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 struct FileMetadata {
     name: String,
     size: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 struct UploadRequest {
     name: String,
     content: String,

--- a/src/extract/path.rs
+++ b/src/extract/path.rs
@@ -72,20 +72,22 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Path<T> {
         Ok(Self(value))
     }
 
+    /// `Path<T>` names no parameters of its own — the route pattern does — so this reports where
+    /// the values come from and nothing about their types.
+    ///
+    /// The types are supplied by `#[skyzen::openapi]`, which probes `T` at the handler's own call
+    /// site with [`SchemaProbe`](crate::openapi::SchemaProbe), where `T` is spelled out and the
+    /// `ToSchema` bound is therefore provable. That indirection is what lets `Path<(String, u32)>`
+    /// keep working: a tuple has no `ToSchema` and never will, and a multi-segment route is a
+    /// perfectly ordinary thing to write. Unlike the body extractors, this one cannot simply
+    /// require the bound.
     #[cfg(feature = "openapi")]
     fn openapi() -> Option<crate::openapi::ExtractorSchema> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Path,
             content_type: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: None,
         })
-    }
-
-    #[cfg(feature = "openapi")]
-    fn register_openapi_schemas(
-        defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
-    ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
     }
 }
 

--- a/src/extract/query.rs
+++ b/src/extract/query.rs
@@ -23,7 +23,7 @@ impl_deref!(Query);
 )]
 pub struct QueryError(String);
 
-impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Query<T> {
+impl<T: Send + Sync + DeserializeOwned + crate::ToSchema + 'static> Extractor for Query<T> {
     type Error = QueryError;
     // The query string is already on the request, so the future is ready on creation rather than
     // an `async` block with nothing to await.
@@ -40,7 +40,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Query<T> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Query,
             content_type: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
         })
     }
 
@@ -48,7 +48,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Query<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -60,13 +60,13 @@ mod tests {
     use serde::Deserialize;
     use skyzen_core::Extractor;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, PartialEq, crate::ToSchema)]
     struct Search {
         q: String,
         page: u8,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, PartialEq, crate::ToSchema)]
     struct Filter {
         tags: Option<Vec<String>>,
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -68,7 +68,8 @@ impl<E: Extractor, R: Responder> core::error::Error for HandlerError<E, R> {}
     note = "a handler is an `async fn` (or closure) whose arguments all implement `Extractor` and whose return type implements `Responder`",
     note = "the future a handler returns must be `Send`: do not hold an `Rc` or a `MutexGuard` across an `.await`",
     note = "a handler takes at most 15 arguments; group the rest into one extractor",
-    note = "common fixes: take path parameters as `Path<T>` or `Params`, take a body as `Json<T>`/`Bytes`/`String`, and return `Json<T>`, `String` or `Result<T>` rather than a bare value"
+    note = "common fixes: take path parameters as `Path<T>` or `Params`, take a body as `Json<T>`/`Bytes`/`String`, and return `Json<T>`, `String` or `Result<T>` rather than a bare value",
+    note = "a payload carried by `Json<T>`, `Form<T>`, `Query<T>` or `PrettyJson<T>` must also derive `ToSchema`, since that is what the generated OpenAPI document describes it with: `#[derive(Serialize, skyzen::ToSchema)]`"
 )]
 pub trait Handler<T: Extractor, R: Responder>: Send + Sync + Clone + 'static {
     /// Handle the request and make a response.

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -267,9 +267,20 @@ where
 /// else falls through to the second.
 ///
 /// The choice is made where the call is written, so it only discriminates when `T` is concrete
-/// there. Calling it from a function generic over `T` always yields the fallback — which is why
-/// `#[skyzen::openapi]` emits the probe at the handler's own call site, where the extractor's
-/// payload type is spelled out.
+/// there. Calling it from a function generic over `T` always yields the fallback, silently — so
+/// this is reachable from exactly one place, `#[skyzen::openapi]`'s expansion, where the payload
+/// type is spelled out and the answer is therefore real.
+///
+/// It exists for one caller: [`Path<T>`](crate::extract::Path), whose payload is legitimately
+/// allowed not to describe itself. A multi-segment route is extracted as `Path<(String, u32)>`,
+/// tuples have no `ToSchema`, and the route pattern already names those parameters — so the
+/// payload only supplies types, and its absence costs a type rather than failing the build. Every
+/// *body* payload takes the opposite route and requires the bound outright: see
+/// [`Json`](crate::utils::Json), whose schema is the documented contract rather than a bonus.
+///
+/// There is deliberately no generic `maybe_schema_of<T>()` wrapper around this. Such a function
+/// can only ever return `None`, and having one meant six extractors and responders reported no
+/// schema while looking as though they reported one.
 #[doc(hidden)]
 #[derive(Debug, Default)]
 pub struct SchemaProbe<T>(PhantomData<T>);
@@ -330,23 +341,6 @@ where
     pub const fn maybe_register(&self, defs: &mut BTreeMap<String, SchemaRef>) {
         let _ = defs;
     }
-}
-
-/// Return the schema for `T` when it implements `ToSchema`; otherwise return `None`.
-///
-/// `T` is generic here, so this always takes the fallback; it exists for extractors whose own
-/// payload type is generic and therefore cannot be probed. `#[skyzen::openapi]` probes at the
-/// handler's call site instead, which is what puts real types in the generated document.
-#[cfg(feature = "openapi")]
-#[must_use]
-pub fn maybe_schema_of<T>() -> Option<SchemaRef> {
-    SchemaProbe::<T>::new().maybe_schema()
-}
-
-/// Register the schema for `T` when it implements `ToSchema`; otherwise do nothing.
-#[cfg(feature = "openapi")]
-pub fn maybe_register_schema_for<T>(defs: &mut BTreeMap<String, SchemaRef>) {
-    SchemaProbe::<T>::new().maybe_register(defs);
 }
 
 /// Register a schema and its dependencies when `OpenAPI` is enabled.

--- a/src/responder/json.rs
+++ b/src/responder/json.rs
@@ -38,7 +38,7 @@ http_error!(
     /// An error occurred when serializing the JSON payload.
     pub PrettyJsonError, StatusCode::INTERNAL_SERVER_ERROR, "Failed to serialize JSON payload");
 
-impl<T: Send + Sync + Serialize + 'static> Responder for PrettyJson<T> {
+impl<T: Send + Sync + Serialize + crate::ToSchema + 'static> Responder for PrettyJson<T> {
     type Error = PrettyJsonError;
     fn respond_to(self, _request: &Request, response: &mut Response) -> Result<(), Self::Error> {
         let payload = to_vec_pretty(&self.0).map_err(|error| {
@@ -57,7 +57,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for PrettyJson<T> {
         Some(vec![crate::openapi::ResponseSchema {
             status: None,
             description: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
             content_type: Some("application/json"),
         }])
     }
@@ -66,7 +66,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for PrettyJson<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -87,7 +87,9 @@ mod tests {
         age: u8,
     }
 
-    #[derive(Debug)]
+    /// A payload whose `Serialize` always fails, so the responder's error path is reachable.
+    /// Its schema is irrelevant and empty, but the bound is real, so it declares one.
+    #[derive(Debug, crate::ToSchema)]
     struct AlwaysFails;
 
     impl Serialize for AlwaysFails {

--- a/src/responder/mod.rs
+++ b/src/responder/mod.rs
@@ -49,7 +49,7 @@ mod tests {
     };
     use serde::Serialize;
 
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, Serialize, crate::ToSchema)]
     struct Article {
         id: u32,
     }

--- a/src/utils/form.rs
+++ b/src/utils/form.rs
@@ -31,7 +31,7 @@ http_error!(
     pub FormEncodeError, StatusCode::INTERNAL_SERVER_ERROR, "Failed to encode form data"
 );
 
-impl<T: Send + Sync + Serialize + 'static> Responder for Form<T> {
+impl<T: Send + Sync + Serialize + crate::ToSchema + 'static> Responder for Form<T> {
     type Error = FormEncodeError;
     fn respond_to(self, _request: &Request, response: &mut Response) -> Result<(), Self::Error> {
         let encoded = to_string(&self.0).map_err(|_| FormEncodeError::new())?;
@@ -47,7 +47,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Form<T> {
         Some(vec![crate::openapi::ResponseSchema {
             status: None,
             description: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
             content_type: Some("application/x-www-form-urlencoded"),
         }])
     }
@@ -56,7 +56,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Form<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -83,7 +83,7 @@ pub enum FormContentTypeError {
     InvalidPayload(String),
 }
 
-impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Form<T> {
+impl<T: Send + Sync + DeserializeOwned + crate::ToSchema + 'static> Extractor for Form<T> {
     type Error = FormRejection;
     async fn extract(request: &mut Request) -> Result<Self, Self::Error> {
         // A GET request carries the form in the query string, so it needs no content type — and
@@ -114,7 +114,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Form<T> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Body,
             content_type: Some("application/x-www-form-urlencoded"),
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
         })
     }
 
@@ -122,7 +122,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Form<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -154,13 +154,13 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use skyzen_core::{Extractor, RequestBodyLimit};
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, PartialEq, crate::ToSchema)]
     struct Payload {
         name: String,
         age: u8,
     }
 
-    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq, crate::ToSchema)]
     struct Tagged {
         tags: Vec<String>,
     }

--- a/src/utils/json.rs
+++ b/src/utils/json.rs
@@ -26,7 +26,7 @@ http_error!(
     /// An error occurred when encoding the JSON response.
     pub JsonEncodingError, StatusCode::INTERNAL_SERVER_ERROR, "Failed to encode JSON response");
 
-impl<T: Send + Sync + Serialize + 'static> Responder for Json<T> {
+impl<T: Send + Sync + Serialize + crate::ToSchema + 'static> Responder for Json<T> {
     type Error = JsonEncodingError;
     fn respond_to(self, _request: &Request, response: &mut Response) -> Result<(), Self::Error> {
         response
@@ -42,7 +42,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Json<T> {
         Some(vec![crate::openapi::ResponseSchema {
             status: None,
             description: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
             content_type: Some("application/json"),
         }])
     }
@@ -51,7 +51,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Json<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -75,7 +75,7 @@ pub enum JsonContentTypeError {
     InvalidPayload(String),
 }
 
-impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Json<T> {
+impl<T: Send + Sync + DeserializeOwned + crate::ToSchema + 'static> Extractor for Json<T> {
     type Error = JsonRejection;
     async fn extract(request: &mut Request) -> Result<Self, Self::Error> {
         if let Some(content_type) = request.headers().get(CONTENT_TYPE) {
@@ -99,7 +99,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Json<T> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Body,
             content_type: Some("application/json"),
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
         })
     }
 
@@ -107,7 +107,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Json<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -140,7 +140,7 @@ mod test {
     use serde::Deserialize;
     use skyzen_core::Extractor;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, crate::ToSchema)]
     struct Payload {
         ok: bool,
     }

--- a/tests/extractors.rs
+++ b/tests/extractors.rs
@@ -5,13 +5,13 @@ use skyzen::{
     extract::{Path, Query},
     routing::{CreateRouteNode, Route},
     utils::Json,
-    Body, RequestBodyLimit, Result, StatusCode,
+    Body, RequestBodyLimit, Result, StatusCode, ToSchema,
 };
 use skyzen_test::TestContext;
 
 /// The filter shape `examples/openapi.rs` documents: a repeated query parameter collected into a
 /// list.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
 struct TaskFilter {
     tags: Option<Vec<String>>,
     limit: Option<u32>,
@@ -49,7 +49,7 @@ async fn an_absent_repeated_parameter_is_still_none() {
     assert!(filter.tags.is_none());
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
 struct ProjectTask {
     project: String,
     task: u32,
@@ -169,7 +169,7 @@ async fn lifting_the_limit_lets_a_large_body_through() {
 
 #[tokio::test]
 async fn a_status_and_a_body_compose_in_a_tuple() {
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, Serialize, ToSchema)]
     struct Created {
         id: u32,
     }

--- a/tests/openapi_schemas.rs
+++ b/tests/openapi_schemas.rs
@@ -1,0 +1,151 @@
+//! Regression tests for the schema a generated document actually carries.
+//!
+//! Issue #18: `Json<T>`'s `Responder::openapi()` probed `T` from a generic context, where the
+//! `ToSchema` bound can never be proved, so it always reported `None`. `#[skyzen::openapi]` has a
+//! second path that destructures the return type syntactically and probes at the concrete call
+//! site, which *did* work — so the defect was invisible for `-> Json<T>` and hit every handler
+//! returning a wrapper the macro cannot see through. These tests document both paths.
+
+use serde::{Deserialize, Serialize};
+use skyzen::{
+    routing::{CreateRouteNode, Route, Router},
+    utils::Json,
+    OpenApi, Request, Responder, Response, StatusCode, ToSchema,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct Widget {
+    id: i64,
+    label: String,
+}
+
+/// The shape the issue was reported against: an application's own result wrapper, which renders
+/// its error side itself and forwards the success side's documentation. `#[skyzen::openapi]`
+/// cannot destructure it, so everything it reports has to come from `Responder::openapi()`.
+struct Outcome<T>(T);
+
+impl<T: Responder> Responder for Outcome<T> {
+    type Error = T::Error;
+
+    fn respond_to(
+        self,
+        request: &Request,
+        response: &mut Response,
+    ) -> core::result::Result<(), Self::Error> {
+        self.0.respond_to(request, response)
+    }
+
+    fn openapi() -> Option<Vec<skyzen::openapi::ResponseSchema>> {
+        T::openapi()
+    }
+
+    fn register_openapi_schemas(
+        defs: &mut std::collections::BTreeMap<String, skyzen::openapi::SchemaRef>,
+    ) {
+        T::register_openapi_schemas(defs);
+    }
+}
+
+/// The path that always worked: the macro sees `Json<Widget>` and probes `Widget` itself.
+#[skyzen::openapi]
+async fn direct() -> Json<Widget> {
+    Json(Widget {
+        id: 1,
+        label: "direct".to_owned(),
+    })
+}
+
+/// The path that did not: the macro sees `Outcome<…>`, gives up on destructuring, and takes
+/// whatever `Responder::openapi()` reports — which used to be a schema-less response.
+#[skyzen::openapi]
+async fn wrapped() -> Outcome<Json<Widget>> {
+    Outcome(Json(Widget {
+        id: 2,
+        label: "wrapped".to_owned(),
+    }))
+}
+
+fn document() -> OpenApi {
+    Route::new(("/direct".at(direct), "/wrapped".at(wrapped)))
+        .build()
+        .openapi()
+}
+
+/// The response body of `GET {path}`, as the serialized document renders it.
+///
+/// utoipa inlines a payload's schema here and *also* registers it under `components`, so these
+/// assertions read the inline form; `the_payload_schema_reaches_the_components_map` covers the
+/// other half.
+fn response_content(spec: &serde_json::Value, path: &str) -> serde_json::Value {
+    spec["paths"][path]["get"]["responses"]
+        .as_object()
+        .and_then(|responses| responses.values().next())
+        .and_then(|response| response.get("content"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null)
+}
+
+#[test]
+fn a_responder_the_macro_cannot_destructure_still_documents_its_payload() {
+    let spec = serde_json::to_value(document().to_utoipa_spec()).expect("the spec serializes");
+
+    let wrapped = response_content(&spec, "/wrapped");
+    assert!(
+        !wrapped.is_null(),
+        "issue #18: the wrapped response documented no content at all: {spec:#}"
+    );
+    let schema = &wrapped["application/json"]["schema"];
+    assert!(
+        schema["properties"].get("label").is_some(),
+        "the wrapped response should describe the payload's fields: {schema:#}"
+    );
+}
+
+#[test]
+fn the_wrapped_and_direct_responses_document_the_same_payload() {
+    let spec = serde_json::to_value(document().to_utoipa_spec()).expect("the spec serializes");
+    assert_eq!(
+        response_content(&spec, "/wrapped"),
+        response_content(&spec, "/direct"),
+        "a wrapper that forwards `openapi()` should document what it forwards to"
+    );
+}
+
+#[test]
+fn the_payload_schema_reaches_the_components_map() {
+    let spec = serde_json::to_value(document().to_utoipa_spec()).expect("the spec serializes");
+    let widget = &spec["components"]["schemas"]["Widget"];
+    assert!(
+        widget.is_object(),
+        "the payload's own schema should be registered: {spec:#}"
+    );
+    assert!(
+        widget["properties"].get("label").is_some(),
+        "the registered schema should describe the payload's fields: {widget:#}"
+    );
+}
+
+/// `StatusCode` keeps its meaning alongside a payload: the pair is a responder too.
+#[skyzen::openapi]
+async fn created() -> (StatusCode, Json<Widget>) {
+    (
+        StatusCode::CREATED,
+        Json(Widget {
+            id: 3,
+            label: "created".to_owned(),
+        }),
+    )
+}
+
+#[test]
+fn a_tuple_responder_documents_its_payload_too() {
+    let router: Router = Route::new(("/created".at(created),)).build();
+    let spec = serde_json::to_value(router.openapi().to_utoipa_spec()).expect("serializes");
+    let content = response_content(&spec, "/created");
+    assert!(
+        content["application/json"]["schema"]["properties"]
+            .get("label")
+            .is_some(),
+        "{content:#}"
+    );
+}

--- a/tests/skyzen_test_macro.rs
+++ b/tests/skyzen_test_macro.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use skyzen::{
     routing::{CreateRouteNode, Route, Router},
     utils::Form,
-    Result,
+    Result, ToSchema,
 };
 use skyzen_services::{
     durable::{Alarm, DurableDb, DurableKv},
@@ -72,7 +72,7 @@ async fn injects_the_durable_services_into_the_test_context(
     assert_eq!(durable_db.database_size().await.unwrap(), 0);
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 struct Login {
     user: String,
     remember: bool,


### PR DESCRIPTION
Closes #18.

**Stacks on #19** (`feat/sql-typed-rows`), which must merge first — `dev` does not currently compile without it: commit 05b91f4 uses `JsonRow` and `fetch_scalar`, which land in that PR. This branch is parented on it, so its diff against `dev` will shrink to just this commit once #19 is in.

## The probe could never fire

`maybe_schema_of::<T>()` wrapped an autoref-specialization probe — an inherent method that exists only when `T: ToSchema`, shadowing a trait method that exists for everything. That construct discriminates **where the call is written**. Inside a function generic over `T` the bound is not provable, so the fallback won for every instantiation, however the caller's concrete type was defined.

Six extractors and responders called it — `Json`, `Form` and `Query` on both sides, `PrettyJson`, and `Path` — and every one reported no schema while looking as though it reported one.

The effect split on whether `#[skyzen::openapi]` could destructure the return type, because its second path emits `schema_of::<Payload>` against a concrete type where the bound resolves normally. So `-> Json<T>` documented correctly and hid the defect, while any wrapper the macro cannot see through documented a `200` with no content — the ordinary shape of an application that renders RFC 9457 problems on the error side.

## The fix

Both generic wrappers are deleted. `Json<T>`, `Form<T>`, `Query<T>` and `PrettyJson<T>` require `T: ToSchema`, so their `openapi()` calls the honest `schema_of::<T>()` and what is documented is what is serialized. `#[skyzen::openapi]` already demanded that bound for return types it could destructure; making it uniform closes the hole rather than opening a new requirement.

The bound sits outside every `#[cfg(feature = "openapi")]`, so the feature stays **additive** — turning it on can never change what compiles.

**`Path<T>` deliberately keeps no bound.** The route pattern names its parameters, so the payload supplies types and nothing else, and `Path<(String, u32)>` for a multi-segment route is ordinary — tuples have no `ToSchema` and never will. Its types come from the macro's concrete-site probe, which is the one place the probe works, so `SchemaProbe` stays for that single caller with a doc comment explaining why no generic wrapper may be built over it again.

## What it costs

A payload derives `ToSchema` beside its serde derive. utoipa already implements it for every primitive, collection and `serde_json::Value`, so only an application's own structs are affected — 24 in-repo call sites, each one line.

The derive expands to `::utoipa::…` paths, so an application declares `utoipa` in its own manifest; `skyzen new --template api` now does, the README says so, and the `Handler` diagnostic names it when that is the missing bound. `macros` is named explicitly on this crate's utoipa dependency rather than inherited from `skyzen-core`, since the re-exported derive is part of the public surface now.

## Verification

`tests/openapi_schemas.rs` is the regression test the report asked for, built around the reported shape rather than around the probe: a wrapper the macro cannot destructure must document the same payload as the direct return. **Three of its four cases fail against the old behaviour**, reporting no content at all — I checked, rather than assuming.

Workspace green on stable: `clippy --workspace --all-targets --all-features -- -D warnings`, `-p skyzen --no-default-features`, `-p skyzen-cloudflare --target wasm32-unknown-unknown`, and 1057 tests across 40 binaries.
