### PR TITLE
feat(manifest): interpolate deploy-time environment placeholders

### DIFF
--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -10,10 +10,14 @@
 //! A backend whose constructor fixes its own variable names (Cosmos DB, the RDS Data API) is
 //! covered too: the section reports those names, so they reach this check and `.env.example` the
 //! same way a key-named one does.
+//!
+//! The same files, plus the process environment, fill `${NAME}` placeholders in `Skyzen.toml`
+//! itself when the CLI reads it. That is deploy-time interpolation (GitHub Actions secrets), not
+//! the runtime environment of the deployed process. `#[skyzen::main]` does not expand them.
 
 use anyhow::{Context, Result};
 use askama::Template;
-use skyzen_manifest::{SkyzenManifest, WiringEnvVar};
+use skyzen_manifest::{InterpolateError, Manifest, SkyzenManifest, WiringEnvVar};
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
@@ -79,6 +83,38 @@ fn collect(
             |key| format!("{section}.{key}"),
         ),
     }));
+}
+
+/// Read `Skyzen.toml`, expanding `${NAME}` from the process environment and then `.env` files.
+///
+/// Process environment wins, matching [`ensure_available`]: a one-off
+/// `CACHE_ID=... skyzen deploy` still overrides `.env`. The CLI's own environment is never
+/// mutated.
+///
+/// # Errors
+///
+/// Fails when the file cannot be read, a placeholder cannot be expanded, a dotenv file is
+/// malformed, or the document does not match the schema.
+pub fn load_manifest(path: &Path) -> Result<Manifest> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to read the current directory")?
+            .join(path)
+    };
+    let root_dir = absolute.parent().unwrap_or_else(|| Path::new("."));
+    let dotenv = load_dotenv_files(root_dir)?;
+    let lookup = |name: &str| lookup_var(name, &dotenv);
+    Ok(Manifest::load_with(&absolute, Some(&lookup))?)
+}
+
+/// Process environment first, then the dotenv map. Invalid Unicode fails rather than skipping.
+fn lookup_var(
+    name: &str,
+    dotenv: &BTreeMap<String, String>,
+) -> Result<Option<String>, InterpolateError> {
+    Ok(skyzen_manifest::process_env(name)?.or_else(|| dotenv.get(name).cloned()))
 }
 
 /// The variables loaded from the project's `.env` files.
@@ -168,7 +204,9 @@ pub fn dotenv_paths(root_dir: &Path) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_available, load_dotenv_files, render_example, required_variables};
+    use super::{
+        ensure_available, load_dotenv_files, load_manifest, render_example, required_variables,
+    };
     use skyzen_manifest::Manifest;
     use std::collections::BTreeMap;
 
@@ -338,5 +376,52 @@ mod tests {
     fn the_example_explains_itself_when_nothing_is_declared() {
         let rendered = render_example(&manifest("")).expect("render");
         assert!(rendered.contains("declares no native environment variables"));
+    }
+
+    #[test]
+    fn load_manifest_interpolates_from_dotenv() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Skyzen.toml"),
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\
+             account_id = \"${SKYZEN_TEST_ACCOUNT_ID}\"\n",
+        )
+        .expect("write manifest");
+        std::fs::write(
+            dir.path().join(".env"),
+            "SKYZEN_TEST_ACCOUNT_ID=acct_from_dotenv\n",
+        )
+        .expect("write dotenv");
+
+        let loaded = load_manifest(&dir.path().join("Skyzen.toml")).expect("load");
+        assert_eq!(
+            loaded
+                .data()
+                .cloudflare
+                .as_ref()
+                .expect("cloudflare")
+                .account_id
+                .as_deref(),
+            Some("acct_from_dotenv")
+        );
+    }
+
+    #[test]
+    fn load_manifest_fails_when_a_placeholder_is_unset() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Skyzen.toml"),
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\
+             account_id = \"${SKYZEN_TEST_UNSET_INTERPOLATION}\"\n",
+        )
+        .expect("write manifest");
+
+        let error = load_manifest(&dir.path().join("Skyzen.toml")).expect_err("unset");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("SKYZEN_TEST_UNSET_INTERPOLATION"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("account_id"), "{rendered}");
     }
 }

