### PR TITLE
release: deploy-time interpolation and committed-secret guards

### DIFF
--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -10,10 +10,14 @@
 //! A backend whose constructor fixes its own variable names (Cosmos DB, the RDS Data API) is
 //! covered too: the section reports those names, so they reach this check and `.env.example` the
 //! same way a key-named one does.
+//!
+//! The same files, plus the process environment, fill `${NAME}` placeholders in `Skyzen.toml`
+//! itself when the CLI reads it. That is deploy-time interpolation (GitHub Actions secrets), not
+//! the runtime environment of the deployed process. `#[skyzen::main]` does not expand them.
 
 use anyhow::{Context, Result};
 use askama::Template;
-use skyzen_manifest::{SkyzenManifest, WiringEnvVar};
+use skyzen_manifest::{InterpolateError, Manifest, SkyzenManifest, WiringEnvVar};
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
@@ -79,6 +83,38 @@ fn collect(
             |key| format!("{section}.{key}"),
         ),
     }));
+}
+
+/// Read `Skyzen.toml`, expanding `${NAME}` from the process environment and then `.env` files.
+///
+/// Process environment wins, matching [`ensure_available`]: a one-off
+/// `CACHE_ID=... skyzen deploy` still overrides `.env`. The CLI's own environment is never
+/// mutated.
+///
+/// # Errors
+///
+/// Fails when the file cannot be read, a placeholder cannot be expanded, a dotenv file is
+/// malformed, or the document does not match the schema.
+pub fn load_manifest(path: &Path) -> Result<Manifest> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to read the current directory")?
+            .join(path)
+    };
+    let root_dir = absolute.parent().unwrap_or_else(|| Path::new("."));
+    let dotenv = load_dotenv_files(root_dir)?;
+    let lookup = |name: &str| lookup_var(name, &dotenv);
+    Ok(Manifest::load_with(&absolute, Some(&lookup))?)
+}
+
+/// Process environment first, then the dotenv map. Invalid Unicode fails rather than skipping.
+fn lookup_var(
+    name: &str,
+    dotenv: &BTreeMap<String, String>,
+) -> Result<Option<String>, InterpolateError> {
+    Ok(skyzen_manifest::process_env(name)?.or_else(|| dotenv.get(name).cloned()))
 }
 
 /// The variables loaded from the project's `.env` files.
@@ -168,7 +204,9 @@ pub fn dotenv_paths(root_dir: &Path) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_available, load_dotenv_files, render_example, required_variables};
+    use super::{
+        ensure_available, load_dotenv_files, load_manifest, render_example, required_variables,
+    };
     use skyzen_manifest::Manifest;
     use std::collections::BTreeMap;
 
@@ -338,5 +376,52 @@ mod tests {
     fn the_example_explains_itself_when_nothing_is_declared() {
         let rendered = render_example(&manifest("")).expect("render");
         assert!(rendered.contains("declares no native environment variables"));
+    }
+
+    #[test]
+    fn load_manifest_interpolates_from_dotenv() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Skyzen.toml"),
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\
+             account_id = \"${SKYZEN_TEST_ACCOUNT_ID}\"\n",
+        )
+        .expect("write manifest");
+        std::fs::write(
+            dir.path().join(".env"),
+            "SKYZEN_TEST_ACCOUNT_ID=acct_from_dotenv\n",
+        )
+        .expect("write dotenv");
+
+        let loaded = load_manifest(&dir.path().join("Skyzen.toml")).expect("load");
+        assert_eq!(
+            loaded
+                .data()
+                .cloudflare
+                .as_ref()
+                .expect("cloudflare")
+                .account_id
+                .as_deref(),
+            Some("acct_from_dotenv")
+        );
+    }
+
+    #[test]
+    fn load_manifest_fails_when_a_placeholder_is_unset() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Skyzen.toml"),
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\
+             account_id = \"${SKYZEN_TEST_UNSET_INTERPOLATION}\"\n",
+        )
+        .expect("write manifest");
+
+        let error = load_manifest(&dir.path().join("Skyzen.toml")).expect_err("unset");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("SKYZEN_TEST_UNSET_INTERPOLATION"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("account_id"), "{rendered}");
     }
 }

--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -12,9 +12,10 @@
 //! same way a key-named one does.
 //!
 //! The same files, plus the process environment, fill `${NAME}` placeholders in `Skyzen.toml`
-//! itself when the CLI reads it. That is deploy-time interpolation (GitHub Actions secrets), not
-//! the runtime environment of the deployed process. `#[skyzen::main]` does not expand them.
+//! itself when the CLI reads it. That is deploy-time interpolation, not the runtime environment
+//! of the deployed process. `#[skyzen::main]` does not expand them.
 
+use crate::{output, secret_files};
 use anyhow::{Context, Result};
 use askama::Template;
 use skyzen_manifest::{InterpolateError, Manifest, SkyzenManifest, WiringEnvVar};
@@ -93,7 +94,8 @@ fn collect(
 ///
 /// # Errors
 ///
-/// Fails when the file cannot be read, a placeholder cannot be expanded, a dotenv file is
+/// Fails when the file cannot be read, a placeholder cannot be expanded, a documented
+/// credential form is stored as a literal, a dotenv file is tracked by git, a dotenv file is
 /// malformed, or the document does not match the schema.
 pub fn load_manifest(path: &Path) -> Result<Manifest> {
     let absolute = if path.is_absolute() {
@@ -106,7 +108,16 @@ pub fn load_manifest(path: &Path) -> Result<Manifest> {
     let root_dir = absolute.parent().unwrap_or_else(|| Path::new("."));
     let dotenv = load_dotenv_files(root_dir)?;
     let lookup = |name: &str| lookup_var(name, &dotenv);
-    Ok(Manifest::load_with(&absolute, Some(&lookup))?)
+    let manifest = Manifest::load_with(&absolute, Some(&lookup))?;
+    for finding in manifest.secret_warnings() {
+        output::warn(format!(
+            "{finding}; if this is a secret, use a ${{NAME}} placeholder or `skyzen secret set`"
+        ));
+    }
+    for warning in secret_files::ensure(root_dir)? {
+        output::warn(warning);
+    }
+    Ok(manifest)
 }
 
 /// Process environment first, then the dotenv map. Invalid Unicode fails rather than skipping.
@@ -423,5 +434,24 @@ mod tests {
             "{rendered}"
         );
         assert!(rendered.contains("account_id"), "{rendered}");
+    }
+
+    #[test]
+    fn load_manifest_blocks_a_github_token_without_echoing_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("Skyzen.toml"),
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n",
+        )
+        .expect("write manifest");
+
+        let error = load_manifest(&dir.path().join("Skyzen.toml")).expect_err("block");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("GitHub personal access token"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("ghp_"), "{rendered}");
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ mod output;
 mod project;
 mod providers;
 mod scaffold;
+mod secret_files;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};

--- a/cli/src/migrate.rs
+++ b/cli/src/migrate.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     cli::{MigrateCommand, Provider},
-    environment::{ensure_available, load_dotenv_files, required_variables},
+    environment::{ensure_available, load_dotenv_files, load_manifest, required_variables},
     output,
 };
 use anyhow::{Context, Result};
