### PR TITLE
chore: sync 0.2.1 version bumps onto dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/v0.2.0...v0.2.1) - 2026-08-29
+
+### Added
+
+- *(cli)* refuse committed secrets on CLI load
+- *(manifest)* interpolate deploy-time environment placeholders
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/v0.1.2...v0.2.0) - 2026-08-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [workspace.dependencies]
 skyzen-core = { path = "core", version = "0.2.0" }
-skyzen-macros = { path = "macros", version = "0.2.0" }
-skyzen-manifest = { path = "manifest", version = "0.1.0" }
+skyzen-macros = { path = "macros", version = "0.2.1" }
+skyzen-manifest = { path = "manifest", version = "0.1.1" }
 skyzen-services = { path = "services", version = "0.2.0" }
 skyzen-test = { path = "test", version = "0.2.0" }
 skyzen-redis = { path = "redis", version = "0.2.0" }
@@ -19,7 +19,7 @@ executor-core = { version = "0.7.1", default-features = false, features = ["std"
 skyzen-hyper = { path = "hyper", version = "0.2.0" }
 skyzen-lambda = { path = "lambda", version = "0.1.0" }
 tracing = "0.1.44"
-skyzen = { path = ".", version = "0.2.0" }
+skyzen = { path = ".", version = "0.2.1" }
 smol = "2.0"
 async-executor = "1.13"
 async-io = "2.6"
@@ -43,7 +43,7 @@ clippy.multiple_crate_versions = { level = "allow", priority = 1 }
 
 [package]
 name = "skyzen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A fast, ergonomic HTTP framework that works everywhere"
 license = "MIT OR Apache-2.0"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-cli-v0.2.0...skyzen-cli-v0.2.1) - 2026-08-29
+
+### Added
+
+- *(cli)* refuse committed secrets on CLI load
+- *(manifest)* interpolate deploy-time environment placeholders
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-cli-v0.1.0...skyzen-cli-v0.2.0) - 2026-08-27
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Unified local emulation and deployment CLI for Skyzen"
 license = "MIT OR Apache-2.0"

--- a/cloudflare/CHANGELOG.md
+++ b/cloudflare/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-cloudflare-v0.2.0...skyzen-cloudflare-v0.2.1) - 2026-08-29
+
+### Other
+
+- updated the following local packages: skyzen
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-cloudflare-v0.1.1...skyzen-cloudflare-v0.2.0) - 2026-08-27
 
 ### Added

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-cloudflare"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Cloudflare Workers service implementations for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["cloudflare", "workers", "skyzen", "services"]
 categories = ["web-programming::http-server", "wasm"]
 
 [dependencies]
-skyzen = { path = "..", version = "0.2.0", default-features = false, features = ["ws"] }
+skyzen = { path = "..", version = "0.2.1", default-features = false, features = ["ws"] }
 skyzen-services = { path = "../services", version = "0.2.0" }
 worker-sys = { version = "0.7", features = ["d1", "queue"] }
 wasm-bindgen = "0.2"

--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/macros-v0.2.0...macros-v0.2.1) - 2026-08-29
+
+### Other
+
+- updated the following local packages: skyzen-manifest
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/macros-v0.1.2...macros-v0.2.0) - 2026-08-27
 
 ### Added

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-macros"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Procedural macros powering the Skyzen web framework"
 license = "MIT OR Apache-2.0"

--- a/manifest/CHANGELOG.md
+++ b/manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/zen-rs/skyzen/compare/skyzen-manifest-v0.1.0...skyzen-manifest-v0.1.1) - 2026-08-29
+
+### Added
+
+- *(cli)* refuse committed secrets on CLI load
+- *(manifest)* interpolate deploy-time environment placeholders
+
 ## [0.1.0](https://github.com/zen-rs/skyzen/releases/tag/skyzen-manifest-v0.1.0) - 2026-08-27
 
 ### Added

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-manifest"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Typed Skyzen.toml schema shared by the Skyzen CLI and the Skyzen procedural macros"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Brings the 0.2.1 / skyzen-manifest 0.1.1 version bumps from `main` back onto `dev` so the next feature branch is not behind the crates.io release.
