### PR TITLE
release: OpenAPI schema fix and the sql! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,11 @@ futures-core = { version = "0.3.32" }
 futures-channel = { version = "0.3.32", optional = true }
 multer = { version = "3.1", optional = true }
 http = "1.4"
-utoipa = { version = "5.4", default-features = false }
+# `macros` is named here rather than inherited from `skyzen-core`: `skyzen::ToSchema` re-exports
+# utoipa's *derive*, and a payload carried by `Json`/`Form`/`Query` is now required to implement
+# the trait, so the derive is part of this crate's own public surface and cannot depend on another
+# crate happening to switch it on.
+utoipa = { version = "5.4", default-features = false, features = ["macros"] }
 utoipa-redoc = "6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -278,15 +278,17 @@ use skyzen::{
     extract::{Path, Query},
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Result,
+    Result, ToSchema,
 };
 
-#[derive(Serialize)]
+// A payload carried by `Json`, `Form` or `Query` derives `ToSchema` alongside its serde derive:
+// one says how it goes on the wire, the other how the OpenAPI document describes it.
+#[derive(Serialize, ToSchema)]
 struct MessageResponse {
     message: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 struct GreetingQuery {
     prefix: Option<String>,
 }
@@ -419,9 +421,9 @@ async fn update_profile(
 
 | Extractor | Path | Description |
 |---|---|---|
-| `Json<T>` | `skyzen::utils::Json` | Deserializes a JSON request body |
-| `Query<T>` | `skyzen::extract::Query` | Deserializes the query string, repeated keys included |
-| `Form<T>` | `skyzen::utils::Form` | Deserializes `application/x-www-form-urlencoded` |
+| `Json<T>` | `skyzen::utils::Json` | Deserializes a JSON request body (`T: ToSchema`) |
+| `Query<T>` | `skyzen::extract::Query` | Deserializes the query string, repeated keys included (`T: ToSchema`) |
+| `Form<T>` | `skyzen::utils::Form` | Deserializes `application/x-www-form-urlencoded` (`T: ToSchema`) |
 | `Path<T>` | `skyzen::extract::Path` | Deserializes the captured `{name}` segments into a struct, tuple or primitive |
 | `Params` | `skyzen::routing::Params` | Path parameters by name at runtime (`params.get("id")?`) |
 | `Multipart` | `skyzen::utils::Multipart` | Streams multipart form data and file uploads |
@@ -436,12 +438,23 @@ async fn update_profile(
 | `RequestBodyLimit` | `skyzen::RequestBodyLimit` | The body cap in force, so a handler can size its own reads |
 | `Option<T>`, `Result<T, _>` | — | Wrap any extractor to make its failure recoverable |
 
+A body payload carries `T: ToSchema` so that what the endpoint documents is what it actually
+serializes — the bound is what makes the generated document trustworthy rather than best-effort.
+`#[derive(ToSchema)]` beside the serde derive is the whole cost, and every primitive, collection
+and `serde_json::Value` already has one. The derive expands to `::utoipa::…` paths, so an
+application declares `utoipa = "5"` alongside `skyzen` (`skyzen new` does this for you);
+`skyzen::ToSchema` re-exports the trait the bound is written against.
+
+`Path<T>` is the exception and takes no bound: the route pattern names its parameters, and
+`Path<(String, u32)>` for a multi-segment route has no schema to give. `#[skyzen::openapi]` types
+those parameters by probing the payload at the handler's own call site instead.
+
 ### Built-in Responders
 
 | Responder | Description |
 |---|---|
 | `&'static str`, `String`, `Bytes` | Plain text or raw bytes |
-| `Json<T>` / `PrettyJson<T>` | Serializes `T` to `application/json` |
+| `Json<T>` / `PrettyJson<T>` | Serializes `T` to `application/json` (`T: ToSchema`) |
 | `Html<T>` | Sends its payload as `text/html; charset=utf-8` |
 | `StatusCode` | An empty response with that status |
 | `Redirect` | `to` (302), `see_other` (303), `temporary` (307), `permanent` (308), or `with_status` |

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -204,12 +204,20 @@ pub const fn dependencies(template: Template) -> &'static [DependencySpec] {
         name: "futures-util",
         features: &[],
     };
+    /// A payload carried by `Json`, `Form` or `Query` has to implement `ToSchema`, and utoipa's
+    /// derive expands to `::utoipa::…` paths — so the crate that writes `#[derive(ToSchema)]`
+    /// needs the dependency itself. `skyzen::ToSchema` re-exports the trait, which is what the
+    /// bound is written against; it cannot re-export the crate the expansion names.
+    const UTOIPA: DependencySpec = DependencySpec {
+        name: "utoipa",
+        features: &[],
+    };
 
     match template {
         Template::Minimal => &[SKYZEN],
         // The api template declares a portable KV service, so it needs the wrappers, the
         // in-process backend `[native.service.cache]` names, and the Cloudflare one.
-        Template::Api => &[SKYZEN, SERVICES, TEST, CLOUDFLARE, SERDE],
+        Template::Api => &[SKYZEN, SERVICES, TEST, CLOUDFLARE, SERDE, UTOIPA],
         Template::ServerlessEvents => &[SKYZEN, SERVICES, CLOUDFLARE, SERDE, TRACING],
         Template::DurableRealtime => &[SKYZEN_WS, CLOUDFLARE, SERDE, FUTURES],
     }

--- a/cli/templates/api/Cargo.toml.tmpl
+++ b/cli/templates/api/Cargo.toml.tmpl
@@ -15,3 +15,9 @@ crate-type = ["cdylib", "rlib"]
 # restores agreement after upgrading the CLI.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "={{ ctx.wasm_bindgen_version }}"
+
+[package.metadata.cargo-machete]
+# `utoipa` is reached only through what `#[derive(ToSchema)]` EXPANDS to — `::utoipa::…` paths —
+# so no source line names the crate and an unused-dependency check cannot see the use. Removing it
+# breaks the derive.
+ignored = ["utoipa"]

--- a/cli/templates/api/src/app.rs.tmpl
+++ b/cli/templates/api/src/app.rs.tmpl
@@ -3,10 +3,12 @@ use serde::Serialize;
 use skyzen::{
     routing::{CreateRouteNode, Params, Route, Router},
     utils::Json,
-    Result,
+    Result, ToSchema,
 };
 
-#[derive(Serialize)]
+/// A payload carried by `Json` derives `ToSchema` as well as `Serialize`: the first says how it
+/// is written to the wire, the second how the generated OpenAPI document describes it.
+#[derive(Serialize, ToSchema)]
 struct Greeting {
     name: String,
     seen_before: bool,

--- a/examples/embed_hyper.rs
+++ b/examples/embed_hyper.rs
@@ -49,10 +49,10 @@ use skyzen::{
     hyper::Hyper,
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Server,
+    Server, ToSchema,
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 struct StatusResponse {
     status: &'static str,
     runtime: &'static str,

--- a/examples/native.rs
+++ b/examples/native.rs
@@ -6,14 +6,15 @@ use skyzen::{
     extract::{Path, Query},
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
+    ToSchema,
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct Greeting {
     message: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 struct GreetingQuery {
     name: Option<String>,
     excited: Option<bool>,

--- a/examples/queue-consumer/Cargo.toml
+++ b/examples/queue-consumer/Cargo.toml
@@ -16,9 +16,16 @@ skyzen-services = { path = "../../services" }
 # The `backend = "memory"` wiring in Skyzen.toml expands to `skyzen_test`'s in-process mock.
 skyzen-test = { path = "../../test" }
 serde = { version = "1", features = ["derive"] }
+# utoipa's `ToSchema` derive expands to `::utoipa::…`, so the crate deriving it needs the
+# dependency; `skyzen::ToSchema` re-exports the trait, not the crate the expansion names.
+utoipa = "5"
 tracing = "0.1"
 
 [package.metadata.cargo-machete]
+# `utoipa` is reached only through what `#[derive(ToSchema)]` EXPANDS to — `::utoipa::…` paths —
+# so no source line names the crate and machete cannot see the use. The dependency is load-bearing
+# regardless: without it the derive does not resolve.
+#
 # Consumed by the code `#[skyzen::main]` GENERATES for `backend = "memory"`, which
 # cargo-machete cannot see in the source text.
-ignored = ["skyzen-test"]
+ignored = ["skyzen-test", "utoipa"]

--- a/examples/queue-consumer/src/main.rs
+++ b/examples/queue-consumer/src/main.rs
@@ -22,12 +22,15 @@ use serde::{Deserialize, Serialize};
 use skyzen::{
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Result,
+    Result, ToSchema,
 };
 use skyzen_services::{QueueBatch, QueueBatchDisposition, QueueMessageDisposition, QueueRetry};
 
 /// One unit of work, as it travels through the queue.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+///
+/// `ToSchema` rides along with the serde derives because the job arrives as a `Json<Job>` body:
+/// the payload of a body extractor is what the generated OpenAPI document describes.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 struct Job {
     /// Caller-assigned identity, echoed in the logs.
     id: String,

--- a/examples/services.rs
+++ b/examples/services.rs
@@ -17,18 +17,18 @@ use skyzen::{
     extract::Path,
     routing::{CreateRouteNode, Route, Router},
     utils::Json,
-    Result as SkyResult,
+    Result as SkyResult, ToSchema,
 };
 use skyzen_services::{Kv, Storage};
 use skyzen_test::mock::{InMemoryKv, InMemoryStorage};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 struct FileMetadata {
     name: String,
     size: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 struct UploadRequest {
     name: String,
     content: String,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! Procedural macros for the Skyzen framework.
 
 mod row;
+mod sql;
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
@@ -417,6 +418,49 @@ pub fn derive_http_error(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
     match expand_http_error(input) {
         Ok(tokens) => tokens,
+        Err(error) => error.to_compile_error().into(),
+    }
+}
+
+/// Build a query whose bind order comes from the query text.
+///
+/// ```ignore
+/// let user: User = sql!(db, "SELECT id, login FROM users WHERE id = {id} AND state = {state}")
+///     .fetch_one()
+///     .await?;
+/// ```
+///
+/// expands to exactly what it replaces, with one `?` and one `.bind()` per capture, in the order
+/// the captures are written:
+///
+/// ```ignore
+/// db.query("SELECT id, login FROM users WHERE id = ? AND state = ?")
+///     .bind(id)
+///     .bind(state)
+/// ```
+///
+/// Positional binding is a silent correctness hazard, not just boilerplate: splice one condition
+/// into the middle of a statement and every later `.bind()` shifts by one, and because SQL has so
+/// few distinct types the result usually still compiles and still runs — against the wrong
+/// columns. Writing the value where the placeholder is leaves only one possible ordering.
+///
+/// - **A capture is always a bound value, never substituted text.** An identifier, a table name or
+///   a SQL fragment cannot be interpolated, so the injection question is closed by construction.
+/// - `{name}` binds a value in scope and `{ an.expression() }` binds anything else; `{{` and `}}`
+///   are literal braces, as in `format!`. There are no positional arguments — an argument list is
+///   the very thing that can fall out of step with the query.
+/// - Each capture is bound through `Into<DbValue>`, so it accepts exactly what `.bind()` accepts.
+/// - The first argument is whatever the query runs against: a `Db`, a transaction, or a
+///   `DurableDb`.
+///
+/// Nothing here reads a schema, opens a connection at build time, or parses the SQL beyond finding
+/// the captures. The same statement runs on five backends, so checking it against one dialect's
+/// parser would be a guarantee that does not hold.
+#[proc_macro]
+pub fn sql(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as sql::SqlInput);
+    match sql::expand(&input) {
+        Ok(tokens) => tokens.into(),
         Err(error) => error.to_compile_error().into(),
     }
 }

--- a/macros/src/sql.rs
+++ b/macros/src/sql.rs
@@ -1,0 +1,371 @@
+//! The `sql!` macro: bind order taken from the query text instead of from the call site.
+//!
+//! Positional binding is a silent correctness hazard, not merely verbose. Inserting one condition
+//! into the middle of a statement shifts every following `.bind()` by one, and because SQL has so
+//! few distinct types the shifted call usually still compiles and still runs — against the wrong
+//! columns. Writing the value where the placeholder is removes the possibility: there is only one
+//! ordering, and it is the one the reader sees.
+//!
+//! What this deliberately is *not* is a compile-time query checker. The same statement runs on D1,
+//! `SQLite`, `PostgreSQL`, `MySQL` and Azure SQL, so validating it against one dialect's parser
+//! would be a guarantee that does not hold. Nothing here reads a schema, opens a connection, or
+//! looks at the SQL beyond finding the captures.
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    Error, Expr, LitStr, Token,
+    parse::{Parse, ParseStream},
+};
+
+/// A parsed `sql!(source, "…")` invocation.
+pub struct SqlInput {
+    /// The thing `.query()` is called on — a `Db`, a transaction, a `DurableDb`.
+    source: Expr,
+    /// The query text, captures included.
+    template: LitStr,
+}
+
+impl Parse for SqlInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let source = input.parse()?;
+        input.parse::<Token![,]>().map_err(|_| {
+            Error::new(
+                input.span(),
+                "expected `sql!(source, \"…\")`: the query runs against a `Db`, a transaction or a \
+                 `DurableDb`, named first",
+            )
+        })?;
+        let template = input.parse()?;
+
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+        }
+        if !input.is_empty() {
+            return Err(Error::new(
+                input.span(),
+                "`sql!` takes no arguments after the query: every value is written inline where it \
+                 is bound, as `{value}` or `{ an.expression() }`. That is the point of the macro — \
+                 an argument list is exactly the thing that can fall out of step with the query",
+            ));
+        }
+
+        Ok(Self { source, template })
+    }
+}
+
+/// Expand `sql!`.
+pub fn expand(input: &SqlInput) -> syn::Result<TokenStream> {
+    let template = input.template.value();
+    let span = input.template.span();
+    let Template { sql, captures } = parse_template(&template, span)?;
+
+    let source = &input.source;
+    let binds = captures
+        .iter()
+        .map(|capture| capture.expression(span))
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    let sql = LitStr::new(&sql, span);
+    Ok(quote! {
+        #source.query(#sql)#(.bind(#binds))*
+    })
+}
+
+/// One `{…}` found in the query text.
+struct Capture {
+    /// The Rust source between the braces.
+    source: String,
+}
+
+impl Capture {
+    /// The value this capture binds.
+    fn expression(&self, span: Span) -> syn::Result<Expr> {
+        syn::parse_str(&self.source).map_err(|error| {
+            Error::new(
+                span,
+                format!(
+                    "`{{{}}}` is not a Rust expression: {error}. A capture is a value to bind — \
+                     name a binding in scope, or write an expression; `{{{{` is a literal brace",
+                    self.source,
+                ),
+            )
+        })
+    }
+}
+
+/// A query text split into the SQL a backend sees and the values bound into it.
+struct Template {
+    /// The statement with every capture replaced by `?`, the placeholder every dialect accepts.
+    sql: String,
+    /// The captures, in the order their placeholders appear.
+    captures: Vec<Capture>,
+}
+
+/// Split the macro's query text into SQL and captures.
+///
+/// `{{` and `}}` are literal braces, as in `format!`. Everything else between a `{` and its
+/// matching `}` is Rust source, which the caller parses as an expression — this only has to find
+/// where the capture ends, which means tracking brace depth and not being fooled by a brace inside
+/// a string or character literal.
+fn parse_template(template: &str, span: Span) -> syn::Result<Template> {
+    let mut sql = String::with_capacity(template.len());
+    let mut captures = Vec::new();
+    let mut chars = template.char_indices().peekable();
+
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '{' if chars.peek().map(|(_, next)| *next) == Some('{') => {
+                chars.next();
+                sql.push('{');
+            }
+            '}' if chars.peek().map(|(_, next)| *next) == Some('}') => {
+                chars.next();
+                sql.push('}');
+            }
+            '}' => {
+                return Err(Error::new(
+                    span,
+                    "unmatched `}` in the query; write `}}` for a literal brace",
+                ));
+            }
+            '{' => {
+                let source = read_capture(template, index, &mut chars, span)?;
+                if source.trim().is_empty() {
+                    return Err(Error::new(
+                        span,
+                        "`{}` has nothing to bind: name the value, as in `{user_id}`, or write an \
+                         expression, as in `{ user.id() }`. `sql!` has no positional arguments to \
+                         fall back on",
+                    ));
+                }
+                captures.push(Capture { source });
+                // Every dialect accepts `?`; the query builder rewrites it to `$1` or `@P1` where
+                // the backend needs that, so the macro never has to know which backend it is for.
+                sql.push('?');
+            }
+            other => sql.push(other),
+        }
+    }
+
+    Ok(Template { sql, captures })
+}
+
+/// Read one capture's Rust source, given that the opening `{` has just been consumed.
+fn read_capture(
+    template: &str,
+    open: usize,
+    chars: &mut core::iter::Peekable<core::str::CharIndices<'_>>,
+    span: Span,
+) -> syn::Result<String> {
+    let start = open + '{'.len_utf8();
+    let mut depth = 1usize;
+
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(template[start..index].to_owned());
+                }
+            }
+            // A brace inside a literal is text, not structure. Skipping the literal is what keeps
+            // `{ format!("a}b") }` and `{ split('}') }` from ending the capture early.
+            '"' => skip_string(chars, false),
+            'r' if matches!(chars.peek(), Some((_, '"' | '#'))) => skip_raw_string(chars),
+            '\'' => skip_char_literal(chars),
+            _ => {}
+        }
+    }
+
+    Err(Error::new(
+        span,
+        "unclosed `{` in the query; write `}}` for a literal brace, or close the capture",
+    ))
+}
+
+/// Consume the rest of a `"…"` literal, honouring backslash escapes.
+fn skip_string(chars: &mut core::iter::Peekable<core::str::CharIndices<'_>>, raw: bool) {
+    while let Some((_, ch)) = chars.next() {
+        match ch {
+            '\\' if !raw => {
+                chars.next();
+            }
+            '"' => return,
+            _ => {}
+        }
+    }
+}
+
+/// Consume the rest of a raw string, `r"…"` or `r#"…"#`, given the `r` has been consumed.
+fn skip_raw_string(chars: &mut core::iter::Peekable<core::str::CharIndices<'_>>) {
+    let mut hashes = 0usize;
+    while let Some((_, '#')) = chars.peek() {
+        chars.next();
+        hashes += 1;
+    }
+    if !matches!(chars.peek(), Some((_, '"'))) {
+        // Not a raw string after all — an identifier such as `r#type`, or a bare `r`.
+        return;
+    }
+    chars.next();
+
+    loop {
+        match chars.next() {
+            Some((_, '"')) => {
+                let mut seen = 0usize;
+                while seen < hashes && matches!(chars.peek(), Some((_, '#'))) {
+                    chars.next();
+                    seen += 1;
+                }
+                if seen == hashes {
+                    return;
+                }
+            }
+            Some(_) => {}
+            None => return,
+        }
+    }
+}
+
+/// Consume a `'x'` or `'\n'` character literal, leaving a lifetime alone.
+///
+/// A lifetime and a character literal both open with `'`, and only the literal closes. Looking one
+/// or two characters ahead tells them apart, which matters because `{ text.split('}') }` is an
+/// ordinary thing to write and a lifetime such as `&'a str` is too.
+fn skip_char_literal(chars: &mut core::iter::Peekable<core::str::CharIndices<'_>>) {
+    let Some((_, first)) = chars.peek().copied() else {
+        return;
+    };
+
+    if first == '\\' {
+        chars.next();
+        // The escape body: one character for `\n`, more for `\u{1F600}`, all of which end at `'`.
+        for (_, ch) in chars.by_ref() {
+            if ch == '\'' {
+                return;
+            }
+        }
+        return;
+    }
+
+    // `'a'` is a literal; `'a ` and `'a>` are a lifetime.
+    let mut lookahead = chars.clone();
+    lookahead.next();
+    if matches!(lookahead.peek(), Some((_, '\''))) {
+        chars.next();
+        chars.next();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SqlInput, parse_template};
+    use proc_macro2::Span;
+
+    fn split(template: &str) -> (String, Vec<String>) {
+        let parsed = parse_template(template, Span::call_site()).expect("the template parses");
+        (
+            parsed.sql,
+            parsed
+                .captures
+                .into_iter()
+                .map(|capture| capture.source)
+                .collect(),
+        )
+    }
+
+    fn rejection(template: &str) -> String {
+        parse_template(template, Span::call_site())
+            .err()
+            .map_or_else(
+                || panic!("`{template}` should have been rejected"),
+                |error| error.to_string(),
+            )
+    }
+
+    #[test]
+    fn every_capture_becomes_a_placeholder_in_the_order_it_is_written() {
+        let (sql, captures) =
+            split("SELECT id FROM users WHERE id = {user_id} AND state = {state}");
+        assert_eq!(sql, "SELECT id FROM users WHERE id = ? AND state = ?");
+        assert_eq!(captures, vec!["user_id", "state"]);
+    }
+
+    #[test]
+    fn a_condition_inserted_in_the_middle_renumbers_itself() {
+        // The whole point: the second query is the first with one condition spliced in, and no
+        // call site had to be renumbered for the values to stay with their columns.
+        let (_, before) = split("SELECT id FROM t WHERE a = {a} AND c = {c}");
+        let (_, after) = split("SELECT id FROM t WHERE a = {a} AND b = {b} AND c = {c}");
+        assert_eq!(before, vec!["a", "c"]);
+        assert_eq!(after, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn doubled_braces_are_literal_text() {
+        let (sql, captures) = split("SELECT '{{\"kind\":\"email\"}}'::jsonb");
+        assert_eq!(sql, "SELECT '{\"kind\":\"email\"}'::jsonb");
+        assert!(captures.is_empty());
+    }
+
+    #[test]
+    fn a_capture_may_be_any_expression() {
+        let (sql, captures) =
+            split("SELECT id FROM t WHERE id = { user.id() } AND n = {count + 1}");
+        assert_eq!(sql, "SELECT id FROM t WHERE id = ? AND n = ?");
+        assert_eq!(captures, vec![" user.id() ", "count + 1"]);
+    }
+
+    #[test]
+    fn a_brace_inside_a_literal_does_not_end_the_capture() {
+        let (_, captures) = split(r#"SELECT {  format!("a}b")  } FROM t"#);
+        assert_eq!(captures, vec![r#"  format!("a}b")  "#]);
+
+        let (_, captures) = split("SELECT { name.replace('}', \"\") } FROM t");
+        assert_eq!(captures, vec![" name.replace('}', \"\") "]);
+
+        let (_, captures) = split("SELECT { r#\"a}b\"# } FROM t");
+        assert_eq!(captures, vec![" r#\"a}b\"# "]);
+    }
+
+    #[test]
+    fn a_lifetime_is_not_mistaken_for_a_character_literal() {
+        let (_, captures) = split("SELECT { value as &'static str } FROM t");
+        assert_eq!(captures, vec![" value as &'static str "]);
+    }
+
+    #[test]
+    fn nested_braces_belong_to_the_capture() {
+        let (_, captures) = split("SELECT { if flag { a } else { b } } FROM t");
+        assert_eq!(captures, vec![" if flag { a } else { b } "]);
+    }
+
+    #[test]
+    fn a_malformed_capture_is_refused_with_the_reason() {
+        assert!(rejection("SELECT {} FROM t").contains("nothing to bind"));
+        assert!(rejection("SELECT {a FROM t").contains("unclosed"));
+        assert!(rejection("SELECT a} FROM t").contains("unmatched"));
+    }
+
+    /// `syn`'s types are `Debug` only under its `extra-traits` feature, which costs every build of
+    /// this crate to serve one assertion — so the parse result is inspected rather than unwrapped.
+    fn invocation_rejection(source: &str) -> String {
+        match syn::parse_str::<SqlInput>(source) {
+            Ok(_) => panic!("`{source}` should have been rejected"),
+            Err(error) => error.to_string(),
+        }
+    }
+
+    #[test]
+    fn the_invocation_needs_a_source_and_a_query_and_nothing_else() {
+        assert!(syn::parse_str::<SqlInput>(r#"db, "SELECT 1""#).is_ok());
+        assert!(
+            syn::parse_str::<SqlInput>(r#"db, "SELECT 1","#).is_ok(),
+            "a trailing comma is fine"
+        );
+        assert!(invocation_rejection(r#"db, "SELECT ?", id"#).contains("written inline"));
+        assert!(invocation_rejection(r#""SELECT 1""#).contains("named first"));
+    }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -28,6 +28,13 @@ name = "skyzen-macros"
 git_tag_name = "macros-v{{ version }}"
 
 # A runnable example, not a published crate: it must not get a version bump, a tag or a changelog.
+#
+# `publish` has to be restated even though `release = false` already covers it: the workspace
+# default above is `publish = true`, and release-plz validates that flag against each crate's own
+# `Cargo.toml` *before* it looks at whether the package is released at all. Leaving them to
+# disagree aborts the whole run — no crate is published, which is what happened to the releases on
+# 2026-08-27 and 2026-08-29.
 [[package]]
 name = "skyzen-example-queue-consumer"
 release = false
+publish = false

--- a/src/extract/path.rs
+++ b/src/extract/path.rs
@@ -72,20 +72,22 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Path<T> {
         Ok(Self(value))
     }
 
+    /// `Path<T>` names no parameters of its own — the route pattern does — so this reports where
+    /// the values come from and nothing about their types.
+    ///
+    /// The types are supplied by `#[skyzen::openapi]`, which probes `T` at the handler's own call
+    /// site with [`SchemaProbe`](crate::openapi::SchemaProbe), where `T` is spelled out and the
+    /// `ToSchema` bound is therefore provable. That indirection is what lets `Path<(String, u32)>`
+    /// keep working: a tuple has no `ToSchema` and never will, and a multi-segment route is a
+    /// perfectly ordinary thing to write. Unlike the body extractors, this one cannot simply
+    /// require the bound.
     #[cfg(feature = "openapi")]
     fn openapi() -> Option<crate::openapi::ExtractorSchema> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Path,
             content_type: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: None,
         })
-    }
-
-    #[cfg(feature = "openapi")]
-    fn register_openapi_schemas(
-        defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
-    ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
     }
 }
 

--- a/src/extract/query.rs
+++ b/src/extract/query.rs
@@ -23,7 +23,7 @@ impl_deref!(Query);
 )]
 pub struct QueryError(String);
 
-impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Query<T> {
+impl<T: Send + Sync + DeserializeOwned + crate::ToSchema + 'static> Extractor for Query<T> {
     type Error = QueryError;
     // The query string is already on the request, so the future is ready on creation rather than
     // an `async` block with nothing to await.
@@ -40,7 +40,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Query<T> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Query,
             content_type: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
         })
     }
 
@@ -48,7 +48,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Query<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -60,13 +60,13 @@ mod tests {
     use serde::Deserialize;
     use skyzen_core::Extractor;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, PartialEq, crate::ToSchema)]
     struct Search {
         q: String,
         page: u8,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, PartialEq, crate::ToSchema)]
     struct Filter {
         tags: Option<Vec<String>>,
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -68,7 +68,8 @@ impl<E: Extractor, R: Responder> core::error::Error for HandlerError<E, R> {}
     note = "a handler is an `async fn` (or closure) whose arguments all implement `Extractor` and whose return type implements `Responder`",
     note = "the future a handler returns must be `Send`: do not hold an `Rc` or a `MutexGuard` across an `.await`",
     note = "a handler takes at most 15 arguments; group the rest into one extractor",
-    note = "common fixes: take path parameters as `Path<T>` or `Params`, take a body as `Json<T>`/`Bytes`/`String`, and return `Json<T>`, `String` or `Result<T>` rather than a bare value"
+    note = "common fixes: take path parameters as `Path<T>` or `Params`, take a body as `Json<T>`/`Bytes`/`String`, and return `Json<T>`, `String` or `Result<T>` rather than a bare value",
+    note = "a payload carried by `Json<T>`, `Form<T>`, `Query<T>` or `PrettyJson<T>` must also derive `ToSchema`, since that is what the generated OpenAPI document describes it with: `#[derive(Serialize, skyzen::ToSchema)]`"
 )]
 pub trait Handler<T: Extractor, R: Responder>: Send + Sync + Clone + 'static {
     /// Handle the request and make a response.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub mod runtime;
 /// Attribute & derive macros exported by Skyzen.
 pub use skyzen_macros::{
     durable_object, email, embed_migrations, error, import_config, main, openapi, queue, scheduled,
-    tail, test, Column, FromRow, HttpError,
+    sql, tail, test, Column, FromRow, HttpError,
 };
 
 /// Static asset helpers for building file servers.

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -267,9 +267,20 @@ where
 /// else falls through to the second.
 ///
 /// The choice is made where the call is written, so it only discriminates when `T` is concrete
-/// there. Calling it from a function generic over `T` always yields the fallback — which is why
-/// `#[skyzen::openapi]` emits the probe at the handler's own call site, where the extractor's
-/// payload type is spelled out.
+/// there. Calling it from a function generic over `T` always yields the fallback, silently — so
+/// this is reachable from exactly one place, `#[skyzen::openapi]`'s expansion, where the payload
+/// type is spelled out and the answer is therefore real.
+///
+/// It exists for one caller: [`Path<T>`](crate::extract::Path), whose payload is legitimately
+/// allowed not to describe itself. A multi-segment route is extracted as `Path<(String, u32)>`,
+/// tuples have no `ToSchema`, and the route pattern already names those parameters — so the
+/// payload only supplies types, and its absence costs a type rather than failing the build. Every
+/// *body* payload takes the opposite route and requires the bound outright: see
+/// [`Json`](crate::utils::Json), whose schema is the documented contract rather than a bonus.
+///
+/// There is deliberately no generic `maybe_schema_of<T>()` wrapper around this. Such a function
+/// can only ever return `None`, and having one meant six extractors and responders reported no
+/// schema while looking as though they reported one.
 #[doc(hidden)]
 #[derive(Debug, Default)]
 pub struct SchemaProbe<T>(PhantomData<T>);
@@ -330,23 +341,6 @@ where
     pub const fn maybe_register(&self, defs: &mut BTreeMap<String, SchemaRef>) {
         let _ = defs;
     }
-}
-
-/// Return the schema for `T` when it implements `ToSchema`; otherwise return `None`.
-///
-/// `T` is generic here, so this always takes the fallback; it exists for extractors whose own
-/// payload type is generic and therefore cannot be probed. `#[skyzen::openapi]` probes at the
-/// handler's call site instead, which is what puts real types in the generated document.
-#[cfg(feature = "openapi")]
-#[must_use]
-pub fn maybe_schema_of<T>() -> Option<SchemaRef> {
-    SchemaProbe::<T>::new().maybe_schema()
-}
-
-/// Register the schema for `T` when it implements `ToSchema`; otherwise do nothing.
-#[cfg(feature = "openapi")]
-pub fn maybe_register_schema_for<T>(defs: &mut BTreeMap<String, SchemaRef>) {
-    SchemaProbe::<T>::new().maybe_register(defs);
 }
 
 /// Register a schema and its dependencies when `OpenAPI` is enabled.

--- a/src/responder/json.rs
+++ b/src/responder/json.rs
@@ -38,7 +38,7 @@ http_error!(
     /// An error occurred when serializing the JSON payload.
     pub PrettyJsonError, StatusCode::INTERNAL_SERVER_ERROR, "Failed to serialize JSON payload");
 
-impl<T: Send + Sync + Serialize + 'static> Responder for PrettyJson<T> {
+impl<T: Send + Sync + Serialize + crate::ToSchema + 'static> Responder for PrettyJson<T> {
     type Error = PrettyJsonError;
     fn respond_to(self, _request: &Request, response: &mut Response) -> Result<(), Self::Error> {
         let payload = to_vec_pretty(&self.0).map_err(|error| {
@@ -57,7 +57,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for PrettyJson<T> {
         Some(vec![crate::openapi::ResponseSchema {
             status: None,
             description: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
             content_type: Some("application/json"),
         }])
     }
@@ -66,7 +66,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for PrettyJson<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -87,7 +87,9 @@ mod tests {
         age: u8,
     }
 
-    #[derive(Debug)]
+    /// A payload whose `Serialize` always fails, so the responder's error path is reachable.
+    /// Its schema is irrelevant and empty, but the bound is real, so it declares one.
+    #[derive(Debug, crate::ToSchema)]
     struct AlwaysFails;
 
     impl Serialize for AlwaysFails {

--- a/src/responder/mod.rs
+++ b/src/responder/mod.rs
@@ -49,7 +49,7 @@ mod tests {
     };
     use serde::Serialize;
 
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, Serialize, crate::ToSchema)]
     struct Article {
         id: u32,
     }

--- a/src/utils/form.rs
+++ b/src/utils/form.rs
@@ -31,7 +31,7 @@ http_error!(
     pub FormEncodeError, StatusCode::INTERNAL_SERVER_ERROR, "Failed to encode form data"
 );
 
-impl<T: Send + Sync + Serialize + 'static> Responder for Form<T> {
+impl<T: Send + Sync + Serialize + crate::ToSchema + 'static> Responder for Form<T> {
     type Error = FormEncodeError;
     fn respond_to(self, _request: &Request, response: &mut Response) -> Result<(), Self::Error> {
         let encoded = to_string(&self.0).map_err(|_| FormEncodeError::new())?;
@@ -47,7 +47,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Form<T> {
         Some(vec![crate::openapi::ResponseSchema {
             status: None,
             description: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
             content_type: Some("application/x-www-form-urlencoded"),
         }])
     }
@@ -56,7 +56,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Form<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -83,7 +83,7 @@ pub enum FormContentTypeError {
     InvalidPayload(String),
 }
 
-impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Form<T> {
+impl<T: Send + Sync + DeserializeOwned + crate::ToSchema + 'static> Extractor for Form<T> {
     type Error = FormRejection;
     async fn extract(request: &mut Request) -> Result<Self, Self::Error> {
         // A GET request carries the form in the query string, so it needs no content type — and
@@ -114,7 +114,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Form<T> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Body,
             content_type: Some("application/x-www-form-urlencoded"),
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
         })
     }
 
@@ -122,7 +122,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Form<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -154,13 +154,13 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use skyzen_core::{Extractor, RequestBodyLimit};
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Deserialize, PartialEq, crate::ToSchema)]
     struct Payload {
         name: String,
         age: u8,
     }
 
-    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq, crate::ToSchema)]
     struct Tagged {
         tags: Vec<String>,
     }