@@ -108,7 +108,7 @@ pub fn run(
     command: Option<MigrateCommand>,
     dry_run: bool,
 ) -> Result<()> {
-    let manifest = Manifest::load(manifest_path)?;
+    let manifest = load_manifest(manifest_path)?;
     let targets = resolve_targets(&manifest)?;
 
     // A dry run neither connects nor creates anything: it reads and validates the directories and

--- a/cli/src/providers/azure.rs
+++ b/cli/src/providers/azure.rs
@@ -11,7 +11,7 @@
 mod bundle;
 
 use crate::{
-    output,
+    environment, output,
     project::Project,
     providers::{
         prepare_child_environment, Action, ArtifactBuild, CommandPlan, ProviderPlan, RunMode,
@@ -303,7 +303,7 @@ fn ensure_runs_on_linux(artifact: &Path, target: Option<&str>, require: bool) ->
 /// Only meaningful when the manifest names one: without `target`, the build is whatever the host
 /// is, which is right on a Linux CI machine and caught before the upload anywhere else.
 pub fn check_linux_target(manifest_path: &Path) -> usize {
-    let target = Manifest::load(manifest_path)
+    let target = environment::load_manifest(manifest_path)
         .ok()
         .and_then(|manifest| manifest.data().azure.as_ref()?.target.clone());
     let Some(target) = target else {

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -207,7 +207,7 @@ pub fn prepare(
 /// section", which says what to do, rather than with a file-not-found.
 fn load_or_empty(manifest_path: &Path) -> Result<Manifest> {
     if manifest_path.exists() {
-        return Ok(Manifest::load(manifest_path)?);
+        return environment::load_manifest(manifest_path);
     }
 
     let absolute = if manifest_path.is_absolute() {
@@ -253,7 +253,7 @@ pub fn provision(
              --provider azure`"
         ),
         Provider::Cloudflare => {
-            let manifest = Manifest::load(manifest_path)?;
+            let manifest = environment::load_manifest(manifest_path)?;
             let config = manifest
                 .cloudflare(environment)?
                 .ok_or_else(|| anyhow::anyhow!("missing [cloudflare] section in Skyzen.toml"))?;
@@ -482,7 +482,7 @@ fn check_manifest(
         return 0;
     }
 
-    let manifest = match Manifest::load(manifest_path) {
+    let manifest = match environment::load_manifest(manifest_path) {
         Ok(manifest) => {
             output::ok(format!("{} parses", manifest_path.display()));
             manifest

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -85,7 +85,7 @@ template_set!(
     [
         (MinimalCargoToml, "minimal/Cargo.toml.tmpl", "Cargo.toml"),
         (MinimalSkyzenToml, "minimal/Skyzen.toml.tmpl", "Skyzen.toml"),
-        (MinimalGitignore, "minimal/gitignore.tmpl", ".gitignore"),
+        (MinimalGitignore, "gitignore.tmpl", ".gitignore"),
         (MinimalApp, "minimal/src/app.rs.tmpl", "src/app.rs"),
         (MinimalLib, "minimal/src/lib.rs.tmpl", "src/lib.rs"),
         (MinimalMain, "minimal/src/main.rs.tmpl", "src/main.rs"),
@@ -97,7 +97,7 @@ template_set!(
     [
         (ApiCargoToml, "api/Cargo.toml.tmpl", "Cargo.toml"),
         (ApiSkyzenToml, "api/Skyzen.toml.tmpl", "Skyzen.toml"),
-        (ApiGitignore, "api/gitignore.tmpl", ".gitignore"),
+        (ApiGitignore, "gitignore.tmpl", ".gitignore"),
         (ApiApp, "api/src/app.rs.tmpl", "src/app.rs"),
         (ApiLib, "api/src/lib.rs.tmpl", "src/lib.rs"),
         (ApiMain, "api/src/main.rs.tmpl", "src/main.rs"),
@@ -122,11 +122,7 @@ template_set!(
             "serverless-events/Skyzen.toml.tmpl",
             "Skyzen.toml"
         ),
-        (
-            EventsGitignore,
-            "serverless-events/gitignore.tmpl",
-            ".gitignore"
-        ),
+        (EventsGitignore, "gitignore.tmpl", ".gitignore"),
         (EventsApp, "serverless-events/src/app.rs.tmpl", "src/app.rs"),
         (EventsLib, "serverless-events/src/lib.rs.tmpl", "src/lib.rs"),
         (
@@ -150,11 +146,7 @@ template_set!(
             "durable-realtime/Skyzen.toml.tmpl",
             "Skyzen.toml"
         ),
-        (
-            DurableGitignore,
-            "durable-realtime/gitignore.tmpl",
-            ".gitignore"
-        ),
+        (DurableGitignore, "gitignore.tmpl", ".gitignore"),
         (DurableApp, "durable-realtime/src/app.rs.tmpl", "src/app.rs"),
         (
             DurableObject,

--- a/cli/src/scaffold/tests.rs
+++ b/cli/src/scaffold/tests.rs
@@ -119,6 +119,14 @@ fn every_template_generates_the_files_a_project_needs() {
             )),
             "template `{label}` must pin wasm-bindgen to the embedded generator"
         );
+
+        let gitignore = fs::read_to_string(root.join(".gitignore")).expect(".gitignore");
+        for secret_file in [".env", ".env.local", ".dev.vars"] {
+            assert!(
+                gitignore.lines().any(|line| line == secret_file),
+                "template `{label}` .gitignore must ignore {secret_file}"
+            );
+        }
     }
 }
 

--- a/cli/src/secret_files.rs
+++ b/cli/src/secret_files.rs
@@ -1,0 +1,151 @@
+//! Keep local secret files out of git.
+//!
+//! `.env`, `.env.local` and wrangler's `.dev.vars` hold credentials. Scaffolded `.gitignore`
+//! lists them; this module fails the CLI load when git is already tracking one (a 100% leak)
+//! and warns when a path is not ignored (`git add .` would stage it).
+
+use anyhow::Result;
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+/// Files that must not be committed.
+pub const SECRET_FILES: &[&str] = &[".env", ".env.local", ".dev.vars"];
+
+/// Inspect `root` for secret files git would commit.
+///
+/// Returns heuristic warnings (path exists in the work tree and is not ignored). A tracked
+/// file is an error. Not a git repository, or `git` missing: skip.
+///
+/// # Errors
+///
+/// Fails when any of [`SECRET_FILES`] is tracked by git.
+pub fn ensure(root: &Path) -> Result<Vec<String>> {
+    if !is_git_work_tree(root) {
+        return Ok(Vec::new());
+    }
+
+    let mut warnings = Vec::new();
+    let mut tracked = Vec::new();
+    for file in SECRET_FILES {
+        if is_tracked(root, file) {
+            tracked.push(*file);
+            continue;
+        }
+        if !is_ignored(root, file) {
+            warnings.push(format!(
+                "`{file}` is not gitignored; `git add .` would stage it. Add the name to .gitignore."
+            ));
+        }
+    }
+
+    if !tracked.is_empty() {
+        let names = tracked
+            .iter()
+            .map(|name| format!("`{name}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "{names} tracked by git. Remove from the index (`git rm --cached -- {names}`) and \
+             keep the name in .gitignore so the secret never reaches the remote."
+        );
+    }
+
+    Ok(warnings)
+}
+
+fn is_git_work_tree(root: &Path) -> bool {
+    git(root, &["rev-parse", "--is-inside-work-tree"]).is_some_and(|output| {
+        output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+    })
+}
+
+fn is_tracked(root: &Path, file: &str) -> bool {
+    git(root, &["ls-files", "--error-unmatch", "--", file])
+        .is_some_and(|output| output.status.success())
+}
+
+fn is_ignored(root: &Path, file: &str) -> bool {
+    git(root, &["check-ignore", "-q", "--", file]).is_some_and(|output| output.status.success())
+}
+
+fn git(root: &Path, args: &[&str]) -> Option<std::process::Output> {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure;
+    use std::{fs, process::Command};
+
+    fn git_init(root: &std::path::Path) {
+        let status = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init");
+        // check-ignore and ls-files need identity only when committing; adding does not.
+    }
+
+    #[test]
+    fn a_non_git_directory_is_skipped() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
+        let warnings = ensure(dir.path()).expect("not a git repo");
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn a_gitignored_env_file_is_ok() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git_init(dir.path());
+        fs::write(
+            dir.path().join(".gitignore"),
+            ".env\n.env.local\n.dev.vars\n",
+        )
+        .expect("gitignore");
+        fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
+        let warnings = ensure(dir.path()).expect("ignored");
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn a_tracked_env_file_is_an_error() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git_init(dir.path());
+        fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
+        let add = Command::new("git")
+            .args(["add", "-f", "--", ".env"])
+            .current_dir(dir.path())
+            .status()
+            .expect("git add");
+        assert!(add.success(), "git add");
+
+        let error = ensure(dir.path()).expect_err("tracked");
+        let rendered = error.to_string();
+        assert!(rendered.contains(".env"), "{rendered}");
+        assert!(rendered.contains("tracked"), "{rendered}");
+        assert!(!rendered.contains("aaaa"), "{rendered}");
+    }
+
+    #[test]
+    fn an_unignored_env_path_is_a_warning() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        git_init(dir.path());
+        let warnings = ensure(dir.path()).expect("unignored is not a block");
+        assert!(
+            warnings
+                .iter()
+                .any(|line| line.contains(".env") && line.contains("not gitignored")),
+            "{warnings:?}"
+        );
+    }
+}

--- a/cli/templates/durable-realtime/gitignore.tmpl
+++ b/cli/templates/durable-realtime/gitignore.tmpl
@@ -1,5 +1,0 @@
-/target
-/.skyzen
-/dist
-.env
-.env.local

--- a/cli/templates/gitignore.tmpl
+++ b/cli/templates/gitignore.tmpl
@@ -3,3 +3,4 @@
 /dist
 .env
 .env.local
+.dev.vars

--- a/cli/templates/minimal/gitignore.tmpl
+++ b/cli/templates/minimal/gitignore.tmpl
@@ -1,5 +1,0 @@
-/target
-/.skyzen
-/dist
-.env
-.env.local

--- a/cli/templates/serverless-events/gitignore.tmpl
+++ b/cli/templates/serverless-events/gitignore.tmpl
@@ -1,5 +1,0 @@
-/target
-/.skyzen
-/dist
-.env
-.env.local

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -207,31 +207,19 @@ skyzen logs --env staging
 
 See [Environments](skyzen-toml-reference.md#environments) for the merge rules.
 
-### GitHub Actions
+### CI
 
-`${NAME}` in `Skyzen.toml` is expanded from the job's environment when the CLI reads the file.
-Map repository secrets into `env:` on the deploy step — that is the process environment of
-`skyzen deploy`, not the Worker after it starts.
-
-```yaml
-- run: skyzen deploy --provider cloudflare
-  env:
-    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
-```
-
-```toml
-[cloudflare]
-account_id = "${CLOUDFLARE_ACCOUNT_ID}"
-
-[[cloudflare.kv_namespaces]]
-binding = "CACHE"
-id = "${CACHE_NAMESPACE_ID}"
-```
+`${NAME}` in `Skyzen.toml` is expanded from the process environment, then `.env` / `.env.local`,
+when the CLI reads the file. Drop a gitignored `.env` onto the runner (one file, not one `env:`
+line per key) or export the variables in the job. That is the environment of `skyzen deploy`, not
+the Worker after it starts.
 
 See [Deploy-time interpolation](skyzen-toml-reference.md#deploy-time-interpolation) for the syntax.
 `CLOUDFLARE_API_TOKEN` is wrangler's own credential and stays out of the file.
+
+The CLI refuses to load a checkout that has committed a known credential form in `Skyzen.toml`, or
+that is tracking `.env` / `.env.local` / `.dev.vars`. A secret-named key whose value is not a
+known token is a warning, not a hard failure.
 
 ### Logs and Secrets
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -207,6 +207,32 @@ skyzen logs --env staging
 
 See [Environments](skyzen-toml-reference.md#environments) for the merge rules.
 
+### GitHub Actions
+
+`${NAME}` in `Skyzen.toml` is expanded from the job's environment when the CLI reads the file.
+Map repository secrets into `env:` on the deploy step — that is the process environment of
+`skyzen deploy`, not the Worker after it starts.
+
+```yaml
+- run: skyzen deploy --provider cloudflare
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
+```
+
+```toml
+[cloudflare]
+account_id = "${CLOUDFLARE_ACCOUNT_ID}"
+
+[[cloudflare.kv_namespaces]]
+binding = "CACHE"
+id = "${CACHE_NAMESPACE_ID}"
+```
+
+See [Deploy-time interpolation](skyzen-toml-reference.md#deploy-time-interpolation) for the syntax.
+`CLOUDFLARE_API_TOKEN` is wrangler's own credential and stays out of the file.
+
 ### Logs and Secrets
 
 ```sh

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -744,8 +744,7 @@ The generated `wrangler.toml` contains a complete `[env.<name>]` section for eac
 
 String values may contain `${NAME}` placeholders. `skyzen deploy`, `skyzen dev`, `skyzen provision`
 and the rest of the CLI expand them from the **process environment of the machine running the
-command** — GitHub Actions secrets mapped into the job, or the project's `.env` / `.env.local`.
-Process environment wins over the dotenv files, same as native wiring.
+command**, then from `.env` / `.env.local`. Process environment wins, same as native wiring.
 
 This is not the runtime environment of the deployed Worker or Lambda. `url_env = "CACHE_URL"` names
 a variable the application reads after it starts. `${CACHE_NAMESPACE_ID}` is replaced **before**
@@ -765,18 +764,15 @@ id = "${CACHE_NAMESPACE_ID}"
 API_URL = "${API_URL}"
 ```
 
-```yaml
-# .github/workflows/deploy.yml
-- run: skyzen deploy --provider cloudflare
-  env:
-    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
-    API_URL: ${{ vars.API_URL }}
-```
+Put the values in `.env` (gitignored) or export them in the shell that runs the CLI. Skyzen does
+not require a per-key mapping in GitHub Actions: write `.env` onto the runner, or export the
+variables however the job already does. `CLOUDFLARE_API_TOKEN` is wrangler's own credential and
+stays out of the file.
 
-`CLOUDFLARE_API_TOKEN` is already read by wrangler from the process environment and does not belong
-in the file.
+A documented credential form (GitHub PAT, PEM private key, URL with a password, …) stored as a
+literal fails the CLI load. A `vars` / `[aws.env]` key whose *name* looks like a secret but whose
+value is not a known form is a warning. `${NAME}` is neither. `#[skyzen::main]` does not scan, so
+`cargo build` is not a secret gate.
 
 Rules:
 

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -740,6 +740,57 @@ The generated `wrangler.toml` contains a complete `[env.<name>]` section for eac
 
 `[cloudflare.env.<name>.env]` is rejected: overlays do not nest.
 
+## Deploy-time interpolation
+
+String values may contain `${NAME}` placeholders. `skyzen deploy`, `skyzen dev`, `skyzen provision`
+and the rest of the CLI expand them from the **process environment of the machine running the
+command** — GitHub Actions secrets mapped into the job, or the project's `.env` / `.env.local`.
+Process environment wins over the dotenv files, same as native wiring.
+
+This is not the runtime environment of the deployed Worker or Lambda. `url_env = "CACHE_URL"` names
+a variable the application reads after it starts. `${CACHE_NAMESPACE_ID}` is replaced **before**
+the CLI generates `wrangler.toml` or invokes `cargo lambda`.
+
+```toml
+[cloudflare]
+name = "api"
+compatibility_date = "2025-02-01"
+account_id = "${CLOUDFLARE_ACCOUNT_ID}"
+
+[[cloudflare.kv_namespaces]]
+binding = "CACHE"
+id = "${CACHE_NAMESPACE_ID}"
+
+[cloudflare.vars]
+API_URL = "${API_URL}"
+```
+
+```yaml
+# .github/workflows/deploy.yml
+- run: skyzen deploy --provider cloudflare
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    CACHE_NAMESPACE_ID: ${{ secrets.CACHE_NAMESPACE_ID }}
+    API_URL: ${{ vars.API_URL }}
+```
+
+`CLOUDFLARE_API_TOKEN` is already read by wrangler from the process environment and does not belong
+in the file.
+
+Rules:
+
+- `${NAME}` in string **values** only. Keys are not expanded.
+- `NAME` is `[A-Za-z_][A-Za-z0-9_]*`. Hyphens, defaults (`${NAME:-x}`), and unclosed `${` fail the parse.
+- A missing name fails the parse, naming the TOML path and the variable.
+- `$$` writes a literal `$`. `$${NAME}` is the text `${NAME}`, not a lookup.
+- Expansion runs on the parsed document, so a secret containing quotes or newlines cannot break TOML.
+- Integers and booleans are not strings: `memory_mb = "${MEM}"` is a type error, not an interpolation.
+- `#[skyzen::main]` does **not** expand placeholders. A missing GitHub secret must not fail `cargo build`. Do not wrap `url_env` / `binding` / service names in `${}` — those fields are consumed at compile time as literal names.
+
+Interpolating a secret into `[cloudflare.vars]` or `[aws.env]` still stores it as a plaintext
+platform variable. Worker secrets stay on `skyzen secret set`.
+
 ## Escape Hatch
 
 `[cloudflare.raw]` is merged verbatim into the generated `wrangler.toml`, using the same rules as an

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -31,9 +31,8 @@ let cloudflare = manifest.cloudflare(Some("staging"))?;
 ```
 
 String values may contain `${NAME}` placeholders. The CLI expands them from the process
-environment (GitHub Actions secrets, `.env`) through `Manifest::load_with`. `Manifest::load`
-leaves them as written, which is what `#[skyzen::main]` uses so a missing CI secret cannot fail
-`cargo build`.
+environment and `.env` through `Manifest::load_with`. `Manifest::load` leaves them as written,
+which is what `#[skyzen::main]` uses so a missing CI secret cannot fail `cargo build`.
 
 See the [`Skyzen.toml` reference](https://github.com/zen-rs/skyzen/blob/main/docs/skyzen-toml-reference.md)
 for the full key list.

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -30,6 +30,11 @@ let cloudflare = manifest.cloudflare(Some("staging"))?;
 # Ok::<_, Box<dyn std::error::Error>>(())
 ```
 
+String values may contain `${NAME}` placeholders. The CLI expands them from the process
+environment (GitHub Actions secrets, `.env`) through `Manifest::load_with`. `Manifest::load`
+leaves them as written, which is what `#[skyzen::main]` uses so a missing CI secret cannot fail
+`cargo build`.
+
 See the [`Skyzen.toml` reference](https://github.com/zen-rs/skyzen/blob/main/docs/skyzen-toml-reference.md)
 for the full key list.
 

--- a/manifest/src/interpolate.rs
+++ b/manifest/src/interpolate.rs
@@ -1,0 +1,334 @@
+//! Deploy-time `${NAME}` expansion in `Skyzen.toml` string values.
+//!
+//! The CLI expands placeholders from the process environment (and the project's `.env` files)
+//! when it reads the manifest. `#[skyzen::main]` does **not**: compile-time env is not the
+//! deploy runner, and a GitHub secret the compiler does not have must not fail `cargo build`.
+//!
+//! Expansion runs on the parsed TOML document, before the typed schema, so a value containing
+//! quotes or newlines cannot break the file. Keys are never expanded. A missing, unclosed, or
+//! invalid name fails the parse; there is no `${NAME:-default}`. `$$` writes a literal `$`.
+
+use std::borrow::Cow;
+use toml::Value;
+
+/// Looks up `${NAME}` during expansion. `Ok(None)` means the name is unset.
+pub type EnvLookup<'a> = &'a dyn Fn(&str) -> Result<Option<String>, InterpolateError>;
+
+/// What went wrong expanding a `${NAME}` placeholder.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum InterpolateError {
+    /// A `${` with no matching `}`.
+    #[error("{location}: unclosed `${{`")]
+    Unclosed {
+        /// TOML path of the string, e.g. `cloudflare.kv_namespaces[0].id`.
+        location: String,
+    },
+    /// `${}` with nothing between the braces.
+    #[error("{location}: empty interpolation name")]
+    EmptyName {
+        /// TOML path of the string.
+        location: String,
+    },
+    /// The name is not `[A-Za-z_][A-Za-z0-9_]*`.
+    #[error("{location}: invalid interpolation name `{name}`")]
+    InvalidName {
+        /// TOML path of the string.
+        location: String,
+        /// The rejected name.
+        name: String,
+    },
+    /// `lookup` returned `Ok(None)` for this name.
+    #[error("{location}: environment variable `{name}` is not set")]
+    Missing {
+        /// TOML path of the string.
+        location: String,
+        /// The variable that was asked for.
+        name: String,
+    },
+    /// The process environment holds `name` but the value is not Unicode.
+    #[error("{location}: environment variable `{name}` is not valid Unicode")]
+    NotUnicode {
+        /// TOML path of the string, empty when the error is produced before a path is known.
+        location: String,
+        /// The variable that was asked for.
+        name: String,
+    },
+}
+
+impl InterpolateError {
+    /// Fill in the TOML path when the error was produced without one (process-env Unicode).
+    #[must_use]
+    pub fn at(self, location: &str) -> Self {
+        match self {
+            Self::NotUnicode {
+                name,
+                location: loc,
+            } if loc.is_empty() => Self::NotUnicode {
+                location: location.to_owned(),
+                name,
+            },
+            other => other,
+        }
+    }
+}
+
+/// Read `name` from the process environment.
+///
+/// # Errors
+///
+/// Returns [`InterpolateError::NotUnicode`] when the variable is set but is not valid Unicode.
+pub fn process_env(name: &str) -> Result<Option<String>, InterpolateError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(InterpolateError::NotUnicode {
+            location: String::new(),
+            name: name.to_owned(),
+        }),
+    }
+}
+
+/// Expand `${NAME}` placeholders in `input`.
+///
+/// `lookup` returns the value for `NAME`, `Ok(None)` when it is unset (which becomes
+/// [`InterpolateError::Missing`]), or [`InterpolateError::NotUnicode`].
+///
+/// # Errors
+///
+/// Returns [`InterpolateError`] when a placeholder is unclosed, empty, not an identifier, unset,
+/// or not Unicode.
+pub fn expand<'a>(
+    input: &'a str,
+    location: &str,
+    lookup: EnvLookup<'_>,
+) -> Result<Cow<'a, str>, InterpolateError> {
+    if !input.contains('$') {
+        return Ok(Cow::Borrowed(input));
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(dollar) = rest.find('$') {
+        out.push_str(&rest[..dollar]);
+        let after = &rest[dollar + 1..];
+        if let Some(stripped) = after.strip_prefix('$') {
+            out.push('$');
+            rest = stripped;
+            continue;
+        }
+        if let Some(inner) = after.strip_prefix('{') {
+            let Some(end) = inner.find('}') else {
+                return Err(InterpolateError::Unclosed {
+                    location: location.to_owned(),
+                });
+            };
+            let name = &inner[..end];
+            if name.is_empty() {
+                return Err(InterpolateError::EmptyName {
+                    location: location.to_owned(),
+                });
+            }
+            if !is_ident(name) {
+                return Err(InterpolateError::InvalidName {
+                    location: location.to_owned(),
+                    name: name.to_owned(),
+                });
+            }
+            let value = match lookup(name) {
+                Ok(Some(value)) => value,
+                Ok(None) => {
+                    return Err(InterpolateError::Missing {
+                        location: location.to_owned(),
+                        name: name.to_owned(),
+                    });
+                }
+                Err(error) => return Err(error.at(location)),
+            };
+            out.push_str(&value);
+            rest = &inner[end + 1..];
+            continue;
+        }
+        out.push('$');
+        rest = after;
+    }
+    out.push_str(rest);
+    Ok(Cow::Owned(out))
+}
+
+/// Expand every string **value** in `table`. Keys are left as written.
+///
+/// # Errors
+///
+/// Returns the first [`InterpolateError`] encountered, with `location` set to the TOML path.
+pub fn expand_table(
+    table: &mut toml::Table,
+    lookup: EnvLookup<'_>,
+) -> Result<(), InterpolateError> {
+    expand_table_at(table, "", lookup)
+}
+
+fn expand_table_at(
+    table: &mut toml::Table,
+    parent: &str,
+    lookup: EnvLookup<'_>,
+) -> Result<(), InterpolateError> {
+    for (key, value) in table.iter_mut() {
+        let location = child_path(parent, key);
+        expand_value(value, &location, lookup)?;
+    }
+    Ok(())
+}
+
+fn expand_value(
+    value: &mut Value,
+    location: &str,
+    lookup: EnvLookup<'_>,
+) -> Result<(), InterpolateError> {
+    match value {
+        Value::String(text) => {
+            if let Cow::Owned(expanded) = expand(text, location, lookup)? {
+                *text = expanded;
+            }
+            Ok(())
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                let child = format!("{location}[{index}]");
+                expand_value(item, &child, lookup)?;
+            }
+            Ok(())
+        }
+        Value::Table(table) => expand_table_at(table, location, lookup),
+        Value::Integer(_) | Value::Float(_) | Value::Boolean(_) | Value::Datetime(_) => Ok(()),
+    }
+}
+
+fn child_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_owned()
+    } else {
+        format!("{parent}.{key}")
+    }
+}
+
+fn is_ident(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expand, expand_table, InterpolateError};
+    use std::collections::BTreeMap;
+
+    fn lookup<'a>(
+        env: &'a BTreeMap<&'a str, &'a str>,
+    ) -> impl Fn(&str) -> Result<Option<String>, InterpolateError> + 'a {
+        |name| Ok(env.get(name).map(|value| (*value).to_owned()))
+    }
+
+    #[test]
+    fn a_string_without_dollar_is_unchanged() {
+        let env = BTreeMap::new();
+        let expanded = expand("plain", "k", &lookup(&env)).expect("expand");
+        assert!(matches!(expanded, std::borrow::Cow::Borrowed("plain")));
+    }
+
+    #[test]
+    fn expands_a_placeholder_and_surrounding_text() {
+        let env = BTreeMap::from([("ENV", "staging")]);
+        assert_eq!(
+            expand("api-${ENV}", "name", &lookup(&env)).expect("expand"),
+            "api-staging"
+        );
+    }
+
+    #[test]
+    fn doubled_dollar_is_a_literal_dollar() {
+        let env = BTreeMap::from([("ENV", "x")]);
+        assert_eq!(
+            expand("$${ENV}", "k", &lookup(&env)).expect("expand"),
+            "${ENV}"
+        );
+        assert_eq!(expand("$$", "k", &lookup(&env)).expect("expand"), "$");
+    }
+
+    #[test]
+    fn a_dollar_without_braces_is_literal() {
+        let env = BTreeMap::from([("FOO", "x")]);
+        assert_eq!(expand("$FOO", "k", &lookup(&env)).expect("expand"), "$FOO");
+    }
+
+    #[test]
+    fn a_missing_variable_names_the_name_and_location() {
+        let env = BTreeMap::new();
+        let error =
+            expand("${MISSING}", "cloudflare.account_id", &lookup(&env)).expect_err("unset");
+        assert_eq!(
+            error,
+            InterpolateError::Missing {
+                location: "cloudflare.account_id".to_owned(),
+                name: "MISSING".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn unclosed_empty_and_invalid_names_fail() {
+        let env = BTreeMap::new();
+        let get = lookup(&env);
+        assert!(matches!(
+            expand("${NOPE", "k", &get),
+            Err(InterpolateError::Unclosed { .. })
+        ));
+        assert!(matches!(
+            expand("${}", "k", &get),
+            Err(InterpolateError::EmptyName { .. })
+        ));
+        assert!(matches!(
+            expand("${FOO-BAR}", "k", &get),
+            Err(InterpolateError::InvalidName { name, .. }) if name == "FOO-BAR"
+        ));
+        assert!(matches!(
+            expand("${FOO:-x}", "k", &get),
+            Err(InterpolateError::InvalidName { .. })
+        ));
+    }
+
+    #[test]
+    fn expand_table_walks_nested_tables_and_arrays_and_leaves_keys() {
+        let mut table: toml::Table = toml::from_str(
+            "[cloudflare.vars]\nAPI_URL = \"${API_URL}\"\n\n\
+             [[cloudflare.kv_namespaces]]\nbinding = \"CACHE\"\nid = \"${CACHE_ID}\"\n",
+        )
+        .expect("toml");
+        let env = BTreeMap::from([("API_URL", "https://api.flyco.io"), ("CACHE_ID", "ns_abc")]);
+        expand_table(&mut table, &lookup(&env)).expect("expand");
+
+        assert_eq!(
+            table["cloudflare"]["vars"]["API_URL"].as_str(),
+            Some("https://api.flyco.io")
+        );
+        assert_eq!(
+            table["cloudflare"]["kv_namespaces"][0]["id"].as_str(),
+            Some("ns_abc")
+        );
+        assert_eq!(
+            table["cloudflare"]["kv_namespaces"][0]["binding"].as_str(),
+            Some("CACHE")
+        );
+    }
+
+    #[test]
+    fn a_value_with_quotes_and_newlines_does_not_reparse_the_document() {
+        let env = BTreeMap::from([("BANNER", "he said \"hi\"\nnext")]);
+        assert_eq!(
+            expand("${BANNER}", "vars.BANNER", &lookup(&env)).expect("expand"),
+            "he said \"hi\"\nnext"
+        );
+    }
+}

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -15,9 +15,9 @@
 //! # Deploy-time interpolation
 //!
 //! String values may contain `${NAME}` placeholders. The CLI expands them from the process
-//! environment when it reads the file (GitHub Actions secrets mapped into the job env, or
-//! `.env`). [`Manifest::parse`] leaves them as written so `#[skyzen::main]` does not depend on
-//! secrets the compiler does not have. A missing name fails the CLI parse; there is no default.
+//! environment and the project's `.env` files when it reads the file. [`Manifest::parse`] leaves
+//! them as written so `#[skyzen::main]` does not depend on secrets the compiler does not have.
+//! A missing name fails the CLI parse; there is no default.
 //!
 //! ```
 //! # use skyzen_manifest::Manifest;
@@ -49,6 +49,7 @@ mod interpolate;
 mod merge;
 pub mod migrations;
 mod schema;
+mod secrets;
 
 pub use interpolate::{expand, expand_table, process_env, EnvLookup, InterpolateError};
 pub use merge::deep_merge;
@@ -65,6 +66,7 @@ pub use schema::{
     S3Wiring, ServiceBusWiring, ServiceEntry, ServiceType, SkyzenManifest, SqlUrlWiring, SqsWiring,
     StorageQueueWiring, WiringEnvVar, HTTP_FUNCTION_NAME,
 };
+pub use secrets::{scan_table, SecretError, SecretFinding, SecretReport};
 
 use std::{
     collections::BTreeMap,
@@ -138,6 +140,14 @@ pub enum ManifestError {
         /// What was wrong with the placeholder, including the TOML path.
         source: interpolate::InterpolateError,
     },
+    /// A string value is a documented credential form stored in the file.
+    #[error("{path}: {source}")]
+    CommittedSecret {
+        /// The manifest path.
+        path: PathBuf,
+        /// What was found, without the secret value.
+        source: secrets::SecretError,
+    },
     /// A named environment was requested that the manifest does not declare.
     #[error(
         "{path} declares no Cloudflare environment named `{name}`{}",
@@ -164,6 +174,9 @@ pub struct Manifest {
     root_dir: PathBuf,
     data: SkyzenManifest,
     environments: BTreeMap<String, CloudflareSection>,
+    /// Heuristic secret-shaped values. Empty unless this manifest was loaded with interpolation
+    /// (the CLI). Blocking forms have already failed the parse.
+    secret_warnings: Vec<SecretFinding>,
 }
 
 impl Manifest {
@@ -253,6 +266,22 @@ impl Manifest {
                 source: Box::new(source),
             })?;
 
+        // Scan the file as committed, before interpolation fills in CI secrets. Macros pass
+        // `lookup = None` and skip the scan so `cargo build` does not fail on a token the
+        // compiler never needed.
+        let secret_warnings = if lookup.is_some() {
+            let report = secrets::scan_table(&document);
+            if let Some(source) = secrets::blocking_error(&report) {
+                return Err(ManifestError::CommittedSecret {
+                    path: path.clone(),
+                    source,
+                });
+            }
+            report.warnings
+        } else {
+            Vec::new()
+        };
+
         if let Some(lookup) = lookup {
             interpolate::expand_table(&mut document, lookup).map_err(|source| {
                 ManifestError::Interpolation {
@@ -332,6 +361,7 @@ impl Manifest {
             root_dir: root_dir.into(),
             data,
             environments,
+            secret_warnings,
         })
     }
 
@@ -356,6 +386,16 @@ impl Manifest {
     /// The names of every declared `[cloudflare.env.<name>]` overlay, in sorted order.
     pub fn environment_names(&self) -> impl ExactSizeIterator<Item = &str> {
         self.environments.keys().map(String::as_str)
+    }
+
+    /// Heuristic secret-shaped values found while loading with interpolation.
+    ///
+    /// Blocking credential forms have already failed the parse. These leftovers — a
+    /// secret-named key whose value is not a known token, a JWT-shaped string — are
+    /// warnings for the CLI to print.
+    #[must_use]
+    pub fn secret_warnings(&self) -> &[SecretFinding] {
+        &self.secret_warnings
     }
 
     /// The Cloudflare configuration for `environment`, or the base configuration when `None`.
@@ -1186,6 +1226,36 @@ mod tests {
                 .expect("cloudflare")
                 .vars["BANNER"],
             "he said \"hi\""
+        );
+    }
+
+    #[test]
+    fn the_cli_parse_blocks_a_github_token_and_the_macro_parse_does_not() {
+        let source = "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n";
+        let error = parse_expanded(source, &[]).expect_err("CLI load blocks a known token");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("GitHub personal access token"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("ghp_"), "{rendered}");
+
+        parse(source).expect("compile-time parse does not scan");
+    }
+
+    #[test]
+    fn a_secret_named_literal_warns_on_cli_load_but_does_not_fail() {
+        let manifest = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nAPI_KEY = \"dev-only\"\n",
+            &[],
+        )
+        .expect("heuristic is a warning");
+        assert_eq!(manifest.secret_warnings().len(), 1);
+        assert_eq!(
+            manifest.secret_warnings()[0].kind,
+            "plaintext value of a secret-named key"
         );
     }
 

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -12,6 +12,13 @@
 //! [`Manifest::parse`] resolves every overlay against the base eagerly, so a typo in an
 //! environment nobody selected still fails the parse. Overlays compose with [`deep_merge`].
 //!
+//! # Deploy-time interpolation
+//!
+//! String values may contain `${NAME}` placeholders. The CLI expands them from the process
+//! environment when it reads the file (GitHub Actions secrets mapped into the job env, or
+//! `.env`). [`Manifest::parse`] leaves them as written so `#[skyzen::main]` does not depend on
+//! secrets the compiler does not have. A missing name fails the CLI parse; there is no default.
+//!
 //! ```
 //! # use skyzen_manifest::Manifest;
 //! let manifest = Manifest::parse(
@@ -38,10 +45,12 @@
 //! assert_eq!(staging.workers_dev, Some(true));
 //! ```
 
+mod interpolate;
 mod merge;
 pub mod migrations;
 mod schema;
 
+pub use interpolate::{expand, expand_table, process_env, EnvLookup, InterpolateError};
 pub use merge::deep_merge;
 pub use migrations::{MigrationFile, MigrationsError, DEFAULT_MIGRATIONS_DIR};
 pub use schema::{
@@ -121,6 +130,14 @@ pub enum ManifestError {
         /// Which keys are named and which are missing.
         source: schema::PartialRdsDataWiring,
     },
+    /// A `${NAME}` placeholder in a string value could not be expanded.
+    #[error("{path}: {source}")]
+    Interpolation {
+        /// The manifest path.
+        path: PathBuf,
+        /// What was wrong with the placeholder, including the TOML path.
+        source: interpolate::InterpolateError,
+    },
     /// A named environment was requested that the manifest does not declare.
     #[error(
         "{path} declares no Cloudflare environment named `{name}`{}",
@@ -150,7 +167,7 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    /// Read and parse the manifest at `path`.
+    /// Read and parse the manifest at `path`, leaving `${NAME}` placeholders as written.
     ///
     /// `root_dir` — the project root every relative path in the manifest is resolved against — is
     /// taken to be the manifest's parent directory.
@@ -160,6 +177,20 @@ impl Manifest {
     /// Returns [`ManifestError`] when the file cannot be read, is not valid TOML, does not match
     /// the schema, or has a malformed `[cloudflare.env]` table.
     pub fn load(path: &Path) -> Result<Self, ManifestError> {
+        Self::load_with(path, None)
+    }
+
+    /// Read and parse the manifest at `path`, expanding `${NAME}` through `lookup`.
+    ///
+    /// `lookup` is `None` for compile-time consumers. The CLI supplies one that reads the process
+    /// environment and the project's `.env` files.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError`] when the file cannot be read, a placeholder cannot be expanded,
+    /// the file is not valid TOML, does not match the schema, or has a malformed `[cloudflare.env]`
+    /// table.
+    pub fn load_with(path: &Path, lookup: Option<EnvLookup<'_>>) -> Result<Self, ManifestError> {
         let path = if path.is_absolute() {
             path.to_path_buf()
         } else {
@@ -178,13 +209,14 @@ impl Manifest {
             path: path.clone(),
             source,
         })?;
-        Self::parse(&content, &path, root_dir)
+        Self::parse_with(&content, &path, root_dir, lookup)
     }
 
     /// Parse manifest `content` that came from `path`, rooted at `root_dir`.
     ///
     /// `path` is used only for error messages, so callers holding the content in memory (tests,
     /// or a manifest embedded in a template) can name whatever the user would recognize.
+    /// `${NAME}` placeholders are left as written; see [`parse_with`](Self::parse_with).
     ///
     /// # Errors
     ///
@@ -195,12 +227,40 @@ impl Manifest {
         path: impl AsRef<Path>,
         root_dir: impl Into<PathBuf>,
     ) -> Result<Self, ManifestError> {
+        Self::parse_with(content, path, root_dir, None)
+    }
+
+    /// Parse `content`, expanding `${NAME}` through `lookup` before the typed schema runs.
+    ///
+    /// Expansion walks string **values** only, so a secret containing quotes or newlines cannot
+    /// break the document. A missing name fails rather than leaving a placeholder in a field the
+    /// CLI would treat as a literal id.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError`] when a placeholder cannot be expanded, the content is not valid
+    /// TOML, does not match the schema, or has a malformed `[cloudflare.env]` table.
+    pub fn parse_with(
+        content: &str,
+        path: impl AsRef<Path>,
+        root_dir: impl Into<PathBuf>,
+        lookup: Option<EnvLookup<'_>>,
+    ) -> Result<Self, ManifestError> {
         let path = path.as_ref().to_path_buf();
         let mut document: toml::Table =
             toml::from_str(content).map_err(|source| ManifestError::Syntax {
                 path: path.clone(),
                 source: Box::new(source),
             })?;
+
+        if let Some(lookup) = lookup {
+            interpolate::expand_table(&mut document, lookup).map_err(|source| {
+                ManifestError::Interpolation {
+                    path: path.clone(),
+                    source,
+                }
+            })?;
+        }
 
         // Lift the environment overlays out before any typed deserialization: the base and every
         // overlay then go through the *same* `CloudflareSection`, which is what makes
@@ -362,13 +422,21 @@ fn take_environment_overlays(
 #[cfg(test)]
 mod tests {
     use super::{
-        Manifest, ManifestError, NativeDatabaseBackend, NativeDatabaseSection,
+        InterpolateError, Manifest, ManifestError, NativeDatabaseBackend, NativeDatabaseSection,
         NativeServiceBackend, NativeServiceSection, RdsEngine, ServiceType,
     };
     use std::time::Duration;
 
     fn parse(content: &str) -> Result<Manifest, ManifestError> {
         Manifest::parse(content, "Skyzen.toml", ".")
+    }
+
+    fn parse_expanded(content: &str, env: &[(&str, &str)]) -> Result<Manifest, ManifestError> {
+        let map: std::collections::BTreeMap<&str, &str> = env.iter().copied().collect();
+        let lookup = |name: &str| -> Result<Option<String>, InterpolateError> {
+            Ok(map.get(name).map(|value| (*value).to_owned()))
+        };
+        Manifest::parse_with(content, "Skyzen.toml", ".", Some(&lookup))
     }
 
     /// The `[native.service.cache]` a manifest wiring `cache` with `body` produces.
@@ -1033,6 +1101,91 @@ mod tests {
         assert!(
             error.to_string().contains("prod") && error.to_string().contains("staging"),
             "error should name the request and the alternatives: {error}"
+        );
+    }
+
+    #[test]
+    fn interpolates_string_values_from_the_supplied_lookup() {
+        let manifest = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\naccount_id = \"${ACCOUNT}\"\n\n\
+             [[cloudflare.kv_namespaces]]\nbinding = \"CACHE\"\nid = \"${CACHE_ID}\"\n\n\
+             [cloudflare.vars]\nAPI_URL = \"${API_URL}\"\n\n\
+             [cloudflare.env.staging]\naccount_id = \"${STAGING_ACCOUNT}\"\n",
+            &[
+                ("ACCOUNT", "acct_prod"),
+                ("CACHE_ID", "ns_abc"),
+                ("API_URL", "https://api.flyco.io"),
+                ("STAGING_ACCOUNT", "acct_staging"),
+            ],
+        )
+        .expect("manifest parses");
+
+        let base = manifest
+            .cloudflare(None)
+            .expect("base")
+            .expect("cloudflare");
+        assert_eq!(base.account_id.as_deref(), Some("acct_prod"));
+        assert_eq!(base.kv_namespaces[0].id.as_deref(), Some("ns_abc"));
+        assert_eq!(base.vars["API_URL"], "https://api.flyco.io");
+
+        let staging = manifest
+            .cloudflare(Some("staging"))
+            .expect("known environment")
+            .expect("cloudflare");
+        assert_eq!(staging.account_id.as_deref(), Some("acct_staging"));
+        // Overlay inherits the expanded base binding list.
+        assert_eq!(staging.kv_namespaces[0].id.as_deref(), Some("ns_abc"));
+    }
+
+    #[test]
+    fn parse_without_expansion_leaves_placeholders_in_place() {
+        let manifest = parse(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [[cloudflare.kv_namespaces]]\nbinding = \"CACHE\"\nid = \"${CACHE_ID}\"\n",
+        )
+        .expect("literal parse");
+        assert_eq!(
+            manifest
+                .data()
+                .cloudflare
+                .as_ref()
+                .expect("cloudflare")
+                .kv_namespaces[0]
+                .id
+                .as_deref(),
+            Some("${CACHE_ID}")
+        );
+    }
+
+    #[test]
+    fn a_missing_interpolation_fails_naming_the_variable_and_the_key() {
+        let error = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\naccount_id = \"${ACCOUNT}\"\n",
+            &[],
+        )
+        .expect_err("unset");
+        let rendered = error.to_string();
+        assert!(rendered.contains("ACCOUNT"), "{rendered}");
+        assert!(rendered.contains("account_id"), "{rendered}");
+        assert!(rendered.contains("Skyzen.toml"), "{rendered}");
+    }
+
+    #[test]
+    fn interpolating_a_value_with_quotes_does_not_break_toml() {
+        let manifest = parse_expanded(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.vars]\nBANNER = \"${BANNER}\"\n",
+            &[("BANNER", "he said \"hi\"")],
+        )
+        .expect("manifest parses");
+        assert_eq!(
+            manifest
+                .data()
+                .cloudflare
+                .as_ref()
+                .expect("cloudflare")
+                .vars["BANNER"],
+            "he said \"hi\""
         );
     }
 

--- a/manifest/src/secrets.rs
+++ b/manifest/src/secrets.rs
@@ -1,0 +1,455 @@
+//! Detect secrets that have been written into `Skyzen.toml` as literal strings.
+//!
+//! Two classes, because a false block on a resource id is worse than a missed warning:
+//!
+//! * **Block** — the value is a documented credential form (a GitHub PAT prefix, a PEM
+//!   private key, a URL with a password). The CLI refuses to load the file.
+//! * **Heuristic** — a `vars` / `[aws.env]` key whose *name* looks like a secret, or a
+//!   JWT-shaped string. The CLI warns. `${NAME}` placeholders are neither.
+
+use std::fmt::{Display, Formatter};
+
+/// One string in the document that looks like a secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretFinding {
+    /// TOML path, e.g. `cloudflare.vars.API_KEY`.
+    pub location: String,
+    /// What kind of secret, for the error or warning. Never the value itself.
+    pub kind: &'static str,
+}
+
+impl Display for SecretFinding {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.location, self.kind)
+    }
+}
+
+/// 100% credential forms found in string values.
+///
+/// The value is never stored: printing this error cannot leak the secret a second time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretError {
+    /// Every blocking finding. Never empty.
+    pub findings: Vec<SecretFinding>,
+}
+
+impl std::error::Error for SecretError {}
+
+impl Display for SecretError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "committed secret in Skyzen.toml ({}); use a ${{NAME}} placeholder or `skyzen secret set`",
+            self.findings
+                .iter()
+                .map(SecretFinding::to_string)
+                .collect::<Vec<_>>()
+                .join("; ")
+        )
+    }
+}
+
+/// Block vs warn findings from one document.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SecretReport {
+    /// Documented credential forms. The CLI treats these as a load error.
+    pub blocks: Vec<SecretFinding>,
+    /// Name-based or JWT-shaped values. The CLI warns and continues.
+    pub warnings: Vec<SecretFinding>,
+}
+
+/// Walk every string **value** in `table`. Keys are not inspected for credential forms.
+#[must_use]
+pub fn scan_table(table: &toml::Table) -> SecretReport {
+    let mut report = SecretReport::default();
+    scan_table_at(table, "", &mut report);
+    report
+}
+
+fn scan_table_at(table: &toml::Table, parent: &str, report: &mut SecretReport) {
+    for (key, value) in table {
+        let location = child_path(parent, key);
+        match value {
+            toml::Value::String(text) => classify(&location, key, parent, text, report),
+            toml::Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    scan_value(&format!("{location}[{index}]"), key, parent, item, report);
+                }
+            }
+            toml::Value::Table(child) => scan_table_at(child, &location, report),
+            toml::Value::Integer(_)
+            | toml::Value::Float(_)
+            | toml::Value::Boolean(_)
+            | toml::Value::Datetime(_) => {}
+        }
+    }
+}
+
+fn scan_value(
+    location: &str,
+    key: &str,
+    parent: &str,
+    value: &toml::Value,
+    report: &mut SecretReport,
+) {
+    match value {
+        toml::Value::String(text) => classify(location, key, parent, text, report),
+        toml::Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                scan_value(&format!("{location}[{index}]"), key, parent, item, report);
+            }
+        }
+        toml::Value::Table(child) => scan_table_at(child, location, report),
+        toml::Value::Integer(_)
+        | toml::Value::Float(_)
+        | toml::Value::Boolean(_)
+        | toml::Value::Datetime(_) => {}
+    }
+}
+
+fn classify(location: &str, key: &str, parent: &str, text: &str, report: &mut SecretReport) {
+    if text.trim().is_empty() || is_placeholder(text) {
+        return;
+    }
+    if let Some(kind) = block_kind(text) {
+        report.blocks.push(SecretFinding {
+            location: location.to_owned(),
+            kind,
+        });
+        return;
+    }
+    if looks_like_jwt(text) {
+        report.warnings.push(SecretFinding {
+            location: location.to_owned(),
+            kind: "JWT-shaped string",
+        });
+        return;
+    }
+    if is_secret_key_table(parent) && is_secret_named_key(key) {
+        report.warnings.push(SecretFinding {
+            location: location.to_owned(),
+            kind: "plaintext value of a secret-named key",
+        });
+    }
+}
+
+/// Documented forms that cannot reasonably be a resource id or a URL.
+fn block_kind(text: &str) -> Option<&'static str> {
+    if text.contains("BEGIN ") && text.contains("PRIVATE KEY") {
+        return Some("PEM private key");
+    }
+    if url_has_password(text) {
+        return Some("URL with a password");
+    }
+    if is_aws_access_key_id(text) {
+        return Some("AWS access key id");
+    }
+    for rule in BLOCK_PREFIXES {
+        if token_starting(text, rule.prefix).is_some_and(|token| token.len() >= rule.min_len) {
+            return Some(rule.kind);
+        }
+    }
+    None
+}
+
+struct PrefixRule {
+    prefix: &'static str,
+    min_len: usize,
+    kind: &'static str,
+}
+
+/// Prefixes assigned by the issuer. Lengths are the documented minimums, so a truncated
+/// paste still has to look like that issuer's token, not like a Worker name.
+const BLOCK_PREFIXES: &[PrefixRule] = &[
+    PrefixRule {
+        prefix: "ghp_",
+        min_len: 40,
+        kind: "GitHub personal access token",
+    },
+    PrefixRule {
+        prefix: "gho_",
+        min_len: 40,
+        kind: "GitHub OAuth access token",
+    },
+    PrefixRule {
+        prefix: "ghu_",
+        min_len: 40,
+        kind: "GitHub user-to-server token",
+    },
+    PrefixRule {
+        prefix: "ghs_",
+        min_len: 40,
+        kind: "GitHub server-to-server token",
+    },
+    PrefixRule {
+        prefix: "ghr_",
+        min_len: 40,
+        kind: "GitHub refresh token",
+    },
+    PrefixRule {
+        prefix: "github_pat_",
+        min_len: 82,
+        kind: "GitHub fine-grained personal access token",
+    },
+    PrefixRule {
+        prefix: "glpat-",
+        min_len: 20,
+        kind: "GitLab personal access token",
+    },
+    PrefixRule {
+        prefix: "xoxb-",
+        min_len: 50,
+        kind: "Slack bot token",
+    },
+    PrefixRule {
+        prefix: "xoxp-",
+        min_len: 50,
+        kind: "Slack user token",
+    },
+    PrefixRule {
+        prefix: "sk_live_",
+        min_len: 32,
+        kind: "Stripe live secret key",
+    },
+    PrefixRule {
+        prefix: "sk_test_",
+        min_len: 32,
+        kind: "Stripe test secret key",
+    },
+    PrefixRule {
+        prefix: "rk_live_",
+        min_len: 32,
+        kind: "Stripe live restricted key",
+    },
+    PrefixRule {
+        prefix: "rk_test_",
+        min_len: 32,
+        kind: "Stripe test restricted key",
+    },
+    PrefixRule {
+        prefix: "sk-ant-",
+        min_len: 40,
+        kind: "Anthropic API key",
+    },
+    PrefixRule {
+        prefix: "sk-proj-",
+        min_len: 40,
+        kind: "OpenAI project API key",
+    },
+    PrefixRule {
+        prefix: "AIza",
+        min_len: 39,
+        kind: "Google API key",
+    },
+    PrefixRule {
+        prefix: "npm_",
+        min_len: 40,
+        kind: "npm access token",
+    },
+    PrefixRule {
+        prefix: "shpat_",
+        min_len: 32,
+        kind: "Shopify admin API token",
+    },
+];
+
+fn token_starting<'a>(text: &'a str, prefix: &'a str) -> Option<&'a str> {
+    let pos = text.find(prefix)?;
+    text[pos..].split_whitespace().next()
+}
+
+fn is_aws_access_key_id(text: &str) -> bool {
+    for prefix in ["AKIA", "ASIA"] {
+        if let Some(token) = token_starting(text, prefix) {
+            let rest = &token[prefix.len()..];
+            if rest.len() == 16
+                && rest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn url_has_password(text: &str) -> bool {
+    let Some((_scheme, rest)) = text.split_once("://") else {
+        return false;
+    };
+    let Some((userinfo, _host)) = rest.split_once('@') else {
+        return false;
+    };
+    match userinfo.split_once(':') {
+        Some((_, password)) => !password.is_empty(),
+        None => false,
+    }
+}
+
+fn looks_like_jwt(text: &str) -> bool {
+    let trimmed = text.trim();
+    let mut parts = trimmed.split('.');
+    let Some(header) = parts.next() else {
+        return false;
+    };
+    let Some(payload) = parts.next() else {
+        return false;
+    };
+    parts.next().is_some()
+        && parts.next().is_none()
+        && header.starts_with("eyJ")
+        && payload.starts_with("eyJ")
+}
+
+fn is_placeholder(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed
+        .strip_prefix("${")
+        .and_then(|inner| inner.strip_suffix('}'))
+        .is_some_and(is_ident)
+}
+
+fn is_ident(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+fn is_secret_key_table(parent: &str) -> bool {
+    parent == "aws.env" || parent == "vars" || parent.strip_suffix(".vars").is_some()
+}
+
+const SECRET_KEY_NEEDLES: &[&str] = &[
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "PRIVATE_KEY",
+    "API_KEY",
+    "ACCESS_KEY",
+    "AUTH_KEY",
+    "CREDENTIAL",
+    "CONNECTION_STRING",
+];
+
+fn is_secret_named_key(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    SECRET_KEY_NEEDLES
+        .iter()
+        .any(|needle| upper.contains(needle))
+}
+
+fn child_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_owned()
+    } else {
+        format!("{parent}.{key}")
+    }
+}
+
+/// Turn blocking findings into an error. `None` when there are none.
+#[must_use]
+pub fn blocking_error(report: &SecretReport) -> Option<SecretError> {
+    if report.blocks.is_empty() {
+        None
+    } else {
+        Some(SecretError {
+            findings: report.blocks.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scan_table;
+
+    fn scan(source: &str) -> super::SecretReport {
+        let table: toml::Table = toml::from_str(source).expect("toml");
+        scan_table(&table)
+    }
+
+    #[test]
+    fn a_github_pat_is_a_block() {
+        let report =
+            scan("[cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n");
+        assert_eq!(report.blocks.len(), 1, "{report:?}");
+        assert_eq!(report.blocks[0].kind, "GitHub personal access token");
+        assert!(report.blocks[0].location.contains("TOKEN"));
+    }
+
+    #[test]
+    fn a_placeholder_is_neither_a_block_nor_a_warning() {
+        let report = scan("[cloudflare.vars]\nAPI_KEY = \"${API_KEY}\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings, []);
+    }
+
+    #[test]
+    fn a_secret_named_literal_that_is_not_a_known_form_is_a_warning() {
+        let report = scan("[cloudflare.vars]\nAPI_KEY = \"dev-only\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings.len(), 1);
+        assert_eq!(
+            report.warnings[0].kind,
+            "plaintext value of a secret-named key"
+        );
+    }
+
+    #[test]
+    fn a_postgres_url_with_a_password_is_a_block() {
+        let report =
+            scan("[cloudflare.vars]\nDATABASE = \"postgres://flyco:s3cret@127.0.0.1/app\"\n");
+        assert_eq!(report.blocks[0].kind, "URL with a password");
+    }
+
+    #[test]
+    fn a_url_without_a_password_is_clean() {
+        let report = scan("[cloudflare.vars]\nAPI_URL = \"https://api.flyco.io\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings, []);
+    }
+
+    #[test]
+    fn an_rds_secret_arn_is_not_a_secret() {
+        let report = scan(
+            "[native.database.main]\nbackend = \"rds-data\"\n\
+             secret_arn = \"arn:aws:secretsmanager:us-east-1:111122223333:secret:skyzen-Ab12Cd\"\n",
+        );
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings, []);
+    }
+
+    #[test]
+    fn a_pem_private_key_is_a_block() {
+        let report = scan(
+            "[cloudflare.vars]\nKEY = \"-----BEGIN PRIVATE KEY-----\\nMIIB\\n-----END PRIVATE KEY-----\"\n",
+        );
+        assert_eq!(report.blocks[0].kind, "PEM private key");
+    }
+
+    #[test]
+    fn an_aws_access_key_id_is_a_block() {
+        let report = scan("[aws.env]\nUSER = \"AKIAAAAAAAAAAAAAAAAA\"\n");
+        assert_eq!(report.blocks[0].kind, "AWS access key id");
+    }
+
+    #[test]
+    fn a_jwt_shaped_string_is_a_warning() {
+        let report =
+            scan("[cloudflare.vars]\nCLAIM = \"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.aaaa\"\n");
+        assert_eq!(report.blocks, []);
+        assert_eq!(report.warnings[0].kind, "JWT-shaped string");
+    }
+
+    #[test]
+    fn findings_never_include_the_secret_value() {
+        let report =
+            scan("[cloudflare.vars]\nTOKEN = \"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n");
+        let rendered = report.blocks[0].to_string();
+        assert!(!rendered.contains("ghp_"), "{rendered}");
+    }
+}


### PR DESCRIPTION
Merges `dev` into `main` to trigger the release workflow.

## What ships

| Issue | Commit | What changed |
|---|---|---|
| #27 | `feat(manifest)` | Skyzen.toml `${NAME}` placeholders expand from the process environment and `.env` at CLI load. `#[skyzen::main]` leaves them as written. |
| #29 | `feat(cli)` | CLI load refuses documented credential forms in Skyzen.toml and dotenv files git is already tracking. Heuristic matches (secret-named keys, JWT-shaped strings, unignored dotenv paths) warn only. Errors never print the value. |

Interpolation reads `.env` / the process environment. Docs do not require a per-key GitHub Actions `env:` mapping.

## On merging

Pushing to `main` runs `release.yml`. The `release` job publishes already-bumped crate versions; the `release-pr` job opens the version-bump-and-changelog PR. Merging *that* is what publishes this work to crates.io.