--- a/cli/src/migrate.rs
+++ b/cli/src/migrate.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     cli::{MigrateCommand, Provider},
-    environment::{ensure_available, load_dotenv_files, required_variables},
+    environment::{ensure_available, load_dotenv_files, load_manifest, required_variables},
     output,
 };
 use anyhow::{Context, Result};
@@ -108,7 +108,7 @@ pub fn run(
     command: Option<MigrateCommand>,
     dry_run: bool,
 ) -> Result<()> {
-    let manifest = Manifest::load(manifest_path)?;
+    let manifest = load_manifest(manifest_path)?;
     let targets = resolve_targets(&manifest)?;
 
     // A dry run neither connects nor creates anything: it reads and validates the directories and

--- a/cli/src/providers/azure.rs
+++ b/cli/src/providers/azure.rs
@@ -11,7 +11,7 @@
 mod bundle;
 
 use crate::{
-    output,
+    environment, output,
     project::Project,
     providers::{
         prepare_child_environment, Action, ArtifactBuild, CommandPlan, ProviderPlan, RunMode,
@@ -303,7 +303,7 @@ fn ensure_runs_on_linux(artifact: &Path, target: Option<&str>, require: bool) ->
 /// Only meaningful when the manifest names one: without `target`, the build is whatever the host
 /// is, which is right on a Linux CI machine and caught before the upload anywhere else.
 pub fn check_linux_target(manifest_path: &Path) -> usize {
-    let target = Manifest::load(manifest_path)
+    let target = environment::load_manifest(manifest_path)
         .ok()
         .and_then(|manifest| manifest.data().azure.as_ref()?.target.clone());
     let Some(target) = target else {

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -207,7 +207,7 @@ pub fn prepare(
 /// section", which says what to do, rather than with a file-not-found.
 fn load_or_empty(manifest_path: &Path) -> Result<Manifest> {
     if manifest_path.exists() {
-        return Ok(Manifest::load(manifest_path)?);
+        return environment::load_manifest(manifest_path);
     }
 
     let absolute = if manifest_path.is_absolute() {
@@ -253,7 +253,7 @@ pub fn provision(
              --provider azure`"
         ),
         Provider::Cloudflare => {
-            let manifest = Manifest::load(manifest_path)?;
+            let manifest = environment::load_manifest(manifest_path)?;
             let config = manifest
                 .cloudflare(environment)?
                 .ok_or_else(|| anyhow::anyhow!("missing [cloudflare] section in Skyzen.toml"))?;
@@ -482,7 +482,7 @@ fn check_manifest(
         return 0;
     }
 
-    let manifest = match Manifest::load(manifest_path) {
+    let manifest = match environment::load_manifest(manifest_path) {
         Ok(manifest) => {
             output::ok(format!("{} parses", manifest_path.display()));
             manifest

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -207,6 +207,32 @@ skyzen logs --env staging
 
 See [Environments](skyzen-toml-reference.md#environments) for the merge rules.
 
+### GitHub Actions
+
+`${NAME}` in `Skyzen.toml` is expanded from the job's environment when the CLI reads the file.
+Map repository secrets into `env:` on the deploy step — that is the process environment of
+`skyzen deploy`, not the Worker after it starts.
+
+```yaml
+- run: skyzen deploy --provider cloudflare
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
+```
+
+```toml
+[cloudflare]
+account_id = "${CLOUDFLARE_ACCOUNT_ID}"
+
+[[cloudflare.kv_namespaces]]
+binding = "CACHE"
+id = "${CACHE_NAMESPACE_ID}"
+```
+
+See [Deploy-time interpolation](skyzen-toml-reference.md#deploy-time-interpolation) for the syntax.
+`CLOUDFLARE_API_TOKEN` is wrangler's own credential and stays out of the file.
+
 ### Logs and Secrets
 
 ```sh

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -740,6 +740,57 @@ The generated `wrangler.toml` contains a complete `[env.<name>]` section for eac
 
 `[cloudflare.env.<name>.env]` is rejected: overlays do not nest.
 
+## Deploy-time interpolation
+
+String values may contain `${NAME}` placeholders. `skyzen deploy`, `skyzen dev`, `skyzen provision`
+and the rest of the CLI expand them from the **process environment of the machine running the
+command** — GitHub Actions secrets mapped into the job, or the project's `.env` / `.env.local`.
+Process environment wins over the dotenv files, same as native wiring.
+
+This is not the runtime environment of the deployed Worker or Lambda. `url_env = "CACHE_URL"` names
+a variable the application reads after it starts. `${CACHE_NAMESPACE_ID}` is replaced **before**
+the CLI generates `wrangler.toml` or invokes `cargo lambda`.
+
+```toml
+[cloudflare]
+name = "api"
+compatibility_date = "2025-02-01"
+account_id = "${CLOUDFLARE_ACCOUNT_ID}"
+
+[[cloudflare.kv_namespaces]]
+binding = "CACHE"
+id = "${CACHE_NAMESPACE_ID}"
+
+[cloudflare.vars]
+API_URL = "${API_URL}"
+```
+
+```yaml
+# .github/workflows/deploy.yml
+- run: skyzen deploy --provider cloudflare
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
+    API_URL: ${{ vars.API_URL }}
+```
+
+`CLOUDFLARE_API_TOKEN` is already read by wrangler from the process environment and does not belong
+in the file.
+
+Rules:
+
+- `${NAME}` in string **values** only. Keys are not expanded.
+- `NAME` is `[A-Za-z_][A-Za-z0-9_]*`. Hyphens, defaults (`${NAME:-x}`), and unclosed `${` fail the parse.
+- A missing name fails the parse, naming the TOML path and the variable.
+- `$$` writes a literal `$`. `$${NAME}` is the text `${NAME}`, not a lookup.
+- Expansion runs on the parsed document, so a secret containing quotes or newlines cannot break TOML.
+- Integers and booleans are not strings: `memory_mb = "${MEM}"` is a type error, not an interpolation.
+- `#[skyzen::main]` does **not** expand placeholders. A missing GitHub secret must not fail `cargo build`. Do not wrap `url_env` / `binding` / service names in `${}` — those fields are consumed at compile time as literal names.
+
+Interpolating a secret into `[cloudflare.vars]` or `[aws.env]` still stores it as a plaintext
+platform variable. Worker secrets stay on `skyzen secret set`.
+
 ## Escape Hatch
 
 `[cloudflare.raw]` is merged verbatim into the generated `wrangler.toml`, using the same rules as an

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -30,6 +30,11 @@ let cloudflare = manifest.cloudflare(Some("staging"))?;
 # Ok::<_, Box<dyn std::error::Error>>(())
 ```
 
+String values may contain `${NAME}` placeholders. The CLI expands them from the process
+environment (GitHub Actions secrets, `.env`) through `Manifest::load_with`. `Manifest::load`
+leaves them as written, which is what `#[skyzen::main]` uses so a missing CI secret cannot fail
+`cargo build`.
+
 See the [`Skyzen.toml` reference](https://github.com/zen-rs/skyzen/blob/main/docs/skyzen-toml-reference.md)
 for the full key list.
 

--- a/manifest/src/interpolate.rs
+++ b/manifest/src/interpolate.rs
@@ -1,0 +1,334 @@
+//! Deploy-time `${NAME}` expansion in `Skyzen.toml` string values.
+//!
+//! The CLI expands placeholders from the process environment (and the project's `.env` files)
+//! when it reads the manifest. `#[skyzen::main]` does **not**: compile-time env is not the
+//! deploy runner, and a GitHub secret the compiler does not have must not fail `cargo build`.
+//!
+//! Expansion runs on the parsed TOML document, before the typed schema, so a value containing
+//! quotes or newlines cannot break the file. Keys are never expanded. A missing, unclosed, or
+//! invalid name fails the parse; there is no `${NAME:-default}`. `$$` writes a literal `$`.
+
+use std::borrow::Cow;
+use toml::Value;
+
+/// Looks up `${NAME}` during expansion. `Ok(None)` means the name is unset.
+pub type EnvLookup<'a> = &'a dyn Fn(&str) -> Result<Option<String>, InterpolateError>;
+
+/// What went wrong expanding a `${NAME}` placeholder.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum InterpolateError {
+    /// A `${` with no matching `}`.
+    #[error("{location}: unclosed `${{`")]
+    Unclosed {
+        /// TOML path of the string, e.g. `cloudflare.kv_namespaces[0].id`.
+        location: String,
+    },
+    /// `${}` with nothing between the braces.
+    #[error("{location}: empty interpolation name")]
+    EmptyName {
+        /// TOML path of the string.
+        location: String,
+    },
+    /// The name is not `[A-Za-z_][A-Za-z0-9_]*`.
+    #[error("{location}: invalid interpolation name `{name}`")]
+    InvalidName {
+        /// TOML path of the string.
+        location: String,
+        /// The rejected name.
+        name: String,
+    },
+    /// `lookup` returned `Ok(None)` for this name.
+    #[error("{location}: environment variable `{name}` is not set")]
+    Missing {
+        /// TOML path of the string.
+        location: String,
+        /// The variable that was asked for.
+        name: String,
+    },
+    /// The process environment holds `name` but the value is not Unicode.
+    #[error("{location}: environment variable `{name}` is not valid Unicode")]
+    NotUnicode {
+        /// TOML path of the string, empty when the error is produced before a path is known.
+        location: String,
+        /// The variable that was asked for.
+        name: String,
+    },
+}
+
+impl InterpolateError {
+    /// Fill in the TOML path when the error was produced without one (process-env Unicode).
+    #[must_use]
+    pub fn at(self, location: &str) -> Self {
+        match self {
+            Self::NotUnicode {
+                name,
+                location: loc,
+            } if loc.is_empty() => Self::NotUnicode {
+                location: location.to_owned(),
+                name,
+            },
+            other => other,
+        }
+    }
+}
+
+/// Read `name` from the process environment.
+///
+/// # Errors
+///
+/// Returns [`InterpolateError::NotUnicode`] when the variable is set but is not valid Unicode.
+pub fn process_env(name: &str) -> Result<Option<String>, InterpolateError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(InterpolateError::NotUnicode {
+            location: String::new(),
+            name: name.to_owned(),
+        }),
+    }
+}
+
+/// Expand `${NAME}` placeholders in `input`.
+///
+/// `lookup` returns the value for `NAME`, `Ok(None)` when it is unset (which becomes
+/// [`InterpolateError::Missing`]), or [`InterpolateError::NotUnicode`].
+///
+/// # Errors
+///
+/// Returns [`InterpolateError`] when a placeholder is unclosed, empty, not an identifier, unset,
+/// or not Unicode.
+pub fn expand<'a>(
+    input: &'a str,
+    location: &str,
+    lookup: EnvLookup<'_>,
+) -> Result<Cow<'a, str>, InterpolateError> {
+    if !input.contains('$') {
+        return Ok(Cow::Borrowed(input));
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(dollar) = rest.find('$') {
+        out.push_str(&rest[..dollar]);
+        let after = &rest[dollar + 1..];
+        if let Some(stripped) = after.strip_prefix('$') {
+            out.push('$');
+            rest = stripped;
+            continue;
+        }
+        if let Some(inner) = after.strip_prefix('{') {
+            let Some(end) = inner.find('}') else {
+                return Err(InterpolateError::Unclosed {
+                    location: location.to_owned(),
+                });
+            };
+            let name = &inner[..end];
+            if name.is_empty() {
+                return Err(InterpolateError::EmptyName {
+                    location: location.to_owned(),
+                });
+            }
+            if !is_ident(name) {
+                return Err(InterpolateError::InvalidName {
+                    location: location.to_owned(),
+                    name: name.to_owned(),
+                });
+            }
+            let value = match lookup(name) {
+                Ok(Some(value)) => value,
+                Ok(None) => {
+                    return Err(InterpolateError::Missing {
+                        location: location.to_owned(),
+                        name: name.to_owned(),
+                    });
+                }
+                Err(error) => return Err(error.at(location)),
+            };
+            out.push_str(&value);
+            rest = &inner[end + 1..];
+            continue;
+        }
+        out.push('$');
+        rest = after;
+    }
+    out.push_str(rest);
+    Ok(Cow::Owned(out))
+}
+
+/// Expand every string **value** in `table`. Keys are left as written.
+///
+/// # Errors
+///
+/// Returns the first [`InterpolateError`] encountered, with `location` set to the TOML path.
+pub fn expand_table(
+    table: &mut toml::Table,
+    lookup: EnvLookup<'_>,
+) -> Result<(), InterpolateError> {
+    expand_table_at(table, "", lookup)
+}
+
+fn expand_table_at(
+    table: &mut toml::Table,
+    parent: &str,
+    lookup: EnvLookup<'_>,
+) -> Result<(), InterpolateError> {
+    for (key, value) in table.iter_mut() {
+        let location = child_path(parent, key);
+        expand_value(value, &location, lookup)?;
+    }
+    Ok(())
+}
+
+fn expand_value(
+    value: &mut Value,
+    location: &str,
+    lookup: EnvLookup<'_>,
+) -> Result<(), InterpolateError> {
+    match value {
+        Value::String(text) => {
+            if let Cow::Owned(expanded) = expand(text, location, lookup)? {
+                *text = expanded;
+            }
+            Ok(())
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                let child = format!("{location}[{index}]");
+                expand_value(item, &child, lookup)?;
+            }
+            Ok(())
+        }
+        Value::Table(table) => expand_table_at(table, location, lookup),
+        Value::Integer(_) | Value::Float(_) | Value::Boolean(_) | Value::Datetime(_) => Ok(()),
+    }
+}
+
+fn child_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_owned()
+    } else {
+        format!("{parent}.{key}")
+    }
+}
+
+fn is_ident(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expand, expand_table, InterpolateError};
+    use std::collections::BTreeMap;
+
+    fn lookup<'a>(
+        env: &'a BTreeMap<&'a str, &'a str>,
+    ) -> impl Fn(&str) -> Result<Option<String>, InterpolateError> + 'a {
+        |name| Ok(env.get(name).map(|value| (*value).to_owned()))
+    }
+
+    #[test]
+    fn a_string_without_dollar_is_unchanged() {
+        let env = BTreeMap::new();
+        let expanded = expand("plain", "k", &lookup(&env)).expect("expand");
+        assert!(matches!(expanded, std::borrow::Cow::Borrowed("plain")));
+    }
+
+    #[test]
+    fn expands_a_placeholder_and_surrounding_text() {
+        let env = BTreeMap::from([("ENV", "staging")]);
+        assert_eq!(
+            expand("api-${ENV}", "name", &lookup(&env)).expect("expand"),
+            "api-staging"
+        );
+    }
+
+    #[test]
+    fn doubled_dollar_is_a_literal_dollar() {
+        let env = BTreeMap::from([("ENV", "x")]);
+        assert_eq!(
+            expand("$${ENV}", "k", &lookup(&env)).expect("expand"),
+            "${ENV}"
+        );
+        assert_eq!(expand("$$", "k", &lookup(&env)).expect("expand"), "$");
+    }
+
+    #[test]
+    fn a_dollar_without_braces_is_literal() {
+        let env = BTreeMap::from([("FOO", "x")]);
+        assert_eq!(expand("$FOO", "k", &lookup(&env)).expect("expand"), "$FOO");
+    }
+
+    #[test]
+    fn a_missing_variable_names_the_name_and_location() {
+        let env = BTreeMap::new();
+        let error =
+            expand("${MISSING}", "cloudflare.account_id", &lookup(&env)).expect_err("unset");
+        assert_eq!(
+            error,
+            InterpolateError::Missing {
+                location: "cloudflare.account_id".to_owned(),
+                name: "MISSING".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn unclosed_empty_and_invalid_names_fail() {
+        let env = BTreeMap::new();
+        let get = lookup(&env);
+        assert!(matches!(
+            expand("${NOPE", "k", &get),
+            Err(InterpolateError::Unclosed { .. })
+        ));
+        assert!(matches!(
+            expand("${}", "k", &get),
+            Err(InterpolateError::EmptyName { .. })
+        ));
+        assert!(matches!(
+            expand("${FOO-BAR}", "k", &get),
+            Err(InterpolateError::InvalidName { name, .. }) if name == "FOO-BAR"
+        ));
+        assert!(matches!(
+            expand("${FOO:-x}", "k", &get),
+            Err(InterpolateError::InvalidName { .. })
+        ));
+    }
+
+    #[test]
+    fn expand_table_walks_nested_tables_and_arrays_and_leaves_keys() {
+        let mut table: toml::Table = toml::from_str(
+            "[cloudflare.vars]\nAPI_URL = \"${API_URL}\"\n\n\
+             [[cloudflare.kv_namespaces]]\nbinding = \"CACHE\"\nid = \"${CACHE_ID}\"\n",
+        )
+        .expect("toml");
+        let env = BTreeMap::from([("API_URL", "https://api.flyco.io"), ("CACHE_ID", "ns_abc")]);
+        expand_table(&mut table, &lookup(&env)).expect("expand");
+
+        assert_eq!(
+            table["cloudflare"]["vars"]["API_URL"].as_str(),
+            Some("https://api.flyco.io")
+        );
+        assert_eq!(
+            table["cloudflare"]["kv_namespaces"][0]["id"].as_str(),
+            Some("ns_abc")
+        );
+        assert_eq!(
+            table["cloudflare"]["kv_namespaces"][0]["binding"].as_str(),
+            Some("CACHE")
+        );
+    }
+
+    #[test]
+    fn a_value_with_quotes_and_newlines_does_not_reparse_the_document() {
+        let env = BTreeMap::from([("BANNER", "he said \"hi\"\nnext")]);
+        assert_eq!(
+            expand("${BANNER}", "vars.BANNER", &lookup(&env)).expect("expand"),
+            "he said \"hi\"\nnext"
+        );
+    }
+}

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -12,6 +12,13 @@
 //! [`Manifest::parse`] resolves every overlay against the base eagerly, so a typo in an
 //! environment nobody selected still fails the parse. Overlays compose with [`deep_merge`].
 //!
+//! # Deploy-time interpolation
+//!
+//! String values may contain `${NAME}` placeholders. The CLI expands them from the process
+//! environment when it reads the file (GitHub Actions secrets mapped into the job env, or
+//! `.env`). [`Manifest::parse`] leaves them as written so `#[skyzen::main]` does not depend on
+//! secrets the compiler does not have. A missing name fails the CLI parse; there is no default.
+//!
 //! ```
 //! # use skyzen_manifest::Manifest;
 //! let manifest = Manifest::parse(
@@ -38,10 +45,12 @@
 //! assert_eq!(staging.workers_dev, Some(true));
 //! ```
 
+mod interpolate;
 mod merge;
 pub mod migrations;
 mod schema;
 
+pub use interpolate::{expand, expand_table, process_env, EnvLookup, InterpolateError};
 pub use merge::deep_merge;
 pub use migrations::{MigrationFile, MigrationsError, DEFAULT_MIGRATIONS_DIR};
 pub use schema::{
@@ -121,6 +130,14 @@ pub enum ManifestError {
         /// Which keys are named and which are missing.
         source: schema::PartialRdsDataWiring,
     },
+    /// A `${NAME}` placeholder in a string value could not be expanded.
+    #[error("{path}: {source}")]
+    Interpolation {
+        /// The manifest path.
+        path: PathBuf,
+        /// What was wrong with the placeholder, including the TOML path.
+        source: interpolate::InterpolateError,
+    },
     /// A named environment was requested that the manifest does not declare.
     #[error(
         "{path} declares no Cloudflare environment named `{name}`{}",
@@ -150,7 +167,7 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    /// Read and parse the manifest at `path`.
+    /// Read and parse the manifest at `path`, leaving `${NAME}` placeholders as written.
     ///
     /// `root_dir` — the project root every relative path in the manifest is resolved against — is
     /// taken to be the manifest's parent directory.
@@ -160,6 +177,20 @@ impl Manifest {
     /// Returns [`ManifestError`] when the file cannot be read, is not valid TOML, does not match
     /// the schema, or has a malformed `[cloudflare.env]` table.
     pub fn load(path: &Path) -> Result<Self, ManifestError> {
+        Self::load_with(path, None)
+    }
+
+    /// Read and parse the manifest at `path`, expanding `${NAME}` through `lookup`.
+    ///
+    /// `lookup` is `None` for compile-time consumers. The CLI supplies one that reads the process
+    /// environment and the project's `.env` files.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError`] when the file cannot be read, a placeholder cannot be expanded,
+    /// the file is not valid TOML, does not match the schema, or has a malformed `[cloudflare.env]`
+    /// table.
+    pub fn load_with(path: &Path, lookup: Option<EnvLookup<'_>>) -> Result<Self, ManifestError> {
         let path = if path.is_absolute() {
             path.to_path_buf()
         } else {
@@ -178,13 +209,14 @@ impl Manifest {
             path: path.clone(),
             source,
         })?;
-        Self::parse(&content, &path, root_dir)
+        Self::parse_with(&content, &path, root_dir, lookup)
     }
 
     /// Parse manifest `content` that came from `path`, rooted at `root_dir`.
     ///
     /// `path` is used only for error messages, so callers holding the content in memory (tests,
     /// or a manifest embedded in a template) can name whatever the user would recognize.
+    /// `${NAME}` placeholders are left as written; see [`parse_with`](Self::parse_with).
     ///
     /// # Errors
     ///
@@ -195,12 +227,40 @@ impl Manifest {
         path: impl AsRef<Path>,
         root_dir: impl Into<PathBuf>,
     ) -> Result<Self, ManifestError> {
+        Self::parse_with(content, path, root_dir, None)
+    }
+
+    /// Parse `content`, expanding `${NAME}` through `lookup` before the typed schema runs.
+    ///
+    /// Expansion walks string **values** only, so a secret containing quotes or newlines cannot
+    /// break the document. A missing name fails rather than leaving a placeholder in a field the
+    /// CLI would treat as a literal id.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError`] when a placeholder cannot be expanded, the content is not valid
+    /// TOML, does not match the schema, or has a malformed `[cloudflare.env]` table.
+    pub fn parse_with(
+        content: &str,
+        path: impl AsRef<Path>,
+        root_dir: impl Into<PathBuf>,
+        lookup: Option<EnvLookup<'_>>,
+    ) -> Result<Self, ManifestError> {
         let path = path.as_ref().to_path_buf();
         let mut document: toml::Table =
             toml::from_str(content).map_err(|source| ManifestError::Syntax {
                 path: path.clone(),
                 source: Box::new(source),
             })?;
+
+        if let Some(lookup) = lookup {
+            interpolate::expand_table(&mut document, lookup).map_err(|source| {
+                ManifestError::Interpolation {
+                    path: path.clone(),
+                    source,
+                }
+            })?;
+        }
 
         // Lift the environment overlays out before any typed deserialization: the base and every
         // overlay then go through the *same* `CloudflareSection`, which is what makes
@@ -362,13 +422,21 @@ fn take_environment_overlays(
 #[cfg(test)]
 mod tests {
     use super::{
-        Manifest, ManifestError, NativeDatabaseBackend, NativeDatabaseSection,
+        InterpolateError, Manifest, ManifestError, NativeDatabaseBackend, NativeDatabaseSection,
         NativeServiceBackend, NativeServiceSection, RdsEngine, ServiceType,
     };
     use std::time::Duration;
 
     fn parse(content: &str) -> Result<Manifest, ManifestError> {
         Manifest::parse(content, "Skyzen.toml", ".")
+    }
+
+    fn parse_expanded(content: &str, env: &[(&str, &str)]) -> Result<Manifest, ManifestError> {
+        let map: std::collections::BTreeMap<&str, &str> = env.iter().copied().collect();
+        let lookup = |name: &str| -> Result<Option<String>, InterpolateError> {
+            Ok(map.get(name).map(|value| (*value).to_owned()))
+        };
+        Manifest::parse_with(content, "Skyzen.toml", ".", Some(&lookup))
     }
 
     /// The `[native.service.cache]` a manifest wiring `cache` with `body` produces.
@@ -1033,6 +1101,91 @@ mod tests {
         assert!(
             error.to_string().contains("prod") && error.to_string().contains("staging"),
             "error should name the request and the alternatives: {error}"
+        );
+    }
+
+    #[test]
+    fn interpolates_string_values_from_the_supplied_lookup() {
+        let manifest = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\naccount_id = \"${ACCOUNT}\"\n\n\
+             [[cloudflare.kv_namespaces]]\nbinding = \"CACHE\"\nid = \"${CACHE_ID}\"\n\n\
+             [cloudflare.vars]\nAPI_URL = \"${API_URL}\"\n\n\
+             [cloudflare.env.staging]\naccount_id = \"${STAGING_ACCOUNT}\"\n",
+            &[
+                ("ACCOUNT", "acct_prod"),
+                ("CACHE_ID", "ns_abc"),
+                ("API_URL", "https://api.flyco.io"),
+                ("STAGING_ACCOUNT", "acct_staging"),
+            ],
+        )
+        .expect("manifest parses");
+
+        let base = manifest
+            .cloudflare(None)
+            .expect("base")
+            .expect("cloudflare");
+        assert_eq!(base.account_id.as_deref(), Some("acct_prod"));
+        assert_eq!(base.kv_namespaces[0].id.as_deref(), Some("ns_abc"));
+        assert_eq!(base.vars["API_URL"], "https://api.flyco.io");
+
+        let staging = manifest
+            .cloudflare(Some("staging"))
+            .expect("known environment")
+            .expect("cloudflare");
+        assert_eq!(staging.account_id.as_deref(), Some("acct_staging"));
+        // Overlay inherits the expanded base binding list.
+        assert_eq!(staging.kv_namespaces[0].id.as_deref(), Some("ns_abc"));
+    }
+
+    #[test]
+    fn parse_without_expansion_leaves_placeholders_in_place() {
+        let manifest = parse(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [[cloudflare.kv_namespaces]]\nbinding = \"CACHE\"\nid = \"${CACHE_ID}\"\n",
+        )
+        .expect("literal parse");
+        assert_eq!(
+            manifest
+                .data()
+                .cloudflare
+                .as_ref()
+                .expect("cloudflare")
+                .kv_namespaces[0]
+                .id
+                .as_deref(),
+            Some("${CACHE_ID}")
+        );
+    }
+
+    #[test]
+    fn a_missing_interpolation_fails_naming_the_variable_and_the_key() {
+        let error = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\naccount_id = \"${ACCOUNT}\"\n",
+            &[],
+        )
+        .expect_err("unset");
+        let rendered = error.to_string();
+        assert!(rendered.contains("ACCOUNT"), "{rendered}");
+        assert!(rendered.contains("account_id"), "{rendered}");
+        assert!(rendered.contains("Skyzen.toml"), "{rendered}");
+    }
+
+    #[test]
+    fn interpolating_a_value_with_quotes_does_not_break_toml() {
+        let manifest = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nBANNER = \"${BANNER}\"\n",
+            &[("BANNER", "he said \"hi\"")],
+        )
+        .expect("manifest parses");
+        assert_eq!(
+            manifest
+                .data()
+                .cloudflare
+                .as_ref()
+                .expect("cloudflare")
+                .vars["BANNER"],
+            "he said \"hi\""
         );
     }
 


### PR DESCRIPTION
Fixes #27

`skyzen deploy` now expands `${NAME}` in Skyzen.toml string values from the **deploy runner** environment (GitHub Actions secrets mapped into the job, plus `.env` / `.env.local`). This is not the Worker/Lambda runtime env: `url_env = "CACHE_URL"` still names a variable the process reads after it starts.

## Behaviour

- `${NAME}` in string values only. `NAME` is `[A-Za-z_][A-Za-z0-9_]*`.
- Missing, unclosed, empty, or invalid names fail the parse (no `${NAME:-default}`).
- `$$` writes a literal `$`.
- Expansion runs on the parsed TOML document, so a secret containing quotes or newlines cannot break the file.
- CLI only. `#[skyzen::main]` leaves placeholders as written so a missing CI secret cannot fail `cargo build`.

## GitHub Actions

```yaml
- run: skyzen deploy --provider cloudflare
  env:
    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
```

```toml
[[cloudflare.kv_namespaces]]
binding = "CACHE"
id = "${CACHE_NAMESPACE_ID}"
```

`CLOUDFLARE_API_TOKEN` stays out of the file; wrangler already reads it from the process environment.