--- a/src/utils/json.rs
+++ b/src/utils/json.rs
@@ -26,7 +26,7 @@ http_error!(
     /// An error occurred when encoding the JSON response.
     pub JsonEncodingError, StatusCode::INTERNAL_SERVER_ERROR, "Failed to encode JSON response");
 
-impl<T: Send + Sync + Serialize + 'static> Responder for Json<T> {
+impl<T: Send + Sync + Serialize + crate::ToSchema + 'static> Responder for Json<T> {
     type Error = JsonEncodingError;
     fn respond_to(self, _request: &Request, response: &mut Response) -> Result<(), Self::Error> {
         response
@@ -42,7 +42,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Json<T> {
         Some(vec![crate::openapi::ResponseSchema {
             status: None,
             description: None,
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
             content_type: Some("application/json"),
         }])
     }
@@ -51,7 +51,7 @@ impl<T: Send + Sync + Serialize + 'static> Responder for Json<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -75,7 +75,7 @@ pub enum JsonContentTypeError {
     InvalidPayload(String),
 }
 
-impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Json<T> {
+impl<T: Send + Sync + DeserializeOwned + crate::ToSchema + 'static> Extractor for Json<T> {
     type Error = JsonRejection;
     async fn extract(request: &mut Request) -> Result<Self, Self::Error> {
         if let Some(content_type) = request.headers().get(CONTENT_TYPE) {
@@ -99,7 +99,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Json<T> {
         Some(crate::openapi::ExtractorSchema {
             location: crate::openapi::ParameterLocation::Body,
             content_type: Some("application/json"),
-            schema: crate::openapi::maybe_schema_of::<T>(),
+            schema: crate::openapi::schema_of::<T>(),
         })
     }
 
@@ -107,7 +107,7 @@ impl<T: Send + Sync + DeserializeOwned + 'static> Extractor for Json<T> {
     fn register_openapi_schemas(
         defs: &mut std::collections::BTreeMap<String, crate::openapi::SchemaRef>,
     ) {
-        crate::openapi::maybe_register_schema_for::<T>(defs);
+        crate::openapi::register_schema_for::<T>(defs);
     }
 }
 
@@ -140,7 +140,7 @@ mod test {
     use serde::Deserialize;
     use skyzen_core::Extractor;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, crate::ToSchema)]
     struct Payload {
         ok: bool,
     }

--- a/tests/extractors.rs
+++ b/tests/extractors.rs
@@ -5,13 +5,13 @@ use skyzen::{
     extract::{Path, Query},
     routing::{CreateRouteNode, Route},
     utils::Json,
-    Body, RequestBodyLimit, Result, StatusCode,
+    Body, RequestBodyLimit, Result, StatusCode, ToSchema,
 };
 use skyzen_test::TestContext;
 
 /// The filter shape `examples/openapi.rs` documents: a repeated query parameter collected into a
 /// list.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
 struct TaskFilter {
     tags: Option<Vec<String>>,
     limit: Option<u32>,
@@ -49,7 +49,7 @@ async fn an_absent_repeated_parameter_is_still_none() {
     assert!(filter.tags.is_none());
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
 struct ProjectTask {
     project: String,
     task: u32,
@@ -169,7 +169,7 @@ async fn lifting_the_limit_lets_a_large_body_through() {
 
 #[tokio::test]
 async fn a_status_and_a_body_compose_in_a_tuple() {
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, Serialize, ToSchema)]
     struct Created {
         id: u32,
     }

--- a/tests/openapi_schemas.rs
+++ b/tests/openapi_schemas.rs
@@ -1,0 +1,151 @@
+//! Regression tests for the schema a generated document actually carries.
+//!
+//! Issue #18: `Json<T>`'s `Responder::openapi()` probed `T` from a generic context, where the
+//! `ToSchema` bound can never be proved, so it always reported `None`. `#[skyzen::openapi]` has a
+//! second path that destructures the return type syntactically and probes at the concrete call
+//! site, which *did* work — so the defect was invisible for `-> Json<T>` and hit every handler
+//! returning a wrapper the macro cannot see through. These tests document both paths.
+
+use serde::{Deserialize, Serialize};
+use skyzen::{
+    routing::{CreateRouteNode, Route, Router},
+    utils::Json,
+    OpenApi, Request, Responder, Response, StatusCode, ToSchema,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct Widget {
+    id: i64,
+    label: String,
+}
+
+/// The shape the issue was reported against: an application's own result wrapper, which renders
+/// its error side itself and forwards the success side's documentation. `#[skyzen::openapi]`
+/// cannot destructure it, so everything it reports has to come from `Responder::openapi()`.
+struct Outcome<T>(T);
+
+impl<T: Responder> Responder for Outcome<T> {
+    type Error = T::Error;
+
+    fn respond_to(
+        self,
+        request: &Request,
+        response: &mut Response,
+    ) -> core::result::Result<(), Self::Error> {
+        self.0.respond_to(request, response)
+    }
+
+    fn openapi() -> Option<Vec<skyzen::openapi::ResponseSchema>> {
+        T::openapi()
+    }
+
+    fn register_openapi_schemas(
+        defs: &mut std::collections::BTreeMap<String, skyzen::openapi::SchemaRef>,
+    ) {
+        T::register_openapi_schemas(defs);
+    }
+}
+
+/// The path that always worked: the macro sees `Json<Widget>` and probes `Widget` itself.
+#[skyzen::openapi]
+async fn direct() -> Json<Widget> {
+    Json(Widget {
+        id: 1,
+        label: "direct".to_owned(),
+    })
+}
+
+/// The path that did not: the macro sees `Outcome<…>`, gives up on destructuring, and takes
+/// whatever `Responder::openapi()` reports — which used to be a schema-less response.
+#[skyzen::openapi]
+async fn wrapped() -> Outcome<Json<Widget>> {
+    Outcome(Json(Widget {
+        id: 2,
+        label: "wrapped".to_owned(),
+    }))
+}
+
+fn document() -> OpenApi {
+    Route::new(("/direct".at(direct), "/wrapped".at(wrapped)))
+        .build()
+        .openapi()
+}
+
+/// The response body of `GET {path}`, as the serialized document renders it.
+///
+/// utoipa inlines a payload's schema here and *also* registers it under `components`, so these
+/// assertions read the inline form; `the_payload_schema_reaches_the_components_map` covers the
+/// other half.
+fn response_content(spec: &serde_json::Value, path: &str) -> serde_json::Value {
+    spec["paths"][path]["get"]["responses"]
+        .as_object()
+        .and_then(|responses| responses.values().next())
+        .and_then(|response| response.get("content"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null)
+}
+
+#[test]
+fn a_responder_the_macro_cannot_destructure_still_documents_its_payload() {
+    let spec = serde_json::to_value(document().to_utoipa_spec()).expect("the spec serializes");
+
+    let wrapped = response_content(&spec, "/wrapped");
+    assert!(
+        !wrapped.is_null(),
+        "issue #18: the wrapped response documented no content at all: {spec:#}"
+    );
+    let schema = &wrapped["application/json"]["schema"];
+    assert!(
+        schema["properties"].get("label").is_some(),
+        "the wrapped response should describe the payload's fields: {schema:#}"
+    );
+}
+
+#[test]
+fn the_wrapped_and_direct_responses_document_the_same_payload() {
+    let spec = serde_json::to_value(document().to_utoipa_spec()).expect("the spec serializes");
+    assert_eq!(
+        response_content(&spec, "/wrapped"),
+        response_content(&spec, "/direct"),
+        "a wrapper that forwards `openapi()` should document what it forwards to"
+    );
+}
+
+#[test]
+fn the_payload_schema_reaches_the_components_map() {
+    let spec = serde_json::to_value(document().to_utoipa_spec()).expect("the spec serializes");
+    let widget = &spec["components"]["schemas"]["Widget"];
+    assert!(
+        widget.is_object(),
+        "the payload's own schema should be registered: {spec:#}"
+    );
+    assert!(
+        widget["properties"].get("label").is_some(),
+        "the registered schema should describe the payload's fields: {widget:#}"
+    );
+}
+
+/// `StatusCode` keeps its meaning alongside a payload: the pair is a responder too.
+#[skyzen::openapi]
+async fn created() -> (StatusCode, Json<Widget>) {
+    (
+        StatusCode::CREATED,
+        Json(Widget {
+            id: 3,
+            label: "created".to_owned(),
+        }),
+    )
+}
+
+#[test]
+fn a_tuple_responder_documents_its_payload_too() {
+    let router: Router = Route::new(("/created".at(created),)).build();
+    let spec = serde_json::to_value(router.openapi().to_utoipa_spec()).expect("serializes");
+    let content = response_content(&spec, "/created");
+    assert!(
+        content["application/json"]["schema"]["properties"]
+            .get("label")
+            .is_some(),
+        "{content:#}"
+    );
+}

--- a/tests/skyzen_test_macro.rs
+++ b/tests/skyzen_test_macro.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use skyzen::{
     routing::{CreateRouteNode, Route, Router},
     utils::Form,
-    Result,
+    Result, ToSchema,
 };
 use skyzen_services::{
     durable::{Alarm, DurableDb, DurableKv},
@@ -72,7 +72,7 @@ async fn injects_the_durable_services_into_the_test_context(
     assert_eq!(durable_db.database_size().await.unwrap(), 0);
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 struct Login {
     user: String,
     remember: bool,

--- a/tests/sql_macro.rs
+++ b/tests/sql_macro.rs
@@ -1,0 +1,188 @@
+//! End-to-end tests for `sql!`.
+//!
+//! The macro's *parsing* is unit-tested inside `skyzen-macros`; what cannot be checked there is
+//! that the expansion is a real query builder — that the placeholders it emits are the ones the
+//! backend rewrites, that the captures reach the right columns, and that it works against a
+//! transaction as well as a `Db`.
+
+use skyzen::{sql, Column, FromRow};
+use skyzen_services::{ColumnEnum, Db};
+use skyzen_test::mock::InMemoryDb;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Column)]
+enum State {
+    Active,
+    Suspended,
+}
+
+#[derive(Debug, PartialEq, Eq, FromRow)]
+struct User {
+    id: i64,
+    login: String,
+    state: State,
+}
+
+async fn seeded() -> InMemoryDb {
+    let db = InMemoryDb::new().await.expect("in-memory sqlite connects");
+    db.db()
+        .query(
+            "CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                login TEXT NOT NULL,
+                state TEXT NOT NULL,
+                seats INTEGER NOT NULL
+            )",
+        )
+        .execute()
+        .await
+        .expect("the schema is valid");
+
+    for (id, login, state, seats) in [
+        (1_i64, "ada", State::Active, 3_u32),
+        (2, "grace", State::Suspended, 7),
+        (3, "alan", State::Active, 7),
+    ] {
+        sql!(
+            db.db(),
+            "INSERT INTO users (id, login, state, seats) VALUES ({id}, {login}, {state}, {seats})"
+        )
+        .execute()
+        .await
+        .expect("the insert succeeds");
+    }
+    db
+}
+
+#[tokio::test]
+async fn captures_bind_in_the_order_they_are_written() {
+    let db = seeded().await;
+    let user: User = sql!(
+        db.db(),
+        "SELECT id, login, state FROM users WHERE state = {State::Active} AND seats = {7_u32}"
+    )
+    .fetch_one()
+    .await
+    .expect("the row is found");
+
+    assert_eq!(
+        user,
+        User {
+            id: 3,
+            login: "alan".to_owned(),
+            state: State::Active,
+        }
+    );
+}
+
+/// The hazard the macro exists to remove: this query is the one above with a condition spliced
+/// into the middle. Nothing had to be renumbered, and each value is still read beside its column.
+#[tokio::test]
+async fn a_condition_added_in_the_middle_keeps_every_value_with_its_column() {
+    let db = seeded().await;
+    let user: User = sql!(
+        db.db(),
+        "SELECT id, login, state FROM users
+         WHERE state = {State::Active} AND login = {\"alan\"} AND seats = {7_u32}"
+    )
+    .fetch_one()
+    .await
+    .expect("the row is found");
+    assert_eq!(user.id, 3);
+}
+
+#[tokio::test]
+async fn a_capture_may_be_any_expression() {
+    let db = seeded().await;
+    let wanted = ["ada", "grace"];
+    let login: String = sql!(db.db(), "SELECT login FROM users WHERE login = {wanted[1]}")
+        .fetch_scalar()
+        .await
+        .expect("the row is found");
+    assert_eq!(login, "grace");
+}
+
+#[tokio::test]
+async fn a_capture_is_a_bound_value_and_never_substituted_text() {
+    let db = seeded().await;
+    // If a capture were interpolated, this would truncate the table. It is bound, so it is only
+    // ever a string compared against a column, and it matches nothing.
+    let injection = "ada'; DROP TABLE users; --";
+    let found: Option<String> = sql!(db.db(), "SELECT login FROM users WHERE login = {injection}")
+        .fetch_scalar_optional()
+        .await
+        .expect("the query runs");
+    assert_eq!(found, None);
+
+    let survivors: i64 = sql!(db.db(), "SELECT COUNT(*) FROM users")
+        .fetch_scalar()
+        .await
+        .expect("the table is still there");
+    assert_eq!(survivors, 3);
+}
+
+#[tokio::test]
+async fn doubled_braces_reach_the_backend_as_one_brace() {
+    let db = InMemoryDb::new().await.expect("in-memory sqlite connects");
+    let document: String = sql!(db.db(), "SELECT '{{\"kind\":\"email\"}}'")
+        .fetch_scalar()
+        .await
+        .expect("the literal survives");
+    assert_eq!(document, r#"{"kind":"email"}"#);
+}
+
+#[tokio::test]
+async fn it_works_against_a_transaction_too() {
+    let db = seeded().await;
+    let mut tx = db.db().begin().await.expect("sqlite has transactions");
+    sql!(
+        tx,
+        "UPDATE users SET state = {State::Suspended} WHERE id = {1_i64}"
+    )
+    .execute()
+    .await
+    .expect("the update runs");
+    tx.commit().await.expect("the transaction commits");
+
+    let state: State = sql!(db.db(), "SELECT state FROM users WHERE id = {1_i64}")
+        .fetch_scalar()
+        .await
+        .expect("the row is found");
+    assert_eq!(state, State::Suspended);
+}
+
+/// The macro emits the dialect-neutral `?`, and the builder rewrites it per backend — so a capture
+/// count that disagrees with the statement is caught by the machinery that was already there.
+#[tokio::test]
+async fn the_emitted_placeholder_is_the_one_the_builder_rewrites() {
+    let db = seeded().await;
+    let ids: Vec<i64> = sql!(
+        db.db(),
+        "SELECT id FROM users WHERE seats = {7_u32} ORDER BY id"
+    )
+    .fetch_scalars()
+    .await
+    .expect("the query runs");
+    assert_eq!(ids, vec![2, 3]);
+}
+
+#[test]
+fn the_column_tokens_are_what_the_macro_binds() {
+    assert_eq!(State::TOKENS, ["active", "suspended"]);
+}
+
+/// `Db` reached through a reference, the way a handler holds it.
+async fn count_active(db: &Db) -> i64 {
+    sql!(
+        db,
+        "SELECT COUNT(*) FROM users WHERE state = {State::Active}"
+    )
+    .fetch_scalar()
+    .await
+    .expect("the count runs")
+}
+
+#[tokio::test]
+async fn it_works_through_a_reference_the_way_a_handler_holds_one() {
+    let db = seeded().await;
+    assert_eq!(count_active(db.db()).await, 2);
+}


### PR DESCRIPTION
Merges `dev` into `main` to release the two issues that missed #23.

#23 was cut from `dev` before #21 and #22 had merged into it, so `main` currently has #14 and #15/#16/#17 but not these two. Both are now on `dev`.

## What ships

| Issue | Commit | What changed |
|---|---|---|
| #18 | `fix(openapi)!` | `maybe_schema_of::<T>()` could never return a schema — it wrapped an autoref-specialization probe, which only discriminates at a concrete call site, so from a generic context the `None` arm always won. Six extractors and responders reported no schema while looking as though they reported one. `Json<T>`, `Form<T>`, `Query<T>` and `PrettyJson<T>` now require `T: ToSchema`; `Path<T>` deliberately does not, since a multi-segment route is `Path<(String, u32)>` and tuples have no schema. |
| #20 | `feat(macros)` | `sql!` derives bind order from the query text, so splicing a condition into the middle of a statement can no longer shift every later `.bind()` by one. A capture is always a bound value, never substituted text. No database at build time, no dialect coupling. |

## Breaking changes

- `Json<T>`, `Form<T>`, `Query<T>` and `PrettyJson<T>` require `T: ToSchema`. A payload derives it beside its serde derive; utoipa already covers every primitive, collection and `serde_json::Value`, so only an application's own structs are affected.
- The derive expands to `::utoipa::…` paths, so an application declares `utoipa` in its own manifest. `skyzen new --template api` now does, and the `Handler` diagnostic names it when that is the missing bound.
- `maybe_schema_of` and `maybe_register_schema_for` are removed. Neither could ever return a schema.

`sql!` is purely additive.

## Verification

Both merged green. Locally on stable: `clippy --workspace --all-targets --all-features -- -D warnings`, `fmt --all --check`, `cargo machete`, `-p skyzen --no-default-features`, `-p skyzen-cloudflare --target wasm32-unknown-unknown`, and 1057 tests across 40 binaries.

## On merging

As with #23, merging this does not publish. Pushing to `main` runs `release.yml`, whose `release-pr` job opens the version-bump-and-changelog PR; merging *that* is what publishes.
