### PR TITLE
feat(cli): refuse committed secrets on CLI load

### DIFF
--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -12,9 +12,10 @@
 //! same way a key-named one does.
 //!
 //! The same files, plus the process environment, fill `${NAME}` placeholders in `Skyzen.toml`
-//! itself when the CLI reads it. That is deploy-time interpolation (GitHub Actions secrets), not
-//! the runtime environment of the deployed process. `#[skyzen::main]` does not expand them.
+//! itself when the CLI reads it. That is deploy-time interpolation, not the runtime environment
+//! of the deployed process. `#[skyzen::main]` does not expand them.
 
+use crate::{output, secret_files};
 use anyhow::{Context, Result};
 use askama::Template;
 use skyzen_manifest::{InterpolateError, Manifest, SkyzenManifest, WiringEnvVar};
@@ -93,7 +94,8 @@ fn collect(
 ///
 /// # Errors
 ///
-/// Fails when the file cannot be read, a placeholder cannot be expanded, a dotenv file is
+/// Fails when the file cannot be read, a placeholder cannot be expanded, a documented
+/// credential form is stored as a literal, a dotenv file is tracked by git, a dotenv file is
 /// malformed, or the document does not match the schema.
 pub fn load_manifest(path: &Path) -> Result<Manifest> {
     let absolute = if path.is_absolute() {
@@ -106,7 +108,16 @@ pub fn load_manifest(path: &Path) -> Result<Manifest> {
     let root_dir = absolute.parent().unwrap_or_else(|| Path::new("."));
     let dotenv = load_dotenv_files(root_dir)?;
     let lookup = |name: &str| lookup_var(name, &dotenv);
-    Ok(Manifest::load_with(&absolute, Some(&lookup))?)
+    let manifest = Manifest::load_with(&absolute, Some(&lookup))?;
+    for finding in manifest.secret_warnings() {
+        output::warn(format!(
+            "{finding}; if this is a secret, use a ${{NAME}} placeholder or `skyzen secret set`"
+        ));
+    }
+    for warning in secret_files::ensure(root_dir)? {
+        output::warn(warning);
+    }
+    Ok(manifest)
 }
 
 /// Process environment first, then the dotenv map. Invalid Unicode fails rather than skipping.
@@ -423,5 +434,24 @@ mod tests {
             "{rendered}"
         );
         assert!(rendered.contains("account_id"), "{rendered}");
+    }
+
+    #[test]
+    fn load_manifest_blocks_a_github_token_without_echoing_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Skyzen.toml"),
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n",
+        )
+        .expect("write manifest");
+
+        let error = load_manifest(&dir.path().join("Skyzen.toml")).expect_err("block");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("GitHub personal access token"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("ghp_"), "{rendered}");
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ mod output;
 mod project;
 mod providers;
 mod scaffold;
+mod secret_files;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -85,7 +85,7 @@ template_set!(
     [
         (MinimalCargoToml, "minimal/Cargo.toml.tmpl", "Cargo.toml"),
         (MinimalSkyzenToml, "minimal/Skyzen.toml.tmpl", "Skyzen.toml"),
-        (MinimalGitignore, "minimal/gitignore.tmpl", ".gitignore"),
+        (MinimalGitignore, "gitignore.tmpl", ".gitignore"),
         (MinimalApp, "minimal/src/app.rs.tmpl", "src/app.rs"),
         (MinimalLib, "minimal/src/lib.rs.tmpl", "src/lib.rs"),
         (MinimalMain, "minimal/src/main.rs.tmpl", "src/main.rs"),
@@ -97,7 +97,7 @@ template_set!(
     [
         (ApiCargoToml, "api/Cargo.toml.tmpl", "Cargo.toml"),
         (ApiSkyzenToml, "api/Skyzen.toml.tmpl", "Skyzen.toml"),
-        (ApiGitignore, "api/gitignore.tmpl", ".gitignore"),
+        (ApiGitignore, "gitignore.tmpl", ".gitignore"),
         (ApiApp, "api/src/app.rs.tmpl", "src/app.rs"),
         (ApiLib, "api/src/lib.rs.tmpl", "src/lib.rs"),
         (ApiMain, "api/src/main.rs.tmpl", "src/main.rs"),
@@ -122,11 +122,7 @@ template_set!(
             "serverless-events/Skyzen.toml.tmpl",
             "Skyzen.toml"
         ),
-        (
-            EventsGitignore,
-            "serverless-events/gitignore.tmpl",
-            ".gitignore"
-        ),
+        (EventsGitignore, "gitignore.tmpl", ".gitignore"),
         (EventsApp, "serverless-events/src/app.rs.tmpl", "src/app.rs"),
         (EventsLib, "serverless-events/src/lib.rs.tmpl", "src/lib.rs"),
         (
@@ -150,11 +146,7 @@ template_set!(
             "durable-realtime/Skyzen.toml.tmpl",
             "Skyzen.toml"
         ),
-        (
-            DurableGitignore,
-            "durable-realtime/gitignore.tmpl",
-            ".gitignore"
-        ),
+        (DurableGitignore, "gitignore.tmpl", ".gitignore"),
         (DurableApp, "durable-realtime/src/app.rs.tmpl", "src/app.rs"),
         (
             DurableObject,

--- a/cli/src/scaffold/tests.rs
+++ b/cli/src/scaffold/tests.rs
@@ -119,6 +119,14 @@ fn every_template_generates_the_files_a_project_needs() {
             )),
             "template `{label}` must pin wasm-bindgen to the embedded generator"
         );
+
+        let gitignore = fs::read_to_string(root.join(".gitignore")).expect(".gitignore");
+        for secret_file in [".env", ".env.local", ".dev.vars"] {
+            assert!(
+                gitignore.lines().any(|line| line == secret_file),
+                "template `{label}` .gitignore must ignore {secret_file}"
+            );
+        }
     }
 }
 

--- a/cli/src/secret_files.rs
+++ b/cli/src/secret_files.rs
@@ -1,0 +1,151 @@
+//! Keep local secret files out of git.
+//!
+//! `.env`, `.env.local` and wrangler's `.dev.vars` hold credentials. Scaffolded `.gitignore`
+//! lists them; this module fails the CLI load when git is already tracking one (a 100% leak)
+//! and warns when a path is not ignored (`git add .` would stage it).
+
+use anyhow::Result;
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+/// Files that must not be committed.
+pub const SECRET_FILES: &[&str] = &[".env", ".env.local", ".dev.vars"];
+
+/// Inspect `root` for secret files git would commit.
+///
+/// Returns heuristic warnings (path exists in the work tree and is not ignored). A tracked
+/// file is an error. Not a git repository, or `git` missing: skip.
+///
+/// # Errors
+///
+/// Fails when any of [`SECRET_FILES`] is tracked by git.
+pub fn ensure(root: &Path) -> Result<Vec<String>> {
+    if !is_git_work_tree(root) {
+        return Ok(Vec::new());
+    }
+
+    let mut warnings = Vec::new();
+    let mut tracked = Vec::new();
+    for file in SECRET_FILES {
+        if is_tracked(root, file) {
+            tracked.push(*file);
+            continue;
+        }
+        if !is_ignored(root, file) {
+            warnings.push(format!(
+                "`{file}` is not gitignored; `git add .` would stage it. Add the name to .gitignore."
+            ));
+        }
+    }
+
+    if !tracked.is_empty() {
+        let names = tracked
+            .iter()
+            .map(|name| format!("`{name}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "{names} tracked by git. Remove from the index (`git rm --cached -- {names}`) and \
+             keep the name in .gitignore so the secret never reaches the remote."
+        );
+    }
+
+    Ok(warnings)
+}
+
+fn is_git_work_tree(root: &Path) -> bool {
+    git(root, &["rev-parse", "--is-inside-work-tree"]).is_some_and(|output| {
+        output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+    })
+}
+
+fn is_tracked(root: &Path, file: &str) -> bool {
+    git(root, &["ls-files", "--error-unmatch", "--", file])
+        .is_some_and(|output| output.status.success())
+}
+
+fn is_ignored(root: &Path, file: &str) -> bool {
+    git(root, &["check-ignore", "-q", "--", file]).is_some_and(|output| output.status.success())
+}
+
+fn git(root: &Path, args: &[&str]) -> Option<std::process::Output> {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure;
+    use std::{fs, process::Command};
+
+    fn git_init(root: &std::path::Path) {
+        let status = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init");
+        // check-ignore and ls-files need identity only when committing; adding does not.
+    }
+
+    #[test]
+    fn a_non_git_directory_is_skipped() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
+        let warnings = ensure(dir.path()).expect("not a git repo");
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn a_gitignored_env_file_is_ok() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git_init(dir.path());
+        fs::write(
+            dir.path().join(".gitignore"),
+            ".env\n.env.local\n.dev.vars\n",
+        )
+        .expect("gitignore");
+        fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
+        let warnings = ensure(dir.path()).expect("ignored");
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn a_tracked_env_file_is_an_error() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git_init(dir.path());
+        fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
+        let add = Command::new("git")
+            .args(["add", "-f", "--", ".env"])
+            .current_dir(dir.path())
+            .status()
+            .expect("git add");
+        assert!(add.success(), "git add");
+
+        let error = ensure(dir.path()).expect_err("tracked");
+        let rendered = error.to_string();
+        assert!(rendered.contains(".env"), "{rendered}");
+        assert!(rendered.contains("tracked"), "{rendered}");
+        assert!(!rendered.contains("aaaa"), "{rendered}");
+    }
+
+    #[test]
+    fn an_unignored_env_path_is_a_warning() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git_init(dir.path());
+        let warnings = ensure(dir.path()).expect("unignored is not a block");
+        assert!(
+            warnings
+                .iter()
+                .any(|line| line.contains(".env") && line.contains("not gitignored")),
+            "{warnings:?}"
+        );
+    }
+}

--- a/cli/templates/durable-realtime/gitignore.tmpl
+++ b/cli/templates/durable-realtime/gitignore.tmpl
@@ -1,5 +1,0 @@
-/target
-/.skyzen
-/dist
-.env
-.env.local

--- a/cli/templates/gitignore.tmpl
+++ b/cli/templates/gitignore.tmpl
@@ -3,3 +3,4 @@
 /dist
 .env
 .env.local
+.dev.vars

--- a/cli/templates/minimal/gitignore.tmpl
+++ b/cli/templates/minimal/gitignore.tmpl
@@ -1,5 +1,0 @@
-/target
-/.skyzen
-/dist
-.env
-.env.local

--- a/cli/templates/serverless-events/gitignore.tmpl
+++ b/cli/templates/serverless-events/gitignore.tmpl
@@ -1,5 +1,0 @@
-/target
-/.skyzen
-/dist
-.env
-.env.local

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -207,31 +207,19 @@ skyzen logs --env staging
 
 See [Environments](skyzen-toml-reference.md#environments) for the merge rules.
 
-### GitHub Actions
+### CI
 
-`${NAME}` in `Skyzen.toml` is expanded from the job's environment when the CLI reads the file.
-Map repository secrets into `env:` on the deploy step — that is the process environment of
-`skyzen deploy`, not the Worker after it starts.
-
-```yaml
-- run: skyzen deploy --provider cloudflare
-  env:
-    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
-```
-
-```toml
-[cloudflare]
-account_id = "${CLOUDFLARE_ACCOUNT_ID}"
-
-[[cloudflare.kv_namespaces]]
-binding = "CACHE"
-id = "${CACHE_NAMESPACE_ID}"
-```
+`${NAME}` in `Skyzen.toml` is expanded from the process environment, then `.env` / `.env.local`,
+when the CLI reads the file. Drop a gitignored `.env` onto the runner (one file, not one `env:`
+line per key) or export the variables in the job. That is the environment of `skyzen deploy`, not
+the Worker after it starts.
 
 See [Deploy-time interpolation](skyzen-toml-reference.md#deploy-time-interpolation) for the syntax.
 `CLOUDFLARE_API_TOKEN` is wrangler's own credential and stays out of the file.
+
+The CLI refuses to load a checkout that has committed a known credential form in `Skyzen.toml`, or
+that is tracking `.env` / `.env.local` / `.dev.vars`. A secret-named key whose value is not a
+known token is a warning, not a hard failure.
 
 ### Logs and Secrets
 

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -744,8 +744,7 @@ The generated `wrangler.toml` contains a complete `[env.<name>]` section for eac
 
 String values may contain `${NAME}` placeholders. `skyzen deploy`, `skyzen dev`, `skyzen provision`
 and the rest of the CLI expand them from the **process environment of the machine running the
-command** — GitHub Actions secrets mapped into the job, or the project's `.env` / `.env.local`.
-Process environment wins over the dotenv files, same as native wiring.
+command**, then from `.env` / `.env.local`. Process environment wins, same as native wiring.
 
 This is not the runtime environment of the deployed Worker or Lambda. `url_env = "CACHE_URL"` names
 a variable the application reads after it starts. `${CACHE_NAMESPACE_ID}` is replaced **before**
@@ -765,18 +764,15 @@ id = "${CACHE_NAMESPACE_ID}"
 API_URL = "${API_URL}"
 ```
 
-```yaml
-# .github/workflows/deploy.yml
-- run: skyzen deploy --provider cloudflare
-  env:
-    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
-    API_URL: ${{ vars.API_URL }}
-```
+Put the values in `.env` (gitignored) or export them in the shell that runs the CLI. Skyzen does
+not require a per-key mapping in GitHub Actions: write `.env` onto the runner, or export the
+variables however the job already does. `CLOUDFLARE_API_TOKEN` is wrangler's own credential and
+stays out of the file.
 
-`CLOUDFLARE_API_TOKEN` is already read by wrangler from the process environment and does not belong
-in the file.
+A documented credential form (GitHub PAT, PEM private key, URL with a password, …) stored as a
+literal fails the CLI load. A `vars` / `[aws.env]` key whose *name* looks like a secret but whose
+value is not a known form is a warning. `${NAME}` is neither. `#[skyzen::main]` does not scan, so
+`cargo build` is not a secret gate.
 
 Rules:
 

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -31,9 +31,8 @@ let cloudflare = manifest.cloudflare(Some("staging"))?;
 ```
 
 String values may contain `${NAME}` placeholders. The CLI expands them from the process
-environment (GitHub Actions secrets, `.env`) through `Manifest::load_with`. `Manifest::load`
-leaves them as written, which is what `#[skyzen::main]` uses so a missing CI secret cannot fail
-`cargo build`.
+environment and `.env` through `Manifest::load_with`. `Manifest::load` leaves them as written,
+which is what `#[skyzen::main]` uses so a missing CI secret cannot fail `cargo build`.
 
 See the [`Skyzen.toml` reference](https://github.com/zen-rs/skyzen/blob/main/docs/skyzen-toml-reference.md)
 for the full key list.

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -15,9 +15,9 @@
 //! # Deploy-time interpolation
 //!
 //! String values may contain `${NAME}` placeholders. The CLI expands them from the process
-//! environment when it reads the file (GitHub Actions secrets mapped into the job env, or
-//! `.env`). [`Manifest::parse`] leaves them as written so `#[skyzen::main]` does not depend on
-//! secrets the compiler does not have. A missing name fails the CLI parse; there is no default.
+//! environment and the project's `.env` files when it reads the file. [`Manifest::parse`] leaves
+//! them as written so `#[skyzen::main]` does not depend on secrets the compiler does not have.
+//! A missing name fails the CLI parse; there is no default.
 //!
 //! ```
 //! # use skyzen_manifest::Manifest;
@@ -49,6 +49,7 @@ mod interpolate;
 mod merge;
 pub mod migrations;
 mod schema;
+mod secrets;
 
 pub use interpolate::{expand, expand_table, process_env, EnvLookup, InterpolateError};
 pub use merge::deep_merge;
@@ -65,6 +66,7 @@ pub use schema::{
     S3Wiring, ServiceBusWiring, ServiceEntry, ServiceType, SkyzenManifest, SqlUrlWiring, SqsWiring,
     StorageQueueWiring, WiringEnvVar, HTTP_FUNCTION_NAME,
 };
+pub use secrets::{scan_table, SecretError, SecretFinding, SecretReport};
 
 use std::{
     collections::BTreeMap,
@@ -138,6 +140,14 @@ pub enum ManifestError {
         /// What was wrong with the placeholder, including the TOML path.
         source: interpolate::InterpolateError,
     },
+    /// A string value is a documented credential form stored in the file.
+    #[error("{path}: {source}")]
+    CommittedSecret {
+        /// The manifest path.
+        path: PathBuf,
+        /// What was found, without the secret value.
+        source: secrets::SecretError,
+    },
     /// A named environment was requested that the manifest does not declare.
     #[error(
         "{path} declares no Cloudflare environment named `{name}`{}",
@@ -164,6 +174,9 @@ pub struct Manifest {
     root_dir: PathBuf,
     data: SkyzenManifest,
     environments: BTreeMap<String, CloudflareSection>,
+    /// Heuristic secret-shaped values. Empty unless this manifest was loaded with interpolation
+    /// (the CLI). Blocking forms have already failed the parse.
+    secret_warnings: Vec<SecretFinding>,
 }
 
 impl Manifest {
@@ -253,6 +266,22 @@ impl Manifest {
                 source: Box::new(source),
             })?;
 
+        // Scan the file as committed, before interpolation fills in CI secrets. Macros pass
+        // `lookup = None` and skip the scan so `cargo build` does not fail on a token the
+        // compiler never needed.
+        let secret_warnings = if lookup.is_some() {
+            let report = secrets::scan_table(&document);
+            if let Some(source) = secrets::blocking_error(&report) {
+                return Err(ManifestError::CommittedSecret {
+                    path: path.clone(),
+                    source,
+                });
+            }
+            report.warnings
+        } else {
+            Vec::new()
+        };
+
         if let Some(lookup) = lookup {
             interpolate::expand_table(&mut document, lookup).map_err(|source| {
                 ManifestError::Interpolation {
@@ -332,6 +361,7 @@ impl Manifest {
             root_dir: root_dir.into(),
             data,
             environments,
+            secret_warnings,
         })
     }
 
@@ -356,6 +386,16 @@ impl Manifest {
     /// The names of every declared `[cloudflare.env.<name>]` overlay, in sorted order.
     pub fn environment_names(&self) -> impl ExactSizeIterator<Item = &str> {
         self.environments.keys().map(String::as_str)
+    }
+
+    /// Heuristic secret-shaped values found while loading with interpolation.
+    ///
+    /// Blocking credential forms have already failed the parse. These leftovers — a
+    /// secret-named key whose value is not a known token, a JWT-shaped string — are
+    /// warnings for the CLI to print.
+    #[must_use]
+    pub fn secret_warnings(&self) -> &[SecretFinding] {
+        &self.secret_warnings
     }
 
     /// The Cloudflare configuration for `environment`, or the base configuration when `None`.
@@ -1186,6 +1226,36 @@ mod tests {
                 .expect("cloudflare")
                 .vars["BANNER"],
             "he said \"hi\""
+        );
+    }
+
+    #[test]
+    fn the_cli_parse_blocks_a_github_token_and_the_macro_parse_does_not() {
+        let source = "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n";
+        let error = parse_expanded(source, &[]).expect_err("CLI load blocks a known token");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("GitHub personal access token"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("ghp_"), "{rendered}");
+
+        parse(source).expect("compile-time parse does not scan");
+    }
+
+    #[test]
+    fn a_secret_named_literal_warns_on_cli_load_but_does_not_fail() {
+        let manifest = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nAPI_KEY = \"dev-only\"\n",
+            &[],
+        )
+        .expect("heuristic is a warning");
+        assert_eq!(manifest.secret_warnings().len(), 1);
+        assert_eq!(
+            manifest.secret_warnings()[0].kind,
+            "plaintext value of a secret-named key"
         );
     }
 

--- a/manifest/src/secrets.rs
+++ b/manifest/src/secrets.rs
@@ -1,0 +1,455 @@
+//! Detect secrets that have been written into `Skyzen.toml` as literal strings.
+//!
+//! Two classes, because a false block on a resource id is worse than a missed warning:
+//!
+//! * **Block** — the value is a documented credential form (a GitHub PAT prefix, a PEM
+//!   private key, a URL with a password). The CLI refuses to load the file.
+//! * **Heuristic** — a `vars` / `[aws.env]` key whose *name* looks like a secret, or a
+//!   JWT-shaped string. The CLI warns. `${NAME}` placeholders are neither.
+
+use std::fmt::{Display, Formatter};
+
+/// One string in the document that looks like a secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretFinding {
+    /// TOML path, e.g. `cloudflare.vars.API_KEY`.
+    pub location: String,
+    /// What kind of secret, for the error or warning. Never the value itself.
+    pub kind: &'static str,
+}
+
+impl Display for SecretFinding {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.location, self.kind)
+    }
+}
+
+/// 100% credential forms found in string values.
+///
+/// The value is never stored: printing this error cannot leak the secret a second time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretError {
+    /// Every blocking finding. Never empty.
+    pub findings: Vec<SecretFinding>,
+}
+
+impl std::error::Error for SecretError {}
+
+impl Display for SecretError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "committed secret in Skyzen.toml ({}); use a ${{NAME}} placeholder or `skyzen secret set`",
+            self.findings
+                .iter()
+                .map(SecretFinding::to_string)
+                .collect::<Vec<_>>()
+                .join("; ")
+        )
+    }
+}
+
+/// Block vs warn findings from one document.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SecretReport {
+    /// Documented credential forms. The CLI treats these as a load error.
+    pub blocks: Vec<SecretFinding>,
+    /// Name-based or JWT-shaped values. The CLI warns and continues.
+    pub warnings: Vec<SecretFinding>,
+}
+
+/// Walk every string **value** in `table`. Keys are not inspected for credential forms.
+#[must_use]
+pub fn scan_table(table: &toml::Table) -> SecretReport {
+    let mut report = SecretReport::default();
+    scan_table_at(table, "", &mut report);
+    report
+}
+
+fn scan_table_at(table: &toml::Table, parent: &str, report: &mut SecretReport) {
+    for (key, value) in table {
+        let location = child_path(parent, key);
+        match value {
+            toml::Value::String(text) => classify(&location, key, parent, text, report),
+            toml::Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    scan_value(&format!("{location}[{index}]"), key, parent, item, report);
+                }
+            }
+            toml::Value::Table(child) => scan_table_at(child, &location, report),
+            toml::Value::Integer(_)
+            | toml::Value::Float(_)
+            | toml::Value::Boolean(_)
+            | toml::Value::Datetime(_) => {}
+        }
+    }
+}
+
+fn scan_value(
+    location: &str,
+    key: &str,
+    parent: &str,
+    value: &toml::Value,
+    report: &mut SecretReport,
+) {
+    match value {
+        toml::Value::String(text) => classify(location, key, parent, text, report),
+        toml::Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                scan_value(&format!("{location}[{index}]"), key, parent, item, report);
+            }
+        }
+        toml::Value::Table(child) => scan_table_at(child, location, report),
+        toml::Value::Integer(_)
+        | toml::Value::Float(_)
+        | toml::Value::Boolean(_)
+        | toml::Value::Datetime(_) => {}
+    }
+}
+
+fn classify(location: &str, key: &str, parent: &str, text: &str, report: &mut SecretReport) {
+    if text.trim().is_empty() || is_placeholder(text) {
+        return;
+    }
+    if let Some(kind) = block_kind(text) {
+        report.blocks.push(SecretFinding {
+            location: location.to_owned(),
+            kind,
+        });
+        return;
+    }
+    if looks_like_jwt(text) {
+        report.warnings.push(SecretFinding {
+            location: location.to_owned(),
+            kind: "JWT-shaped string",
+        });
+        return;
+    }
+    if is_secret_key_table(parent) && is_secret_named_key(key) {
+        report.warnings.push(SecretFinding {
+            location: location.to_owned(),
+            kind: "plaintext value of a secret-named key",
+        });
+    }
+}
+
+/// Documented forms that cannot reasonably be a resource id or a URL.
+fn block_kind(text: &str) -> Option<&'static str> {
+    if text.contains("BEGIN ") && text.contains("PRIVATE KEY") {
+        return Some("PEM private key");
+    }
+    if url_has_password(text) {
+        return Some("URL with a password");
+    }
+    if is_aws_access_key_id(text) {
+        return Some("AWS access key id");
+    }
+    for rule in BLOCK_PREFIXES {
+        if token_starting(text, rule.prefix).is_some_and(|token| token.len() >= rule.min_len) {
+            return Some(rule.kind);
+        }
+    }
+    None
+}
+
+struct PrefixRule {
+    prefix: &'static str,
+    min_len: usize,
+    kind: &'static str,
+}
+
+/// Prefixes assigned by the issuer. Lengths are the documented minimums, so a truncated
+/// paste still has to look like that issuer's token, not like a Worker name.
+const BLOCK_PREFIXES: &[PrefixRule] = &[
+    PrefixRule {
+        prefix: "ghp_",
+        min_len: 40,
+        kind: "GitHub personal access token",
+    },
+    PrefixRule {
+        prefix: "gho_",
+        min_len: 40,
+        kind: "GitHub OAuth access token",
+    },
+    PrefixRule {
+        prefix: "ghu_",
+        min_len: 40,
+        kind: "GitHub user-to-server token",
+    },
+    PrefixRule {
+        prefix: "ghs_",
+        min_len: 40,
+        kind: "GitHub server-to-server token",
+    },
+    PrefixRule {
+        prefix: "ghr_",
+        min_len: 40,
+        kind: "GitHub refresh token",
+    },
+    PrefixRule {
+        prefix: "github_pat_",
+        min_len: 82,
+        kind: "GitHub fine-grained personal access token",
+    },
+    PrefixRule {
+        prefix: "glpat-",
+        min_len: 20,
+        kind: "GitLab personal access token",
+    },
+    PrefixRule {
+        prefix: "xoxb-",
+        min_len: 50,
+        kind: "Slack bot token",
+    },
+    PrefixRule {
+        prefix: "xoxp-",
+        min_len: 50,
+        kind: "Slack user token",
+    },
+    PrefixRule {
+        prefix: "sk_live_",
+        min_len: 32,
+        kind: "Stripe live secret key",
+    },
+    PrefixRule {
+        prefix: "sk_test_",
+        min_len: 32,
+        kind: "Stripe test secret key",
+    },
+    PrefixRule {
+        prefix: "rk_live_",
+        min_len: 32,
+        kind: "Stripe live restricted key",
+    },
+    PrefixRule {
+        prefix: "rk_test_",
+        min_len: 32,
+        kind: "Stripe test restricted key",
+    },
+    PrefixRule {
+        prefix: "sk-ant-",
+        min_len: 40,
+        kind: "Anthropic API key",
+    },
+    PrefixRule {
+        prefix: "sk-proj-",
+        min_len: 40,
+        kind: "OpenAI project API key",
+    },
+    PrefixRule {
+        prefix: "AIza",
+        min_len: 39,
+        kind: "Google API key",
+    },
+    PrefixRule {
+        prefix: "npm_",
+        min_len: 40,
+        kind: "npm access token",
+    },
+    PrefixRule {
+        prefix: "shpat_",
+        min_len: 32,
+        kind: "Shopify admin API token",
+    },
+];
+
+fn token_starting<'a>(text: &'a str, prefix: &'a str) -> Option<&'a str> {
+    let pos = text.find(prefix)?;
+    text[pos..].split_whitespace().next()
+}
+
+fn is_aws_access_key_id(text: &str) -> bool {
+    for prefix in ["AKIA", "ASIA"] {
+        if let Some(token) = token_starting(text, prefix) {
+            let rest = &token[prefix.len()..];
+            if rest.len() == 16
+                && rest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn url_has_password(text: &str) -> bool {
+    let Some((_scheme, rest)) = text.split_once("://") else {
+        return false;
+    };
+    let Some((userinfo, _host)) = rest.split_once('@') else {
+        return false;
+    };
+    match userinfo.split_once(':') {
+        Some((_, password)) => !password.is_empty(),
+        None => false,
+    }
+}
+
+fn looks_like_jwt(text: &str) -> bool {
+    let trimmed = text.trim();
+    let mut parts = trimmed.split('.');
+    let Some(header) = parts.next() else {
+        return false;
+    };
+    let Some(payload) = parts.next() else {
+        return false;
+    };
+    parts.next().is_some()
+        && parts.next().is_none()
+        && header.starts_with("eyJ")
+        && payload.starts_with("eyJ")
+}
+
+fn is_placeholder(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed
+        .strip_prefix("${")
+        .and_then(|inner| inner.strip_suffix('}'))
+        .is_some_and(is_ident)
+}
+
+fn is_ident(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+fn is_secret_key_table(parent: &str) -> bool {
+    parent == "aws.env" || parent == "vars" || parent.strip_suffix(".vars").is_some()
+}
+
+const SECRET_KEY_NEEDLES: &[&str] = &[
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "PRIVATE_KEY",
+    "API_KEY",
+    "ACCESS_KEY",
+    "AUTH_KEY",
+    "CREDENTIAL",
+    "CONNECTION_STRING",
+];
+
+fn is_secret_named_key(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    SECRET_KEY_NEEDLES
+        .iter()
+        .any(|needle| upper.contains(needle))
+}
+
+fn child_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_owned()
+    } else {
+        format!("{parent}.{key}")
+    }
+}
+
+/// Turn blocking findings into an error. `None` when there are none.
+#[must_use]
+pub fn blocking_error(report: &SecretReport) -> Option<SecretError> {
+    if report.blocks.is_empty() {
+        None
+    } else {
+        Some(SecretError {
+            findings: report.blocks.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scan_table;
+
+    fn scan(source: &str) -> super::SecretReport {
+        let table: toml::Table = toml::from_str(source).expect("toml");
+        scan_table(&table)
+    }
+
+    #[test]
+    fn a_github_pat_is_a_block() {
+        let report =
+            scan("[cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n");
+        assert_eq!(report.blocks.len(), 1, "{report:?}");
+        assert_eq!(report.blocks[0].kind, "GitHub personal access token");
+        assert!(report.blocks[0].location.contains("TOKEN"));
+    }
+
+    #[test]
+    fn a_placeholder_is_neither_a_block_nor_a_warning() {
+        let report = scan("[cloudflare.vars]\nAPI_KEY = \"${API_KEY}\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings, []);
+    }
+
+    #[test]
+    fn a_secret_named_literal_that_is_not_a_known_form_is_a_warning() {
+        let report = scan("[cloudflare.vars]\nAPI_KEY = \"dev-only\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings.len(), 1);
+        assert_eq!(
+            report.warnings[0].kind,
+            "plaintext value of a secret-named key"
+        );
+    }
+
+    #[test]
+    fn a_postgres_url_with_a_password_is_a_block() {
+        let report =
+            scan("[cloudflare.vars]\nDATABASE = \"postgres://flyco:s3cret@127.0.0.1/app\"\n");
+        assert_eq!(report.blocks[0].kind, "URL with a password");
+    }
+
+    #[test]
+    fn a_url_without_a_password_is_clean() {
+        let report = scan("[cloudflare.vars]\nAPI_URL = \"https://api.flyco.io\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings, []);
+    }
+
+    #[test]
+    fn an_rds_secret_arn_is_not_a_secret() {
+        let report = scan(
+            "[native.database.main]\nbackend = \"rds-data\"\n\
+             secret_arn = \"arn:aws:secretsmanager:us-east-1:111122223333:secret:skyzen-Ab12Cd\"\n",
+        );
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings, []);
+    }
+
+    #[test]
+    fn a_pem_private_key_is_a_block() {
+        let report = scan(
+            "[cloudflare.vars]\nKEY = \"-----BEGIN PRIVATE KEY-----\\nMIIB\\n-----END PRIVATE KEY-----\"\n",
+        );
+        assert_eq!(report.blocks[0].kind, "PEM private key");
+    }
+
+    #[test]
+    fn an_aws_access_key_id_is_a_block() {
+        let report = scan("[aws.env]\nUSER = \"AKIAAAAAAAAAAAAAAAAA\"\n");
+        assert_eq!(report.blocks[0].kind, "AWS access key id");
+    }
+
+    #[test]
+    fn a_jwt_shaped_string_is_a_warning() {
+        let report =
+            scan("[cloudflare.vars]\nCLAIM = \"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.aaaa\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings[0].kind, "JWT-shaped string");
+    }
+
+    #[test]
+    fn findings_never_include_the_secret_value() {
+        let report =
+            scan("[cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n");
+        let rendered = report.blocks[0].to_string();
+        assert!(!rendered.contains("ghp_"), "{rendered}");
+    }
+}


### PR DESCRIPTION
Fixes #29

CLI load (`skyzen doctor` / `dev` / `deploy` / `provision`) now refuses a checkout that has already leaked a credential, and warns on the rest.

## Block (100%)

- Documented token forms in Skyzen.toml string values: GitHub PAT/OAuth prefixes, Stripe `sk_live_`/`sk_test_`, AWS `AKIA`/`ASIA` access key ids, PEM private keys, URLs with a password, and the other issuer prefixes in `manifest/src/secrets.rs`.
- `.env`, `.env.local`, or `.dev.vars` **tracked by git**.

The error names the TOML path (or file) and the kind. It never prints the value.

`${NAME}` placeholders are not secrets. `secret_arn` (an ARN) is not. `#[skyzen::main]` does not scan, so `cargo build` is not a secret gate.

## Warn (heuristic)

- A `vars` / `[aws.env]` key whose *name* looks like a secret (`API_KEY`, `TOKEN`, …) but whose value is not a known form (`API_KEY = "dev-only"`).
- JWT-shaped strings.
- Those dotenv paths exist in a git repo and are **not gitignored** (`git add .` would stage them).

## CI mapping

Interpolation still reads the process environment and `.env`. Docs no longer show a per-key GitHub Actions `env:` block. Write a gitignored `.env` onto the runner, or export variables however the job already does.
