### PR TITLE
feat!: unify the secret system around [[secret]]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,8 @@ Skyzen is a router-first HTTP framework targeting both native servers (Tokio + H
 
 **Framework Core:**
 - **`skyzen`** (`/`) - Main framework crate: routing, extractors, responders, middleware, static files, and runtime helpers.
-- **`skyzen-core`** (`core/`) - Foundational traits (`Extractor`, `Responder`, `Server`) reusable by alternative runtimes. Supports `no_std` when `std` feature is disabled.
-- **`skyzen-macros`** (`macros/`) - Procedural macros: `#[skyzen::main]`, `#[skyzen::error]`, `#[skyzen::openapi]`, `#[skyzen::queue]`, `#[skyzen::scheduled]`, `#[skyzen::email]`, `#[skyzen::tail]`, `#[skyzen::durable_object]`, `#[skyzen::test]`, `#[derive(HttpError)]`, plus the function-like `import_config!` and `embed_migrations!`.
+- **`skyzen-core`** (`core/`) - Foundational traits (`Extractor`, `Responder`, `Server`) reusable by alternative runtimes, plus `Secret`, the one runtime representation of a `[[secret]]` value. Supports `no_std` when `std` feature is disabled (`Secret` is `std`-only).
+- **`skyzen-macros`** (`macros/`) - Procedural macros: `#[skyzen::main]`, `#[skyzen::error]`, `#[skyzen::openapi]`, `#[skyzen::queue]`, `#[skyzen::scheduled]`, `#[skyzen::email]`, `#[skyzen::tail]`, `#[skyzen::durable_object]`, `#[skyzen::test]`, `#[derive(HttpError)]`, plus the function-like `import_config!` (one named extractor per `[[service]]`, `[[database]]` and `[[secret]]`) and `embed_migrations!`.
 - **`skyzen-manifest`** (`manifest/`) - The one typed `Skyzen.toml` schema, consumed by **both** `skyzen-macros` (at compile time) and `skyzen-cli` (at deploy time), so a section can never be accepted by one and rejected by the other. Every struct carries `deny_unknown_fields` and the `type`/`backend` discriminants are enums, so a typo or an unsupported value fails at parse time.
 - **`skyzen-hyper`** (`hyper/`) - Hyper server adapter implementing the `Server` trait from `skyzen-core`.
 - **`skyzen-lambda`** (`lambda/`) - AWS Lambda adapter: HTTP invocations and SQS batches, driven by its own Tokio runtime. Reached through the root crate's optional `lambda` feature, never named by an application.
@@ -58,12 +58,12 @@ Skyzen is a router-first HTTP framework targeting both native servers (Tokio + H
 - **`skyzen-redis`** (`redis/`) - Redis implementation of `KeyValueStore`, atomics included.
 - **`skyzen-s3`** (`s3/`) - S3-compatible implementation of `ObjectStorage`, with streaming, ranges, multipart and presigning.
 - **`skyzen-cloudflare`** (`cloudflare/`) - Cloudflare Workers implementations for KV, R2, Queues, D1 SQL, Durable Objects, the secrets store, `WorkerContext`/`CfProperties`, and the email/tail events (**wasm32-only**).
-- **`skyzen-cloudflare-admin`** (`cloudflare-admin/`) - Cloudflare REST API client, used by `skyzen provision`.
+- **`skyzen-cloudflare-admin`** (`cloudflare-admin/`) - The shared Cloudflare control-plane types: the `{success, errors, result}` response envelope and `TokenSource`. No HTTP transport and no endpoint wrappers, and nothing in this workspace depends on it — `skyzen provision` drives wrangler.
 - **`skyzen-aws`** (`aws/`) - AWS implementations: DynamoDB (`DynamoKv`), SQS (`SqsQueue`, FIFO and consume side), the Aurora Data API (`RdsDataDb`, with real transactions), and `S3Storage` re-exported from `skyzen-s3`.
 - **`skyzen-azure`** (`azure/`) - Azure implementations: Cosmos DB (`CosmosKv`), Blob Storage (`AzureBlob`), Service Bus (`ServiceBusQueue`), Azure Storage queues (`AzureStorageQueue`).
 
 **Tooling:**
-- **`skyzen-cli`** (`cli/`) - Unified CLI binary: `new`, `add`, `doctor`, `dev`, `build`, `provision`, `migrate` (+ `migrate status`), `deploy`, `logs`, `secret`, `completions`, with a global `--provider` / `--env` / `--manifest` / `--dry-run`. It links the wasm-bindgen generator and the binaryen optimizer in rather than shelling out, so `cargo install skyzen-cli` is the whole toolchain install. Templates and the generated Worker shim are askama templates under `cli/templates/`; `wrangler.toml` is a `Serialize` model, never string assembly.
+- **`skyzen-cli`** (`cli/`) - Unified CLI binary: `new`, `add`, `doctor`, `dev`, `build`, `provision`, `migrate` (+ `migrate status`), `deploy`, `logs`, `secret` (`set` / `push` / `list`, on Cloudflare, AWS and Azure), `completions`, with a global `--provider` / `--env` / `--manifest` / `--dry-run`. `environment.rs` is the one resolver for the variables a running application needs — `[[secret]]` entries and native wiring — and each provider's module is the one sink that delivers them. It links the wasm-bindgen generator and the binaryen optimizer in rather than shelling out, so `cargo install skyzen-cli` is the whole toolchain install. Templates and the generated Worker shim are askama templates under `cli/templates/`; `wrangler.toml` is a `Serialize` model, never string assembly.
 
 ---
 
@@ -142,6 +142,25 @@ remain Cloudflare-only, because nothing else has those events.
   cannot disagree about which files count or how a checksum is computed. `Db::migrate` applies each
   file and its bookkeeping row in one `execute_batch`, and refuses to run when an applied file's
   checksum no longer matches.
+
+### 5b. Secrets
+- A secret is one model on every target: `[[secret]] name = "NAME"` declares it, `import_config!`
+  generates `NameInPascalCase` wrapping `skyzen::Secret` (`STRIPE_KEY` → `StripeKey`), and
+  `#[skyzen::main]` **resolves it once at startup** — `std::env::var` natively, `CfSecret::classic`
+  or `CfSecret::from_store` on Workers when `[cloudflare.secret.<NAME>]` backs it. There is no bare
+  `Secret` extractor: the type names a value, not a capability. A test layers one in with
+  `router.layer(StripeKey::new(Secret::new("x")))`.
+- `Secret` is readable only through `expose`, its `Debug` is `Secret(<redacted>)`, and it has no
+  `Display`.
+- **One identifier rule.** Every variable name in the schema — a secret's name and every `*_env`
+  wiring key — is a `VarName`, validated `[A-Za-z_][A-Za-z0-9_]*` at parse time, so the CLI and the
+  macro cannot read different variables from the same key.
+- **No value on argv or stdout.** The CLI carries values in `SecretString`, delivers them on a
+  child process's standard input (wrangler) or in a request body (Lambda, ARM), writes value-bearing
+  files 0600, and prints `write <path> (secret values, not shown)` under `--dry-run`. A leak needs a
+  visible `expose_secret()`, which is what a review looks for. The canonical description, including
+  the `.env` precedence rule and the per-provider delivery table, is
+  `docs/skyzen-toml-reference.md#secrets`.
 
 ### 6. Error Handling & Log Security
 - `#[skyzen::error]` generates `Display`, `Error`, and `HttpError` implementations with status code attributes.

--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ skyzen migrate status                 # what is applied, what is pending
 skyzen deploy --provider cloudflare   # or aws, or azure — same application, no code changes
 skyzen logs --env staging             # stream the deployed application's logs
 skyzen secret set API_KEY             # value read from stdin
+skyzen secret push                    # deliver every declared [[secret]]
 skyzen completions fish
 ```
 
@@ -887,39 +888,7 @@ There are three different environments. They are not interchangeable:
 |---|---|
 | `url_env = "CACHE_URL"` | The **name** of a variable the native process reads after it starts |
 | `id = "${CACHE_NAMESPACE_ID}"` | A **deploy-time** placeholder. The CLI expands it before generating `wrangler.toml` |
-| `skyzen secret set API_KEY` | A **Worker secret**. `[cloudflare.vars]` is plaintext and committed; do not put credentials there |
-
-### Local
-
-`skyzen new` writes `.env.example` from the manifest and gitignores `.env`, `.env.local`, and
-wrangler's `.dev.vars`. Copy the example, fill it in, and run:
-
-```sh
-cp .env.example .env
-skyzen dev
-```
-
-`.env.local` overrides `.env`. A variable already in the process environment wins over both.
-`skyzen dev` refuses to start when a name the native wiring declared is set nowhere.
-
-### `Skyzen.toml`
-
-String values may contain `${NAME}` placeholders. The CLI expands them from the process
-environment, then from `.env` / `.env.local`, when it reads the file — including `skyzen deploy`,
-`skyzen provision`, and `skyzen doctor`. A missing name fails the load, naming the TOML path.
-
-```toml
-[cloudflare]
-account_id = "${CLOUDFLARE_ACCOUNT_ID}"
-
-[[cloudflare.kv_namespaces]]
-binding = "CACHE"
-id = "${CACHE_NAMESPACE_ID}"
-```
-
-`CLOUDFLARE_API_TOKEN` stays out of the file: wrangler reads it from the environment (and from
-`.env`) on its own. Do not wrap `url_env`, `binding`, or service names in `${}` — those are
-consumed at compile time as literal names.
+| `[[secret]] name = "API_KEY"` | A **portable secret**. `skyzen deploy` delivers it, and `import_config!` generates the `ApiKey` type a handler asks for. `[cloudflare.vars]` is plaintext and committed; do not put credentials there |
 
 ### GitHub Actions
 
@@ -951,11 +920,12 @@ jobs:
 
       - name: Deploy to Cloudflare
         run: skyzen deploy --provider cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
-`DEPLOY_ENV` is the body of `.env` (multi-line), not a single key. The CLI interpolates from that
-file; wrangler picks up `CLOUDFLARE_API_TOKEN` from it the same way. If the job already exports
-variables in the process environment, those win over `.env`.
+`DEPLOY_ENV` is the body of `.env` (multi-line), not a single key. `CLOUDFLARE_API_TOKEN` is
+wrangler's own credential rather than one of the application's: export it in the job's `env:`.
 
 To target a named environment overlay (e.g. `[cloudflare.env.staging]`), pair GitHub Actions
 Environments with the `--env` flag:
@@ -970,15 +940,9 @@ jobs:
       - run: skyzen deploy --provider cloudflare --env staging
 ```
 
-### What the CLI refuses
-
-A documented credential form stored as a literal in `Skyzen.toml` (a GitHub PAT, a PEM private key,
-a URL with a password, an `AKIA…` access key id) fails the load. So does a git checkout that is
-**tracking** `.env`, `.env.local`, or `.dev.vars`. A `vars` / `[aws.env]` key whose *name* looks
-like a secret but whose value is not a known form is a warning, not a hard failure. Errors name
-the path and the kind; they never print the value.
-
-The syntax and the merge rules are in the [Skyzen.toml reference](docs/skyzen-toml-reference.md#deploy-time-interpolation).
+Declaring a secret, where a value is looked up, what each provider delivers and what the CLI
+refuses to load are all in [Secrets](docs/skyzen-toml-reference.md#secrets) and
+[Deploy-time interpolation](docs/skyzen-toml-reference.md#deploy-time-interpolation).
 
 ---
 
@@ -987,8 +951,8 @@ The syntax and the merge rules are in the [Skyzen.toml reference](docs/skyzen-to
 | Crate | Path | Description |
 |---|---|---|
 | [`skyzen`](.) | Root | Routing, extractors, responders, middleware, static files, WebSockets, runtime |
-| [`skyzen-core`](core/) | `core/` | `Extractor`, `Responder`, `Middleware`, `Server`, the error types; `no_std`-capable |
-| [`skyzen-macros`](macros/) | `macros/` | `#[skyzen::main]`, `#[skyzen::error]`, `#[skyzen::openapi]`, `#[skyzen::queue]`, `#[skyzen::test]`, `embed_migrations!`, … |
+| [`skyzen-core`](core/) | `core/` | `Extractor`, `Responder`, `Middleware`, `Server`, `Secret`, the error types; `no_std`-capable |
+| [`skyzen-macros`](macros/) | `macros/` | `#[skyzen::main]`, `#[skyzen::error]`, `#[skyzen::openapi]`, `#[skyzen::queue]`, `#[skyzen::test]`, `import_config!` (services, databases and `[[secret]]` types), `embed_migrations!`, … |
 | [`skyzen-manifest`](manifest/) | `manifest/` | The one typed `Skyzen.toml` schema, shared by the macros and the CLI |
 | [`skyzen-services`](services/) | `services/` | The portable capabilities: `Kv`, `Storage`, `Queue`, `Db`, migrations, durable variants |
 | [`skyzen-test`](test/) | `test/` | `TestClient`, `TestContext`, in-memory backends, assertions, `insta` snapshots |
@@ -996,11 +960,11 @@ The syntax and the merge rules are in the [Skyzen.toml reference](docs/skyzen-to
 | [`skyzen-lambda`](lambda/) | `lambda/` | AWS Lambda adapter — HTTP invocations and SQS batches (root crate's `lambda` feature) |
 | [`skyzen-redis`](redis/) | `redis/` | Redis `KeyValueStore` |
 | [`skyzen-s3`](s3/) | `s3/` | S3-compatible `ObjectStorage` |
-| [`skyzen-cloudflare`](cloudflare/) | `cloudflare/` | Workers KV, R2, Queues, D1, Durable Objects, secrets store, `request.cf` (*wasm32 only*) |
-| [`skyzen-cloudflare-admin`](cloudflare-admin/) | `cloudflare-admin/` | Cloudflare REST client, used by `skyzen provision` |
+| [`skyzen-cloudflare`](cloudflare/) | `cloudflare/` | Workers KV, R2, Queues, D1, Durable Objects, `CfSecret`, `request.cf` (*wasm32 only*) |
+| [`skyzen-cloudflare-admin`](cloudflare-admin/) | `cloudflare-admin/` | Shared Cloudflare API response envelopes and token-source types for tools that call the control-plane API |
 | [`skyzen-aws`](aws/) | `aws/` | `DynamoKv`, `SqsQueue`, `RdsDataDb`, and `S3Storage` re-exported |
 | [`skyzen-azure`](azure/) | `azure/` | `CosmosKv`, `AzureBlob`, `ServiceBusQueue`, `AzureStorageQueue`, `AzureSqlDb` |
-| [`skyzen-cli`](cli/) | `cli/` | The `skyzen` binary: scaffolding, local emulation, provisioning, migrations, deployment |
+| [`skyzen-cli`](cli/) | `cli/` | The `skyzen` binary: scaffolding, local emulation, provisioning, migrations, secret delivery, deployment |
 
 ---
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,15 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 askama = "0.16"
+# The Lambda environment is delivered in-process rather than through `cargo lambda`, so a value
+# never reaches a command line. Same feature selection as `skyzen-aws`, so the workspace resolves
+# one HTTP stack: the SDK default `rustls` feature pulls the legacy connector (rustls 0.21 /
+# hyper-rustls 0.24) alongside the modern `default-https-client`, and carries unpatched advisories.
+aws-config = "1"
+aws-sdk-lambda = { version = "1", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 ctrlc = "3.5"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,6 +34,9 @@ ignore = "0.4"
 notify-debouncer-full = "0.4"
 pathdiff = "0.2"
 regex = "1"
+# The Azure app settings are read and written over ARM, which has no Rust SDK for the Web Apps
+# provider; same rustls-only selection as `skyzen-azure` so the workspace resolves one TLS stack.
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ ignore = "0.4"
 notify-debouncer-full = "0.4"
 pathdiff = "0.2"
 regex = "1"
+secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 skyzen-manifest.workspace = true

--- a/cli/README.md
+++ b/cli/README.md
@@ -152,8 +152,13 @@ skyzen deploy --provider cloudflare --dry-run   # real build, `wrangler deploy -
 skyzen logs
 skyzen logs -- --format json     # forwarded to `wrangler tail`
 skyzen secret set API_KEY        # value read from stdin
-skyzen secret list
+skyzen secret push               # deliver every declared [[secret]], no rebuild
+skyzen secret list               # names only
 ```
+
+`skyzen secret` works on Cloudflare, AWS and Azure, on the names `[[secret]]` declares; an
+undeclared name is refused rather than uploaded, and no value reaches a command line. See
+[Secrets](../docs/skyzen-toml-reference.md#secrets).
 
 ### `skyzen completions`
 
@@ -180,9 +185,9 @@ Global flags are accepted before or after the subcommand.
 | Provider | `dev` | `deploy` | Generated Config |
 |----------|-------|----------|-----------------|
 | Native | `cargo run` with Skyzen watch/restart | — | none |
-| Cloudflare | wasm build + `wrangler dev --local`, rebuilt on change | `wrangler deploy` | `.skyzen/gen/wrangler.toml`, `dist/worker.js`, `dist/worker_bg.js`, `dist/worker_bg.wasm` |
-| AWS | — (run it as a server with `skyzen dev`) | `cargo lambda build` then `cargo lambda deploy`, with the flags derived from `[aws]` | none |
-| Azure | — (`func start` over a built bundle) | `func azure functionapp publish` | `.skyzen/gen/azure/{host.json, local.settings.json, <function>/function.json}` plus the staged binary |
+| Cloudflare | wasm build + `wrangler dev --local`, rebuilt on change | `wrangler deploy`, then the classic secrets through `wrangler secret bulk` | `.skyzen/gen/wrangler.toml`, `.skyzen/gen/.dev.vars`, `dist/worker.js`, `dist/worker_bg.js`, `dist/worker_bg.wasm` |
+| AWS | — (run it as a server with `skyzen dev`) | `cargo lambda build` then `cargo lambda deploy`, with the flags derived from `[aws]`, then the function environment | none |
+| Azure | — (`func start` over a built bundle) | `func azure functionapp publish`, then the app settings | `.skyzen/gen/azure/{host.json, local.settings.json, <function>/function.json}` plus the staged binary |
 
 ## Skyzen.toml
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -5,6 +5,7 @@
 //! a bespoke parser has to reimplement one at a time.
 
 use clap::{Parser, Subcommand, ValueEnum};
+use skyzen_manifest::VarName;
 use std::path::PathBuf;
 
 /// Unified local emulation and deployment CLI for Skyzen.
@@ -138,14 +139,22 @@ pub enum MigrateCommand {
 }
 
 /// The `skyzen secret` operations.
+///
+/// Every one of them works on a name the manifest declares as `[[secret]]`: the CLI has no notion
+/// of a secret the application does not read, and a typo is refused rather than uploaded.
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum SecretCommand {
-    /// Set a secret, reading its value from stdin.
+    /// Set one secret, reading its value from this command's standard input.
     Set {
-        /// The secret's name, as seen from `env` in the Worker.
-        name: String,
+        /// The secret's name, as declared by a `[[secret]]` entry.
+        name: VarName,
     },
-    /// List the secrets the deployed Worker has.
+    /// Deliver every declared secret's local value to the deployment.
+    ///
+    /// The same delivery `skyzen deploy` performs, without rebuilding: the values come from the
+    /// process environment and the project's `.env` files, and a missing one is refused.
+    Push,
+    /// List the secrets the deployment has.
     List,
 }
 
@@ -377,6 +386,31 @@ mod tests {
     fn an_unknown_migrate_subcommand_is_rejected() {
         Cli::try_parse_from(["skyzen", "migrate", "rollback"])
             .expect_err("there is no rollback; migrations are forward-only");
+    }
+
+    #[test]
+    fn a_secret_is_named_by_an_environment_variable_name_or_it_is_not_named() {
+        let parsed = parse(&["skyzen", "secret", "set", "STRIPE_KEY"]);
+        let Command::Secret { command } = parsed.command else {
+            panic!("expected `secret`");
+        };
+        assert_eq!(
+            command,
+            super::SecretCommand::Set {
+                name: "STRIPE_KEY".parse().expect("a name")
+            }
+        );
+
+        // The manifest's rule, applied by the parser: a name an operating system would not accept
+        // is refused before anything is read from standard input.
+        Cli::try_parse_from(["skyzen", "secret", "set", "STRIPE-KEY"])
+            .expect_err("not an environment variable name");
+
+        let push = parse(&["skyzen", "secret", "push"]);
+        let Command::Secret { command } = push.command else {
+            panic!("expected `secret`");
+        };
+        assert_eq!(command, super::SecretCommand::Push);
     }
 
     #[test]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -109,7 +109,7 @@ pub enum Command {
         wrangler_args: Vec<String>,
     },
 
-    /// Manage the deployed Worker's secrets.
+    /// Manage the deployed application's secrets, on Cloudflare, AWS or Azure.
     Secret {
         /// The secret operation to perform.
         #[command(subcommand)]
@@ -142,6 +142,10 @@ pub enum MigrateCommand {
 ///
 /// Every one of them works on a name the manifest declares as `[[secret]]`: the CLI has no notion
 /// of a secret the application does not read, and a typo is refused rather than uploaded.
+///
+/// All three work on every cloud provider — `wrangler` on Cloudflare, the function environment on
+/// AWS, the application settings on Azure — and none of them puts a value on a command line. See
+/// `docs/skyzen-toml-reference.md#secrets`.
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum SecretCommand {
     /// Set one secret, reading its value from this command's standard input.
@@ -154,7 +158,7 @@ pub enum SecretCommand {
     /// The same delivery `skyzen deploy` performs, without rebuilding: the values come from the
     /// process environment and the project's `.env` files, and a missing one is refused.
     Push,
-    /// List the secrets the deployment has.
+    /// List the names the deployment has. Never a value: no command prints one.
     List,
 }
 

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -216,7 +216,7 @@ fn watch_paths(root: &Path) -> Vec<PathBuf> {
         root.join("Cargo.toml"),
     ];
     // An edited `.env` changes what the child sees, so it belongs in the watch set too.
-    candidates.extend(environment::dotenv_paths(root));
+    candidates.extend(environment::Environment::paths(root));
 
     candidates.retain(|path| path.exists());
     candidates.sort();

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -7,14 +7,14 @@
 
 use crate::{
     environment, output,
-    providers::{ArtifactBuild, CommandPlan, RunMode},
+    providers::{self, CommandPlan, RunMode, Task},
 };
 use anyhow::{Context, Result};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use std::{
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::Child,
     sync::mpsc::{self, RecvTimeoutError},
     time::Duration,
 };
@@ -40,7 +40,7 @@ pub struct Supervision<'a> {
     /// The process to run.
     pub command: &'a CommandPlan,
     /// The build to re-run under [`RunMode::Rebuild`].
-    pub build: Option<&'a dyn ArtifactBuild>,
+    pub build: Option<&'a dyn Task>,
     /// Whether a change restarts the child or re-runs the build.
     pub mode: RunMode,
     /// Environment for the child, from the project's `.env` files.
@@ -61,19 +61,7 @@ struct SupervisedChild {
 impl SupervisedChild {
     fn spawn(command: &CommandPlan, child_env: &[(String, String)]) -> Result<Self> {
         output::step(command.display());
-        let mut process = Command::new(&command.program);
-        process
-            .args(&command.args)
-            .envs(child_env.iter().map(|(key, value)| (key, value)))
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
-        if let Some(cwd) = &command.cwd {
-            process.current_dir(cwd);
-        }
-        let child = process
-            .spawn()
-            .with_context(|| format!("failed to launch {}", command.program))?;
+        let child = providers::spawn_command(command, child_env)?;
         Ok(Self { child: Some(child) })
     }
 

--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -78,7 +78,7 @@ fn collect(
     named: Vec<WiringEnvVar<'_>>,
 ) {
     variables.extend(named.into_iter().map(|variable| RequiredVariable {
-        name: variable.name.to_owned(),
+        name: variable.name.to_string(),
         declared_by: variable.key.map_or_else(
             || format!("{section} backend = \"{backend}\""),
             |key| format!("{section}.{key}"),

--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -1,69 +1,119 @@
-//! Environment variables the manifest's native wiring reads, and the `.env` files that supply them.
+//! The one resolver for the variables a deployment has to supply, and the `.env` files behind it.
 //!
-//! The variables a wiring names — `url_env`, `bucket_env`, `connection_env`, `sas_url_env` — were
-//! parsed and then discarded: only the proc-macro read them, at compile time, so declaring
-//! `url_env = "CACHE_URL"` and forgetting to export it produced a panic at the first request
-//! rather than a message at startup. `skyzen dev` now loads the `.env` files, checks the declared
-//! variables are present, and hands the result to the child process — never to the CLI's own
-//! environment, so nothing global is mutated.
+//! A manifest names variables in two ways: a `[[secret]]` entry declares one outright, and a
+//! native wiring names one through `url_env`, `bucket_env`, `connection_env`, `sas_url_env` or a
+//! backend whose constructor fixes its own names. [`runtime_variables`] collapses both into one
+//! list, and [`Environment`] is the single place that decides where a value comes from — so the
+//! CLI, `.env.example` and `skyzen doctor` cannot disagree about whether something is set.
 //!
-//! A backend whose constructor fixes its own variable names (Cosmos DB, the RDS Data API) is
-//! covered too: the section reports those names, so they reach this check and `.env.example` the
-//! same way a key-named one does.
-//!
-//! The same files, plus the process environment, fill `${NAME}` placeholders in `Skyzen.toml`
-//! itself when the CLI reads it. That is deploy-time interpolation, not the runtime environment
-//! of the deployed process. `#[skyzen::main]` does not expand them.
+//! The precedence rule between the process environment and the `.env` files is stated once, in
+//! `docs/skyzen-toml-reference.md#secrets`. The same sources fill `${NAME}` placeholders in
+//! `Skyzen.toml` when the CLI reads it, which is deploy-time interpolation and not the runtime
+//! environment of the deployed process: `#[skyzen::main]` does not expand them.
 
 use crate::{output, secret_files};
 use anyhow::{Context, Result};
 use askama::Template;
-use skyzen_manifest::{InterpolateError, Manifest, SkyzenManifest, WiringEnvVar};
+use secrecy::{ExposeSecret, SecretString};
+use skyzen_manifest::{InterpolateError, Manifest, SkyzenManifest, VarName, WiringEnvVar};
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
-/// The dotenv files loaded, in order. A later file overrides an earlier one, and both lose to a
-/// variable already present in the CLI's own environment — the usual precedence, so a one-off
-/// `CACHE_URL=... skyzen dev` still wins.
+/// The dotenv files loaded, in order. A later file overrides an earlier one.
 const DOTENV_FILES: &[&str] = &[".env", ".env.local"];
 
-/// An environment variable the manifest says a native run needs.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RequiredVariable {
-    /// The variable's name.
-    pub name: String,
-    /// The manifest key that asked for it, for the error message.
-    pub declared_by: String,
+/// What a runtime variable is for, which decides which providers need it delivered.
+///
+/// A Worker backs its services with bindings rather than connection strings, so it never wants a
+/// [`Wiring`](VariableKind::Wiring) variable; the Lambda and Functions binaries *are* the native
+/// binary, so they want both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum VariableKind {
+    /// A `[[secret]]` entry: a value the deployment delivers, never written to the manifest.
+    Secret,
+    /// A variable a native wiring reads to reach its backend.
+    Wiring,
 }
 
-/// Every environment variable the manifest's native wiring reads at startup.
-pub fn required_variables(manifest: &SkyzenManifest) -> Vec<RequiredVariable> {
-    let mut variables = Vec::new();
-    let Some(native) = &manifest.native else {
-        return variables;
-    };
+impl VariableKind {
+    /// Both kinds, for a provider that runs the native binary.
+    pub const ALL: &'static [Self] = &[Self::Secret, Self::Wiring];
 
-    for (name, service) in &native.service {
-        collect(
-            &mut variables,
-            &format!("[native.service.{name}]"),
-            service.backend().as_str(),
-            service.env_vars(),
-        );
+    /// How the kind is spelled in a report.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Secret => "secret",
+            Self::Wiring => "wiring",
+        }
     }
-    for (name, database) in &native.database {
-        collect(
-            &mut variables,
-            &format!("[native.database.{name}]"),
-            database.backend().as_str(),
-            database.env_vars(),
-        );
+}
+
+/// An environment variable the manifest says the running application needs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RuntimeVariable {
+    /// The variable's name.
+    pub name: VarName,
+    /// The manifest entry that asked for it, for the error message.
+    pub declared_by: String,
+    /// What it is for.
+    pub kind: VariableKind,
+}
+
+/// Every environment variable the manifest declares for a running application.
+///
+/// `[[secret]]` entries and native wiring variables in one list, sorted by name, because a caller
+/// that has to check "is this set" does not care which of the two shapes named it.
+#[must_use]
+pub fn runtime_variables(manifest: &SkyzenManifest) -> Vec<RuntimeVariable> {
+    let mut variables: Vec<RuntimeVariable> = manifest
+        .secret
+        .iter()
+        .map(|secret| RuntimeVariable {
+            declared_by: format!("[[secret]] {}", secret.name),
+            name: secret.name.clone(),
+            kind: VariableKind::Secret,
+        })
+        .collect();
+
+    if let Some(native) = &manifest.native {
+        for (name, service) in &native.service {
+            collect(
+                &mut variables,
+                &format!("[native.service.{name}]"),
+                service.backend().as_str(),
+                service.env_vars(),
+            );
+        }
+        for (name, database) in &native.database {
+            collect(
+                &mut variables,
+                &format!("[native.database.{name}]"),
+                database.backend().as_str(),
+                database.env_vars(),
+            );
+        }
     }
 
     variables.sort();
     variables.dedup();
+    variables
+}
+
+/// The runtime variables of the given kinds.
+///
+/// A Worker resolves its services from bindings, so it needs the secrets and nothing else; the
+/// native, Lambda and Functions binaries read both. `skyzen migrate` opens one connection, so it
+/// needs the wiring and has no business demanding a project's production secrets.
+#[must_use]
+pub fn runtime_variables_of(
+    manifest: &SkyzenManifest,
+    kinds: &[VariableKind],
+) -> Vec<RuntimeVariable> {
+    let mut variables = runtime_variables(manifest);
+    variables.retain(|variable| kinds.contains(&variable.kind));
     variables
 }
 
@@ -72,25 +122,188 @@ pub fn required_variables(manifest: &SkyzenManifest) -> Vec<RequiredVariable> {
 /// A backend that fixes its own variable names — Cosmos DB's account endpoint and key, the four
 /// the RDS Data API reads — is named instead of a key, because there is no key to correct.
 fn collect(
-    variables: &mut Vec<RequiredVariable>,
+    variables: &mut Vec<RuntimeVariable>,
     section: &str,
     backend: &str,
     named: Vec<WiringEnvVar<'_>>,
 ) {
-    variables.extend(named.into_iter().map(|variable| RequiredVariable {
-        name: variable.name.to_string(),
+    variables.extend(named.into_iter().map(|variable| RuntimeVariable {
+        name: variable.name.clone(),
         declared_by: variable.key.map_or_else(
             || format!("{section} backend = \"{backend}\""),
             |key| format!("{section}.{key}"),
         ),
+        kind: VariableKind::Wiring,
     }));
 }
 
-/// Read `Skyzen.toml`, expanding `${NAME}` from the process environment and then `.env` files.
+/// The values a project's `.env` files hold, and the rule for reading one.
 ///
-/// Process environment wins, matching [`ensure_available`]: a one-off
-/// `CACHE_ID=... skyzen deploy` still overrides `.env`. The CLI's own environment is never
-/// mutated.
+/// Loaded once per command: every caller that needs a value — the interpolator, `skyzen dev`'s
+/// child environment, `skyzen migrate`'s connection URL, `skyzen doctor`'s report — asks this
+/// rather than reaching for `std::env` and a `BTreeMap` of its own.
+#[derive(Debug, Clone, Default)]
+pub struct Environment {
+    /// `.env` then `.env.local`, later wins.
+    dotenv: BTreeMap<String, String>,
+}
+
+impl Environment {
+    /// Load the project's dotenv files.
+    ///
+    /// # Errors
+    ///
+    /// Fails when a dotenv file exists but cannot be read or parsed — a silently ignored typo in
+    /// `.env` is exactly the mystery this whole module exists to remove.
+    pub fn load(root: &Path) -> Result<Self> {
+        let mut dotenv = BTreeMap::new();
+        for file in DOTENV_FILES {
+            let path = root.join(file);
+            if !path.exists() {
+                continue;
+            }
+            let entries = dotenvy::from_path_iter(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            for entry in entries {
+                let (key, value) =
+                    entry.with_context(|| format!("failed to parse {}", path.display()))?;
+                dotenv.insert(key, value);
+            }
+        }
+        Ok(Self { dotenv })
+    }
+
+    /// The value of one variable: the process environment first, then the dotenv files.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the process environment holds the name with a value that is not Unicode, which
+    /// is a broken value rather than an absent one and must not be read as "unset".
+    pub fn get(&self, name: &str) -> Result<Option<SecretString>, InterpolateError> {
+        Ok(skyzen_manifest::process_env(name)?
+            .or_else(|| self.dotenv.get(name).cloned())
+            .map(SecretString::from))
+    }
+
+    /// The lookup `Manifest::load_with` expands `${NAME}` through.
+    ///
+    /// An interpolated value is by definition not a secret: it is written into the generated
+    /// `wrangler.toml` or an ARM request, so it hands back a plain `String`.
+    pub fn lookup(&self) -> impl Fn(&str) -> Result<Option<String>, InterpolateError> + '_ {
+        move |name: &str| {
+            Ok(skyzen_manifest::process_env(name)?.or_else(|| self.dotenv.get(name).cloned()))
+        }
+    }
+
+    /// The dotenv entries a child process should be started with.
+    ///
+    /// Only the ones the process environment does not already hold: `Command::envs` overrides what
+    /// the child inherits, so handing it the whole map would let `.env` beat a one-off
+    /// `CACHE_URL=... skyzen dev` — the precedence backwards from everywhere else.
+    #[must_use]
+    pub fn child_overrides(&self) -> Vec<(String, String)> {
+        self.dotenv
+            .iter()
+            .filter(|(name, _)| std::env::var_os(name).is_none())
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect()
+    }
+
+    /// Resolve every declared variable, or fail naming all the ones that are missing.
+    ///
+    /// All-or-nothing: a deployment that ships half its configuration fails at cold start, where
+    /// the message is a panic in a log rather than a list of manifest keys.
+    ///
+    /// # Errors
+    ///
+    /// Fails listing every missing variable and the manifest entry that declared it, or when a
+    /// value in the process environment is not Unicode.
+    pub fn resolve(&self, variables: &[RuntimeVariable]) -> Result<ResolvedVariables> {
+        let mut resolved = BTreeMap::new();
+        let mut missing = Vec::new();
+
+        for variable in variables {
+            match self.get(variable.name.as_str())? {
+                Some(value) => {
+                    resolved.insert(variable.name.clone(), value);
+                }
+                None => missing.push(variable),
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(ResolvedVariables(resolved));
+        }
+
+        let details = missing
+            .iter()
+            .map(|variable| format!("  {} (declared by {})", variable.name, variable.declared_by))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "Skyzen.toml declares environment variables that are not set and are in no .env file:\n\
+             {details}\n\
+             Set them in the environment, or add them to .env (see .env.example)."
+        )
+    }
+
+    /// The dotenv files that exist, for the watcher to notice edits to.
+    #[must_use]
+    pub fn paths(root: &Path) -> Vec<PathBuf> {
+        DOTENV_FILES
+            .iter()
+            .map(|file| root.join(file))
+            .filter(|path| path.exists())
+            .collect()
+    }
+}
+
+/// An [`Environment`] holding exactly `contents`, for tests across the crate.
+///
+/// It goes through the real loader — a temporary `.env` parsed by `dotenvy` — so a test cannot
+/// accidentally exercise a map the CLI would never have produced.
+#[cfg(test)]
+pub fn from_dotenv(contents: &str) -> Environment {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(dir.path().join(DOTENV_FILES[0]), contents).expect("write .env");
+    Environment::load(dir.path()).expect("load")
+}
+
+/// Every declared variable with the value that was found for it.
+///
+/// The values stay wrapped, so a provider that puts one on a command line or in a log has to write
+/// `expose_secret()` to do it — which is what makes the leak visible in a diff.
+#[derive(Debug, Default)]
+pub struct ResolvedVariables(BTreeMap<VarName, SecretString>);
+
+impl ResolvedVariables {
+    /// The variables, in name order.
+    pub fn iter(&self) -> impl Iterator<Item = (&VarName, &SecretString)> {
+        self.0.iter()
+    }
+
+    /// The names alone, which is all a report may print.
+    pub fn names(&self) -> impl Iterator<Item = &VarName> {
+        self.0.keys()
+    }
+
+    /// Whether nothing was declared.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'a> IntoIterator for &'a ResolvedVariables {
+    type Item = (&'a VarName, &'a SecretString);
+    type IntoIter = std::collections::btree_map::Iter<'a, VarName, SecretString>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+/// Read `Skyzen.toml`, expanding `${NAME}` from the process environment and then `.env` files.
 ///
 /// # Errors
 ///
@@ -98,6 +311,18 @@ fn collect(
 /// credential form is stored as a literal, a dotenv file is tracked by git, a dotenv file is
 /// malformed, or the document does not match the schema.
 pub fn load_manifest(path: &Path) -> Result<Manifest> {
+    Ok(load_manifest_with(path)?.0)
+}
+
+/// Read `Skyzen.toml` and hand back the [`Environment`] it was read through.
+///
+/// The dotenv files are read once per command: a caller that also has to resolve runtime variables
+/// takes the environment from here rather than loading the same files a second time.
+///
+/// # Errors
+///
+/// As [`load_manifest`].
+pub fn load_manifest_with(path: &Path) -> Result<(Manifest, Environment)> {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
@@ -106,9 +331,11 @@ pub fn load_manifest(path: &Path) -> Result<Manifest> {
             .join(path)
     };
     let root_dir = absolute.parent().unwrap_or_else(|| Path::new("."));
-    let dotenv = load_dotenv_files(root_dir)?;
-    let lookup = |name: &str| lookup_var(name, &dotenv);
-    let manifest = Manifest::load_with(&absolute, Some(&lookup))?;
+    let environment = Environment::load(root_dir)?;
+    let manifest = {
+        let lookup = environment.lookup();
+        Manifest::load_with(&absolute, Some(&lookup))?
+    };
     for finding in manifest.secret_warnings() {
         output::warn(format!(
             "{finding}; if this is a secret, use a ${{NAME}} placeholder or `skyzen secret set`"
@@ -117,72 +344,7 @@ pub fn load_manifest(path: &Path) -> Result<Manifest> {
     for warning in secret_files::ensure(root_dir)? {
         output::warn(warning);
     }
-    Ok(manifest)
-}
-
-/// Process environment first, then the dotenv map. Invalid Unicode fails rather than skipping.
-fn lookup_var(
-    name: &str,
-    dotenv: &BTreeMap<String, String>,
-) -> Result<Option<String>, InterpolateError> {
-    Ok(skyzen_manifest::process_env(name)?.or_else(|| dotenv.get(name).cloned()))
-}
-
-/// The variables loaded from the project's `.env` files.
-///
-/// # Errors
-///
-/// Fails when a dotenv file exists but cannot be read or parsed — a silently ignored typo in
-/// `.env` is exactly the mystery this whole module exists to remove.
-pub fn load_dotenv_files(root_dir: &Path) -> Result<BTreeMap<String, String>> {
-    let mut loaded = BTreeMap::new();
-    for file in DOTENV_FILES {
-        let path = root_dir.join(file);
-        if !path.exists() {
-            continue;
-        }
-        let entries = dotenvy::from_path_iter(&path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        for entry in entries {
-            let (key, value) =
-                entry.with_context(|| format!("failed to parse {}", path.display()))?;
-            loaded.insert(key, value);
-        }
-    }
-    Ok(loaded)
-}
-
-/// Fail when a variable the manifest declares is available from neither the environment nor the
-/// dotenv files.
-///
-/// # Errors
-///
-/// Fails listing every missing variable and the manifest key that declared it.
-pub fn ensure_available(
-    required: &[RequiredVariable],
-    dotenv: &BTreeMap<String, String>,
-) -> Result<()> {
-    let missing: Vec<&RequiredVariable> = required
-        .iter()
-        .filter(|variable| {
-            !dotenv.contains_key(&variable.name) && std::env::var_os(&variable.name).is_none()
-        })
-        .collect();
-
-    if missing.is_empty() {
-        return Ok(());
-    }
-
-    let details = missing
-        .iter()
-        .map(|variable| format!("  {} (declared by {})", variable.name, variable.declared_by))
-        .collect::<Vec<_>>()
-        .join("\n");
-    anyhow::bail!(
-        "Skyzen.toml declares environment variables that are not set and are in no .env file:\n\
-         {details}\n\
-         Set them in the environment, or add them to .env (see .env.example)."
-    )
+    Ok((manifest, environment))
 }
 
 /// Render the `.env.example` a scaffolded project ships.
@@ -191,35 +353,39 @@ pub fn ensure_available(
 ///
 /// Fails only when the template itself cannot render.
 pub fn render_example(manifest: &SkyzenManifest) -> Result<String> {
-    EnvExampleTemplate {
-        variables: required_variables(manifest),
-    }
-    .render()
-    .context("failed to render .env.example")
+    let mut variables = runtime_variables(manifest);
+    // Secrets first: they are the ones a first run has to be told about, and the wiring variables
+    // usually already have a value in the developer's shell.
+    variables.sort_by(|left, right| {
+        left.kind
+            .cmp(&right.kind)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    EnvExampleTemplate { variables }
+        .render()
+        .context("failed to render .env.example")
 }
 
 #[derive(Template)]
 #[template(path = "env.example.tmpl", escape = "none")]
 struct EnvExampleTemplate {
-    variables: Vec<RequiredVariable>,
+    variables: Vec<RuntimeVariable>,
 }
 
-/// The dotenv files, for the watcher to notice edits to.
-pub fn dotenv_paths(root_dir: &Path) -> Vec<PathBuf> {
-    DOTENV_FILES
-        .iter()
-        .map(|file| root_dir.join(file))
-        .filter(|path| path.exists())
-        .collect()
+/// Expose a resolved value at the one place that sends it somewhere.
+///
+/// A free function rather than a method so that every exposure reads the same way in a diff.
+#[must_use]
+pub fn expose(value: &SecretString) -> &str {
+    value.expose_secret()
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ensure_available, load_dotenv_files, load_manifest, render_example, required_variables,
+        from_dotenv, load_manifest, render_example, runtime_variables, Environment, VariableKind,
     };
-    use skyzen_manifest::Manifest;
-    use std::collections::BTreeMap;
+    use skyzen_manifest::{Manifest, VarName};
 
     fn manifest(source: &str) -> skyzen_manifest::SkyzenManifest {
         Manifest::parse(source, "Skyzen.toml", ".")
@@ -235,17 +401,32 @@ mod tests {
          [native.service.uploads]\nbackend = \"s3\"\nbucket_env = \"UPLOADS_BUCKET\"\n\n\
          [native.database.main]\nbackend = \"postgres\"\nurl_env = \"DATABASE_URL\"\n";
 
+    /// A name no test machine has exported, so "unset" means unset.
+    const UNSET: &str = "SKYZEN_TEST_DEFINITELY_UNSET";
+
     #[test]
     fn collects_every_declared_variable_with_the_key_that_declared_it() {
-        let variables = required_variables(&manifest(WIRED));
+        let variables = runtime_variables(&manifest(WIRED));
         let names: Vec<_> = variables.iter().map(|v| v.name.as_str()).collect();
         assert_eq!(names, ["CACHE_URL", "DATABASE_URL", "UPLOADS_BUCKET"]);
         assert!(variables[0].declared_by.contains("[native.service.cache]"));
+        assert!(variables.iter().all(|v| v.kind == VariableKind::Wiring));
+    }
+
+    #[test]
+    fn a_declared_secret_is_a_runtime_variable_naming_its_entry() {
+        let variables = runtime_variables(&manifest(
+            "[[secret]]\nname = \"STRIPE_KEY\"\n\n[[secret]]\nname = \"JWT_SIGNING_KEY\"\n",
+        ));
+        let names: Vec<_> = variables.iter().map(|v| v.name.as_str()).collect();
+        assert_eq!(names, ["JWT_SIGNING_KEY", "STRIPE_KEY"]);
+        assert!(variables.iter().all(|v| v.kind == VariableKind::Secret));
+        assert_eq!(variables[1].declared_by, "[[secret]] STRIPE_KEY");
     }
 
     #[test]
     fn a_backend_that_fixes_its_own_variables_names_the_backend_rather_than_a_key() {
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(
             "[[service]]\nname = \"sessions\"\ntype = \"kv\"\n\n\
              [native.service.sessions]\nbackend = \"cosmos\"\n\
              database = \"appdb\"\ncontainer = \"sessions\"\n\n\
@@ -279,7 +460,7 @@ mod tests {
     fn an_rds_data_wiring_that_names_its_values_declares_no_variables_to_set() {
         // The manifest replaced the four variables, so demanding them would refuse to start a
         // deployment whose configuration is complete.
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(
             "[[database]]\nname = \"main\"\ntype = \"sql\"\n\n\
              [native.database.main]\nbackend = \"rds-data\"\n\
              resource_arn = \"arn:aws:rds:us-east-1:111122223333:cluster:skyzen\"\n\
@@ -291,7 +472,7 @@ mod tests {
 
     #[test]
     fn an_azure_sql_wiring_declares_the_variable_holding_its_connection_string() {
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(
             "[[database]]\nname = \"main\"\ntype = \"sql\"\n\n\
              [native.database.main]\nbackend = \"azure-sql\"\n\
              url_env = \"AZURE_SQL_CONNECTION_STRING\"\n",
@@ -303,7 +484,7 @@ mod tests {
 
     #[test]
     fn a_backend_whose_variable_the_manifest_names_reports_the_key() {
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(
             "[[service]]\nname = \"jobs\"\ntype = \"queue\"\n\n\
              [native.service.jobs]\nbackend = \"storage-queue\"\nsas_url_env = \"JOBS_SAS_URL\"\n",
         ));
@@ -319,7 +500,7 @@ mod tests {
     fn a_backend_reached_through_an_ambient_credential_chain_declares_nothing() {
         // DynamoDB's credentials and region come from the AWS chain, which has its own sources —
         // naming one of them would refuse to start on a machine using another.
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(
             "[[service]]\nname = \"sessions\"\ntype = \"kv\"\n\n\
              [native.service.sessions]\nbackend = \"dynamodb\"\ntable = \"skyzen-sessions\"\n",
         ));
@@ -328,7 +509,7 @@ mod tests {
 
     #[test]
     fn a_memory_backend_declares_nothing() {
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(
             "[[service]]\nname = \"cache\"\ntype = \"kv\"\n\n\
              [native.service.cache]\nbackend = \"memory\"\n",
         ));
@@ -336,28 +517,39 @@ mod tests {
     }
 
     #[test]
-    fn a_missing_variable_is_reported_with_its_manifest_key() {
-        let variables = required_variables(&manifest(WIRED));
-        let error = ensure_available(&variables, &BTreeMap::new()).expect_err("nothing is set");
+    fn resolve_lists_every_missing_variable_with_the_entry_that_declared_it() {
+        let variables = runtime_variables(&manifest(&format!(
+            "[[secret]]\nname = \"{UNSET}\"\n\n{WIRED}"
+        )));
+        let error = Environment::default()
+            .resolve(&variables)
+            .expect_err("nothing is set");
         let rendered = error.to_string();
         assert!(rendered.contains("CACHE_URL"), "{rendered}");
+        assert!(rendered.contains("UPLOADS_BUCKET"), "{rendered}");
+        assert!(rendered.contains("DATABASE_URL"), "{rendered}");
         assert!(
             rendered.contains("[native.service.cache].url_env"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(&format!("[[secret]] {UNSET}")),
             "{rendered}"
         );
     }
 
     #[test]
     fn a_dotenv_entry_satisfies_a_declared_variable() {
-        let variables = required_variables(&manifest(
+        let variables = runtime_variables(&manifest(&format!(
             "[[service]]\nname = \"cache\"\ntype = \"kv\"\n\n\
-             [native.service.cache]\nbackend = \"redis\"\nurl_env = \"SKYZEN_TEST_CACHE_URL\"\n",
-        ));
-        let dotenv = BTreeMap::from([(
-            "SKYZEN_TEST_CACHE_URL".to_owned(),
-            "redis://127.0.0.1:6379".to_owned(),
-        )]);
-        ensure_available(&variables, &dotenv).expect("the dotenv entry supplies it");
+             [native.service.cache]\nbackend = \"redis\"\nurl_env = \"{UNSET}\"\n"
+        )));
+        let environment = from_dotenv(&format!("{UNSET}=redis://127.0.0.1:6379\n"));
+        let resolved = environment
+            .resolve(&variables)
+            .expect("the dotenv entry supplies it");
+        let names: Vec<_> = resolved.names().map(VarName::as_str).collect();
+        assert_eq!(names, [UNSET]);
     }
 
     #[test]
@@ -366,9 +558,46 @@ mod tests {
         std::fs::write(dir.path().join(".env"), "SHARED=base\nONLY_BASE=1\n").expect("write .env");
         std::fs::write(dir.path().join(".env.local"), "SHARED=local\n").expect("write .env.local");
 
-        let loaded = load_dotenv_files(dir.path()).expect("load");
-        assert_eq!(loaded["SHARED"], "local");
-        assert_eq!(loaded["ONLY_BASE"], "1");
+        let environment = Environment::load(dir.path()).expect("load");
+        assert_eq!(
+            super::expose(&environment.get("SHARED").expect("read").expect("set")),
+            "local"
+        );
+        assert_eq!(
+            super::expose(&environment.get("ONLY_BASE").expect("read").expect("set")),
+            "1"
+        );
+    }
+
+    #[test]
+    fn the_process_environment_beats_the_dotenv_files() {
+        const NAME: &str = "SKYZEN_TEST_PROCESS_WINS";
+        // SAFETY: single-threaded test process, and the variable is unique to this test.
+        unsafe { std::env::set_var(NAME, "from_process") };
+        let environment = from_dotenv(&format!("{NAME}=from_dotenv\n"));
+
+        assert_eq!(
+            super::expose(&environment.get(NAME).expect("read").expect("set")),
+            "from_process"
+        );
+        assert!(
+            !environment
+                .child_overrides()
+                .iter()
+                .any(|(name, _)| name == NAME),
+            "a name the process environment already holds must not be overridden for the child"
+        );
+
+        unsafe { std::env::remove_var(NAME) };
+    }
+
+    #[test]
+    fn child_overrides_carry_the_names_the_process_environment_lacks() {
+        let environment = from_dotenv(&format!("{UNSET}=from_dotenv\n"));
+        assert_eq!(
+            environment.child_overrides(),
+            vec![(UNSET.to_owned(), "from_dotenv".to_owned())]
+        );
     }
 
     #[test]
@@ -384,9 +613,22 @@ mod tests {
     }
 
     #[test]
+    fn the_example_lists_declared_secrets_before_the_wiring_variables() {
+        let rendered = render_example(&manifest(&format!(
+            "[[secret]]\nname = \"STRIPE_KEY\"\n\n{WIRED}"
+        )))
+        .expect("render");
+        assert!(rendered.contains("STRIPE_KEY="), "{rendered}");
+        assert!(rendered.contains("# [[secret]] STRIPE_KEY"), "{rendered}");
+        let secret = rendered.find("STRIPE_KEY=").expect("the secret");
+        let wiring = rendered.find("CACHE_URL=").expect("the wiring variable");
+        assert!(secret < wiring, "{rendered}");
+    }
+
+    #[test]
     fn the_example_explains_itself_when_nothing_is_declared() {
         let rendered = render_example(&manifest("")).expect("render");
-        assert!(rendered.contains("declares no native environment variables"));
+        assert!(rendered.contains("declares no runtime environment variables"));
     }
 
     #[test]

--- a/cli/src/environment.rs
+++ b/cli/src/environment.rs
@@ -380,6 +380,17 @@ pub fn expose(value: &SecretString) -> &str {
     value.expose_secret()
 }
 
+/// A second, owned handle on a resolved value.
+///
+/// `SecretString` is deliberately not `Clone`, which is what stops a value being copied about
+/// casually. A sink that has to *own* one — a command whose standard input carries it — still
+/// needs a copy, and the copy zeroizes itself like the original, so this is the one way to make
+/// one and it reads the same way in a diff as [`expose`].
+#[must_use]
+pub fn duplicate(value: &SecretString) -> SecretString {
+    SecretString::from(value.expose_secret().to_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ mod migrate;
 mod output;
 mod project;
 mod providers;
+mod runtime;
 mod scaffold;
 mod secret_files;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,7 +20,6 @@ use std::{
     fs,
     io::Write as _,
     path::{Path, PathBuf},
-    process::{Command as Process, Stdio},
 };
 
 fn main() {
@@ -160,12 +159,13 @@ fn execute(plan: &ProviderPlan, dry_run: bool) -> Result<()> {
     }
 
     if plan.run_mode == RunMode::Once {
-        return run_commands(&plan.commands, simulate, &plan.child_env);
+        return providers::run_steps(&plan.steps, simulate, &plan.child_env);
     }
 
-    let Some(command) = plan.commands.first() else {
-        anyhow::bail!("a supervised run needs at least one command");
-    };
+    // Everything a supervised process needs done first — seeding a local store, say — is a step
+    // ahead of it, and runs before it starts.
+    let (preamble, command) = plan.supervised()?;
+    providers::run_steps(preamble, simulate, &plan.child_env)?;
     if simulate {
         output::dry_run(format!("supervise {}", command.display()));
         return Ok(());
@@ -232,41 +232,6 @@ fn write_generated_file(file: &providers::GeneratedFile) -> Result<()> {
     handle
         .write_all(contents.as_bytes())
         .with_context(|| format!("failed to write {}", file.path.display()))
-}
-
-fn run_commands(
-    commands: &[providers::CommandPlan],
-    simulate: bool,
-    child_env: &[(String, String)],
-) -> Result<()> {
-    for command in commands {
-        let display = command.display();
-        if simulate {
-            output::dry_run(display);
-            continue;
-        }
-
-        output::step(&display);
-        let mut process = Process::new(&command.program);
-        process
-            .args(&command.args)
-            .envs(child_env.iter().map(|(key, value)| (key, value)))
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
-        if let Some(cwd) = &command.cwd {
-            process.current_dir(cwd);
-        }
-
-        let status = process
-            .status()
-            .with_context(|| format!("failed to launch {}", command.program))?;
-        if !status.success() {
-            anyhow::bail!("command failed with status {status}: {display}");
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,12 +13,12 @@ mod secret_files;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
-use cli::{Cli, Command};
-use providers::{Action, FileContents, ProviderPlan, RunMode};
-use secrecy::ExposeSecret as _;
+use cli::{Cli, Command, SecretCommand};
+use providers::{Action, FileContents, ProviderPlan, RunMode, SecretAction};
+use secrecy::{zeroize::Zeroize as _, ExposeSecret as _};
 use std::{
     fs,
-    io::Write as _,
+    io::{Read as _, Write as _},
     path::{Path, PathBuf},
 };
 
@@ -81,7 +81,7 @@ fn run() -> Result<()> {
                 },
             ),
         },
-        command => run_plan(&cli, &action_for(command)),
+        command => run_plan(&cli, &action_for(command)?),
     }
 }
 
@@ -111,8 +111,8 @@ fn project_root(manifest_path: &Path) -> Result<PathBuf> {
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf))
 }
 
-fn action_for(command: &Command) -> Action {
-    match command {
+fn action_for(command: &Command) -> Result<Action> {
+    Ok(match command {
         Command::Build { release } => Action::Build { release: *release },
         Command::Dev { runner_args } => Action::Dev {
             runner_args: runner_args.clone(),
@@ -121,7 +121,16 @@ fn action_for(command: &Command) -> Action {
         Command::Logs { wrangler_args } => Action::Logs {
             wrangler_args: wrangler_args.clone(),
         },
-        Command::Secret { command } => Action::Secret(command.clone()),
+        Command::Secret { command } => Action::Secret(match command {
+            // Read here rather than in a provider: every provider then delivers the same value the
+            // same way, and none of them has to know how a terminal prompts for one.
+            SecretCommand::Set { name } => SecretAction::Set {
+                name: name.clone(),
+                value: read_secret_value(name)?,
+            },
+            SecretCommand::Push => SecretAction::Push,
+            SecretCommand::List => SecretAction::List,
+        }),
         // `Migrate` belongs here too: `run` picks between the native runner and the provider plan
         // itself, and builds the `Action` on the branch that needs one.
         Command::New { .. }
@@ -132,7 +141,29 @@ fn action_for(command: &Command) -> Action {
         | Command::Completions { .. } => {
             unreachable!("handled before dispatch")
         }
+    })
+}
+
+/// Read one secret's value from the CLI's own standard input.
+///
+/// All of it, with the trailing newline a `printf`, an `echo` or a here-string leaves behind
+/// removed — the same trimming wrangler does — because a value with an accidental newline is
+/// rejected by whatever it is eventually sent to, hours later.
+fn read_secret_value(name: &skyzen_manifest::VarName) -> Result<secrecy::SecretString> {
+    let mut buffer = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buffer)
+        .with_context(|| format!("failed to read the value for `{name}` from standard input"))?;
+    let value = secrecy::SecretString::from(buffer.trim_end_matches(['\n', '\r']).to_owned());
+    buffer.zeroize();
+
+    if value.expose_secret().is_empty() {
+        anyhow::bail!(
+            "no value for `{name}` on standard input; pipe one in, as in `printf %s \"$VALUE\" | \
+             skyzen secret set {name}`"
+        );
     }
+    Ok(value)
 }
 
 fn execute(plan: &ProviderPlan, dry_run: bool) -> Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,9 +14,11 @@ mod secret_files;
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use cli::{Cli, Command};
-use providers::{Action, ProviderPlan, RunMode};
+use providers::{Action, FileContents, ProviderPlan, RunMode};
+use secrecy::ExposeSecret as _;
 use std::{
     fs,
+    io::Write as _,
     path::{Path, PathBuf},
     process::{Command as Process, Stdio},
 };
@@ -141,16 +143,10 @@ fn execute(plan: &ProviderPlan, dry_run: bool) -> Result<()> {
 
     for file in &plan.generated_files {
         if simulate {
-            output::dry_run(format!("write {}", file.path.display()));
-            println!("{}", file.contents);
+            println!("{}", dry_run_report(file));
             continue;
         }
-        if let Some(parent) = file.path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create {}", parent.display()))?;
-        }
-        fs::write(&file.path, &file.contents)
-            .with_context(|| format!("failed to write {}", file.path.display()))?;
+        write_generated_file(file)?;
         output::step(format!("wrote {}", file.path.display()));
     }
 
@@ -187,6 +183,57 @@ fn execute(plan: &ProviderPlan, dry_run: bool) -> Result<()> {
     })
 }
 
+/// What `--dry-run` says about one generated file.
+///
+/// A pure function so the promise it makes — that a secret's value never reaches stdout — is
+/// something a test can hold it to, rather than something a reader has to trust the printing code
+/// about.
+fn dry_run_report(file: &providers::GeneratedFile) -> String {
+    match &file.contents {
+        FileContents::Public(contents) => {
+            format!("[dry-run] write {}\n{contents}", file.path.display())
+        }
+        FileContents::Secret(_) => format!(
+            "[dry-run] write {} (secret values, not shown)",
+            file.path.display()
+        ),
+    }
+}
+
+/// Write one generated file, creating its directory.
+///
+/// A file holding values is created readable by its owner alone. Doing it in the `OpenOptions`
+/// rather than with a `set_permissions` afterwards means there is no window in which the values
+/// are on disk under the default mode.
+fn write_generated_file(file: &providers::GeneratedFile) -> Result<()> {
+    if let Some(parent) = file.path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let (contents, owner_only) = match &file.contents {
+        FileContents::Public(contents) => (contents.as_str(), false),
+        FileContents::Secret(secret) => (secret.expose_secret(), true),
+    };
+
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    if owner_only {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    #[cfg(not(unix))]
+    let _ = owner_only;
+
+    let mut handle = options
+        .open(&file.path)
+        .with_context(|| format!("failed to write {}", file.path.display()))?;
+    handle
+        .write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write {}", file.path.display()))
+}
+
 fn run_commands(
     commands: &[providers::CommandPlan],
     simulate: bool,
@@ -220,4 +267,34 @@ fn run_commands(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dry_run_report;
+    use crate::providers::{FileContents, GeneratedFile};
+    use std::path::PathBuf;
+
+    #[test]
+    fn a_dry_run_prints_configuration_verbatim() {
+        let report = dry_run_report(&GeneratedFile {
+            path: PathBuf::from("/tmp/app/wrangler.toml"),
+            contents: FileContents::Public("name = \"demo\"".to_owned()),
+        });
+        assert!(report.contains("write /tmp/app/wrangler.toml"), "{report}");
+        assert!(report.contains("name = \"demo\""), "{report}");
+    }
+
+    #[test]
+    fn a_dry_run_never_prints_a_value() {
+        let report = dry_run_report(&GeneratedFile {
+            path: PathBuf::from("/tmp/app/.dev.vars"),
+            contents: FileContents::Secret("STRIPE_KEY=sk_live_123".into()),
+        });
+        assert_eq!(
+            report,
+            "[dry-run] write /tmp/app/.dev.vars (secret values, not shown)"
+        );
+        assert!(!report.contains("sk_live_123"), "{report}");
+    }
 }

--- a/cli/src/migrate.rs
+++ b/cli/src/migrate.rs
@@ -17,6 +17,7 @@ use crate::{
     cli::{MigrateCommand, Provider},
     environment::{self, load_manifest_with, runtime_variables_of, Environment, VariableKind},
     output,
+    runtime::block_on,
 };
 use anyhow::{Context, Result};
 use secrecy::SecretString;
@@ -129,19 +130,13 @@ pub fn run(
         &[VariableKind::Wiring],
     ))?;
 
-    // A current-thread runtime: this is one connection doing a handful of statements, so a thread
-    // pool would be pure startup cost. `enable_all` is what gives sqlx's TCP drivers a reactor.
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("failed to start the async runtime the database drivers need")?;
-
-    runtime.block_on(async {
+    // One connection doing a handful of statements, on the CLI's own current-thread runtime.
+    block_on(async {
         for target in &targets {
             run_target(target, &environment, command).await?;
         }
         Ok(())
-    })
+    })?
 }
 
 /// Apply or report one database's migrations.

--- a/cli/src/migrate.rs
+++ b/cli/src/migrate.rs
@@ -21,7 +21,7 @@ use crate::{
 use anyhow::{Context, Result};
 use skyzen_manifest::{
     migrations::MigrationFile, DatabaseEntry, Manifest, NativeDatabaseBackend,
-    NativeDatabaseSection,
+    NativeDatabaseSection, VarName,
 };
 use skyzen_services::{Db, Migration, Migrations};
 use std::{collections::BTreeMap, path::PathBuf};
@@ -34,7 +34,7 @@ struct Target {
     /// The driver its `[native.database.<name>]` names.
     backend: NativeDatabaseBackend,
     /// The environment variable holding the connection URL.
-    url_env: String,
+    url_env: VarName,
     /// The migrations directory, resolved against the project root.
     directory: PathBuf,
     /// The files that directory holds, already validated and checksummed.
@@ -281,7 +281,7 @@ async fn connect(target: &Target, url: &str) -> Result<Db> {
 fn connection_url(target: &Target, dotenv: &BTreeMap<String, String>) -> Result<String> {
     std::env::var(&target.url_env)
         .ok()
-        .or_else(|| dotenv.get(&target.url_env).cloned())
+        .or_else(|| dotenv.get(target.url_env.as_str()).cloned())
         .with_context(|| {
             format!(
                 "{} is not set; it holds the connection URL for database `{}` \
@@ -388,7 +388,7 @@ fn target_for(
         url_env: section
             .url_env()
             .context("a database with no connection URL is not resolved into a target")?
-            .to_owned(),
+            .clone(),
         directory,
         files,
     })
@@ -398,7 +398,7 @@ fn target_for(
 mod tests {
     use super::{connection_url, dispatch, resolve_targets, run, Dispatch, Target};
     use crate::cli::{MigrateCommand, Provider};
-    use skyzen_manifest::{Manifest, NativeDatabaseBackend};
+    use skyzen_manifest::{Manifest, NativeDatabaseBackend, VarName};
     use std::{collections::BTreeMap, fs, path::Path};
 
     /// A manifest wiring one SQLite database whose URL comes from `variable`.
@@ -579,11 +579,11 @@ mod tests {
         let target = Target {
             name: "main".to_owned(),
             backend: NativeDatabaseBackend::Sqlite,
-            url_env: "SKYZEN_TEST_URL_PRECEDENCE".to_owned(),
+            url_env: VarName::from_static("SKYZEN_TEST_URL_PRECEDENCE"),
             directory: std::path::PathBuf::from("migrations"),
             files: Vec::new(),
         };
-        let dotenv = BTreeMap::from([(target.url_env.clone(), "from-dotenv".to_owned())]);
+        let dotenv = BTreeMap::from([(target.url_env.to_string(), "from-dotenv".to_owned())]);
         assert_eq!(
             connection_url(&target, &dotenv).expect("dotenv"),
             "from-dotenv"
@@ -600,7 +600,7 @@ mod tests {
         let target = Target {
             name: "main".to_owned(),
             backend: NativeDatabaseBackend::Sqlite,
-            url_env: "SKYZEN_TEST_NEVER_SET_URL".to_owned(),
+            url_env: VarName::from_static("SKYZEN_TEST_NEVER_SET_URL"),
             directory: std::path::PathBuf::from("migrations"),
             files: Vec::new(),
         };

--- a/cli/src/migrate.rs
+++ b/cli/src/migrate.rs
@@ -15,16 +15,17 @@
 
 use crate::{
     cli::{MigrateCommand, Provider},
-    environment::{ensure_available, load_dotenv_files, load_manifest, required_variables},
+    environment::{self, load_manifest_with, runtime_variables_of, Environment, VariableKind},
     output,
 };
 use anyhow::{Context, Result};
+use secrecy::SecretString;
 use skyzen_manifest::{
     migrations::MigrationFile, DatabaseEntry, Manifest, NativeDatabaseBackend,
     NativeDatabaseSection, VarName,
 };
 use skyzen_services::{Db, Migration, Migrations};
-use std::{collections::BTreeMap, path::PathBuf};
+use std::path::PathBuf;
 
 /// One `[[database]]` entry with everything the runner needs resolved.
 #[derive(Debug)]
@@ -108,7 +109,7 @@ pub fn run(
     command: Option<MigrateCommand>,
     dry_run: bool,
 ) -> Result<()> {
-    let manifest = load_manifest(manifest_path)?;
+    let (manifest, environment) = load_manifest_with(manifest_path)?;
     let targets = resolve_targets(&manifest)?;
 
     // A dry run neither connects nor creates anything: it reads and validates the directories and
@@ -120,9 +121,13 @@ pub fn run(
         return Ok(());
     }
 
-    let dotenv = load_dotenv_files(manifest.root_dir())
-        .context("failed to load the project's .env files")?;
-    ensure_available(&required_variables(manifest.data()), &dotenv)?;
+    // The wiring variables only: this opens one connection, so demanding the project's
+    // `[[secret]]` values as well would refuse to migrate from a machine that has no business
+    // holding them.
+    environment.resolve(&runtime_variables_of(
+        manifest.data(),
+        &[VariableKind::Wiring],
+    ))?;
 
     // A current-thread runtime: this is one connection doing a handful of statements, so a thread
     // pool would be pure startup cost. `enable_all` is what gives sqlx's TCP drivers a reactor.
@@ -133,7 +138,7 @@ pub fn run(
 
     runtime.block_on(async {
         for target in &targets {
-            run_target(target, &dotenv, command).await?;
+            run_target(target, &environment, command).await?;
         }
         Ok(())
     })
@@ -142,10 +147,10 @@ pub fn run(
 /// Apply or report one database's migrations.
 async fn run_target(
     target: &Target,
-    dotenv: &BTreeMap<String, String>,
+    environment: &Environment,
     command: Option<MigrateCommand>,
 ) -> Result<()> {
-    let url = connection_url(target, dotenv)?;
+    let url = connection_url(target, environment)?;
     let migrations = target.migrations();
 
     output::step(format!(
@@ -156,7 +161,7 @@ async fn run_target(
         target.directory.display()
     ));
 
-    let db = connect(target, &url).await?;
+    let db = connect(target, environment::expose(&url)).await?;
 
     match command {
         Some(MigrateCommand::Status) => report_status(target, &db, &migrations).await,
@@ -277,11 +282,11 @@ async fn connect(target: &Target, url: &str) -> Result<Db> {
     })
 }
 
-/// The connection URL for `target`, preferring the real environment over the dotenv files.
-fn connection_url(target: &Target, dotenv: &BTreeMap<String, String>) -> Result<String> {
-    std::env::var(&target.url_env)
-        .ok()
-        .or_else(|| dotenv.get(target.url_env.as_str()).cloned())
+/// The connection URL for `target`, read through the one resolver.
+fn connection_url(target: &Target, environment: &Environment) -> Result<SecretString> {
+    environment
+        .get(target.url_env.as_str())
+        .with_context(|| format!("failed to read {}", target.url_env))?
         .with_context(|| {
             format!(
                 "{} is not set; it holds the connection URL for database `{}` \
@@ -397,9 +402,12 @@ fn target_for(
 #[cfg(test)]
 mod tests {
     use super::{connection_url, dispatch, resolve_targets, run, Dispatch, Target};
-    use crate::cli::{MigrateCommand, Provider};
+    use crate::{
+        cli::{MigrateCommand, Provider},
+        environment::{expose, from_dotenv, Environment},
+    };
     use skyzen_manifest::{Manifest, NativeDatabaseBackend, VarName};
-    use std::{collections::BTreeMap, fs, path::Path};
+    use std::{fs, path::Path};
 
     /// A manifest wiring one SQLite database whose URL comes from `variable`.
     fn manifest_source(variable: &str) -> String {
@@ -583,15 +591,18 @@ mod tests {
             directory: std::path::PathBuf::from("migrations"),
             files: Vec::new(),
         };
-        let dotenv = BTreeMap::from([(target.url_env.to_string(), "from-dotenv".to_owned())]);
+        let environment = from_dotenv(&format!("{}=from-dotenv\n", target.url_env));
         assert_eq!(
-            connection_url(&target, &dotenv).expect("dotenv"),
+            expose(&connection_url(&target, &environment).expect("dotenv")),
             "from-dotenv"
         );
 
         // SAFETY: single-threaded test process, and the variable is unique to this test.
         unsafe { std::env::set_var(&target.url_env, "from-env") };
-        assert_eq!(connection_url(&target, &dotenv).expect("env"), "from-env");
+        assert_eq!(
+            expose(&connection_url(&target, &environment).expect("env")),
+            "from-env"
+        );
         unsafe { std::env::remove_var(&target.url_env) };
     }
 
@@ -604,8 +615,8 @@ mod tests {
             directory: std::path::PathBuf::from("migrations"),
             files: Vec::new(),
         };
-        let error =
-            connection_url(&target, &BTreeMap::new()).expect_err("the variable is set nowhere");
+        let error = connection_url(&target, &Environment::default())
+            .expect_err("the variable is set nowhere");
         let rendered = error.to_string();
         assert!(rendered.contains("SKYZEN_TEST_NEVER_SET_URL"), "{rendered}");
         assert!(

--- a/cli/src/providers/aws.rs
+++ b/cli/src/providers/aws.rs
@@ -9,6 +9,7 @@
 //! binary notices `AWS_LAMBDA_RUNTIME_API` and serves invocations instead of binding a port.
 
 use crate::{
+    environment::VariableKind,
     output,
     project::Project,
     providers::{prepare_child_environment, Action, CommandPlan, ProviderPlan, RunMode},
@@ -61,7 +62,7 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
         // `cargo lambda deploy` reads AWS credentials from the environment, and the manifest's own
         // declared variables are what the function will run with.
         child_env: if matches!(action, Action::Deploy) {
-            prepare_child_environment(manifest)?
+            prepare_child_environment(manifest, VariableKind::ALL)?.child_env
         } else {
             Vec::new()
         },

--- a/cli/src/providers/aws.rs
+++ b/cli/src/providers/aws.rs
@@ -12,7 +12,9 @@ use crate::{
     environment::VariableKind,
     output,
     project::Project,
-    providers::{prepare_child_environment, Action, CommandPlan, ProviderPlan, RunMode},
+    providers::{
+        prepare_child_environment, Action, CommandPlan, CommandStdin, ProviderPlan, RunMode, Step,
+    },
 };
 use anyhow::Result;
 use skyzen_manifest::{AwsSection, Manifest};
@@ -55,7 +57,7 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
     };
 
     Ok(ProviderPlan {
-        commands,
+        steps: commands.into_iter().map(Step::Command).collect(),
         generated_files: Vec::new(),
         build: None,
         run_mode: RunMode::Once,
@@ -110,6 +112,7 @@ fn build_command(config: &AwsSection, root_dir: &std::path::Path, release: bool)
         program: "cargo".to_owned(),
         args,
         cwd: Some(root_dir.to_path_buf()),
+        stdin: CommandStdin::Inherit,
     }
 }
 
@@ -153,6 +156,7 @@ fn deploy_command(config: &AwsSection, root_dir: &std::path::Path, binary: &str)
         program: "cargo".to_owned(),
         args,
         cwd: Some(root_dir.to_path_buf()),
+        stdin: CommandStdin::Inherit,
     }
 }
 
@@ -179,6 +183,7 @@ fn logs_command(
         program: "aws".to_owned(),
         args,
         cwd: Some(root_dir.to_path_buf()),
+        stdin: CommandStdin::Inherit,
     }
 }
 
@@ -258,7 +263,7 @@ fn event_source_hint(function: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{event_source_hint, prepare};
-    use crate::providers::{Action, CommandPlan};
+    use crate::providers::{Action, Step};
     use skyzen_manifest::Manifest;
 
     fn manifest(source: &str) -> Manifest {
@@ -274,9 +279,9 @@ mod tests {
     fn planned(action: &Action, source: &str) -> Vec<String> {
         prepare(action, &manifest(source), &project())
             .expect("plan")
-            .commands
+            .steps
             .iter()
-            .map(CommandPlan::display)
+            .map(Step::describe)
             .collect()
     }
 

--- a/cli/src/providers/aws.rs
+++ b/cli/src/providers/aws.rs
@@ -7,16 +7,24 @@
 //!
 //! The application itself needs no AWS-specific code: built with the `lambda` feature, the same
 //! binary notices `AWS_LAMBDA_RUNTIME_API` and serves invocations instead of binding a port.
+//!
+//! The one thing `cargo lambda` is *not* asked to do is carry the function's environment: a
+//! `--env-var NAME=value` flag is printed by every progress line and visible in the process table,
+//! so the variables are delivered afterwards through the SDK instead. See [`lambda_env`].
+
+mod lambda_env;
 
 use crate::{
     environment::VariableKind,
     output,
     project::Project,
     providers::{
-        prepare_child_environment, Action, CommandPlan, CommandStdin, ProviderPlan, RunMode, Step,
+        prepare_child_environment, secrets::Delivery, Action, CommandPlan, CommandStdin,
+        ProviderPlan, RunMode, SecretAction, Step,
     },
 };
 use anyhow::Result;
+use lambda_env::{LambdaEnvironment, LambdaEnvironmentNames};
 use skyzen_manifest::{AwsSection, Manifest};
 
 /// The feature the application must be built with for a Lambda deployment to serve anything.
@@ -32,23 +40,46 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
     let config = manifest.data().aws.clone().unwrap_or_default();
     let root_dir = manifest.root_dir().to_path_buf();
     let binary = project.binary_target_name()?.to_owned();
+    let function = function_name(&config, &binary);
 
     ensure_lambda_feature(project);
     if matches!(action, Action::Deploy) {
-        report_event_source(manifest, config.function_name.as_deref().unwrap_or(&binary));
+        report_event_source(manifest, &function);
     }
 
-    let commands = match action {
-        Action::Build { release } => vec![build_command(&config, &root_dir, *release)],
+    // `cargo lambda deploy` reads AWS credentials from the environment, and a `.env` entry the
+    // shell does not already hold is part of that environment.
+    let mut child_env = Vec::new();
+
+    let steps = match action {
+        Action::Build { release } => {
+            vec![Step::Command(build_command(&config, &root_dir, *release))]
+        }
         // A deploy always builds optimized first: `cargo lambda deploy` uploads whatever is in
         // `target/lambda`, so deploying without building would ship the previous build.
-        Action::Deploy => vec![
-            build_command(&config, &root_dir, true),
-            deploy_command(&config, &root_dir, &binary),
-        ],
-        Action::Logs { wrangler_args } => {
-            vec![logs_command(&config, &root_dir, &binary, wrangler_args)]
+        Action::Deploy => {
+            let prepared = prepare_child_environment(manifest, VariableKind::ALL)?;
+            child_env = prepared.child_env;
+            let mut steps = vec![
+                Step::Command(build_command(&config, &root_dir, true)),
+                Step::Command(deploy_command(&config, &root_dir, &binary)),
+            ];
+            let delivery = Delivery::from_resolved(&prepared.resolved).with_defaults(&config.env);
+            if !delivery.is_empty() {
+                steps.push(Step::Task(Box::new(LambdaEnvironment::new(
+                    function, delivery,
+                ))));
+            }
+            steps
         }
+        Action::Logs { wrangler_args } => {
+            vec![Step::Command(logs_command(
+                &root_dir,
+                &function,
+                wrangler_args,
+            ))]
+        }
+        Action::Secret(secret) => vec![secret_step(secret, manifest, &config, function)?],
         other => anyhow::bail!(
             "`skyzen {}` has no AWS implementation{}",
             super::action_name(other),
@@ -57,20 +88,62 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
     };
 
     Ok(ProviderPlan {
-        steps: commands.into_iter().map(Step::Command).collect(),
+        steps,
         generated_files: Vec::new(),
         build: None,
         run_mode: RunMode::Once,
-        // `cargo lambda deploy` reads AWS credentials from the environment, and the manifest's own
-        // declared variables are what the function will run with.
-        child_env: if matches!(action, Action::Deploy) {
-            prepare_child_environment(manifest, VariableKind::ALL)?.child_env
-        } else {
-            Vec::new()
-        },
+        child_env,
         watch_root: None,
         execute_despite_dry_run: false,
     })
+}
+
+/// The one step a `skyzen secret` action performs.
+///
+/// Every one of them is the same `UpdateFunctionConfiguration` call: Lambda has no secret store of
+/// its own, so a function's environment *is* where its values live, and delivering one is
+/// delivering all of them merged over what is already there.
+///
+/// # Errors
+///
+/// Fails when a declared variable is set nowhere, or when there is nothing at all to push.
+fn secret_step(
+    action: &SecretAction,
+    manifest: &Manifest,
+    config: &AwsSection,
+    function: String,
+) -> Result<Step> {
+    let delivery = match action {
+        SecretAction::Set { name, value } => Delivery::one(name.as_str(), value),
+        SecretAction::Push => {
+            let resolved = prepare_child_environment(manifest, VariableKind::ALL)?.resolved;
+            let delivery = Delivery::from_resolved(&resolved).with_defaults(&config.env);
+            if delivery.is_empty() {
+                anyhow::bail!(
+                    "there is nothing to push: Skyzen.toml declares no [[secret]], no native \
+                     wiring variable and no [aws.env] entry"
+                );
+            }
+            delivery
+        }
+        SecretAction::List => {
+            return Ok(Step::Task(Box::new(LambdaEnvironmentNames::new(function))))
+        }
+    };
+    Ok(Step::Task(Box::new(LambdaEnvironment::new(
+        function, delivery,
+    ))))
+}
+
+/// The function a deploy acts on: the manifest's name, or the binary's own.
+///
+/// The same rule `cargo lambda deploy` applies to the positional argument it is given, computed
+/// once so the upload, the log tail and the environment delivery cannot name different functions.
+fn function_name(config: &AwsSection, binary: &str) -> String {
+    config
+        .function_name
+        .clone()
+        .unwrap_or_else(|| binary.to_owned())
 }
 
 /// What to suggest when an action has no AWS counterpart.
@@ -78,10 +151,6 @@ const fn unsupported_hint(action: &Action) -> &'static str {
     match action {
         Action::Dev { .. } => {
             ": run it as an ordinary server with `skyzen dev`, or invoke it with `cargo lambda watch`"
-        }
-        Action::Secret(_) => {
-            ": Lambda has no secret store of its own — put values in [aws.env], or read them from \
-             Secrets Manager or SSM at startup"
         }
         Action::Migrate { .. } => {
             ": point `skyzen migrate` at the database directly rather than through the function"
@@ -116,7 +185,7 @@ fn build_command(config: &AwsSection, root_dir: &std::path::Path, release: bool)
     }
 }
 
-/// `cargo lambda deploy`, carrying the sizing, environment and URL the manifest declares.
+/// `cargo lambda deploy`, carrying the sizing and the URL the manifest declares.
 fn deploy_command(config: &AwsSection, root_dir: &std::path::Path, binary: &str) -> CommandPlan {
     let mut args = vec!["lambda".to_owned(), "deploy".to_owned()];
 
@@ -131,10 +200,8 @@ fn deploy_command(config: &AwsSection, root_dir: &std::path::Path, binary: &str)
         args.push("--timeout".to_owned());
         args.push(timeout.as_secs().to_string());
     }
-    for (key, value) in &config.env {
-        args.push("--env-var".to_owned());
-        args.push(format!("{key}={value}"));
-    }
+    // No `--env-var`: `[aws.env]` and every declared variable are delivered by the SDK step that
+    // follows, so no value reaches this command line.
     // Named in both directions: turning `url` off should *remove* the URL rather than leave the
     // one an earlier deploy created still serving the internet.
     args.push(
@@ -164,13 +231,7 @@ fn deploy_command(config: &AwsSection, root_dir: &std::path::Path, binary: &str)
 ///
 /// `cargo lambda` has no `logs` subcommand — it covers building, deploying and invoking — so this
 /// is the AWS CLI's log tail against the log group Lambda creates for the function.
-fn logs_command(
-    config: &AwsSection,
-    root_dir: &std::path::Path,
-    binary: &str,
-    extra: &[String],
-) -> CommandPlan {
-    let function = config.function_name.as_deref().unwrap_or(binary);
+fn logs_command(root_dir: &std::path::Path, function: &str, extra: &[String]) -> CommandPlan {
     let mut args = vec![
         "logs".to_owned(),
         "tail".to_owned(),
@@ -205,6 +266,10 @@ fn ensure_lambda_feature(project: &Project) {
 
 /// Report what `skyzen doctor --provider aws` can tell from the manifest alone.
 pub fn check_manifest(manifest: &Manifest) -> usize {
+    // The Lambda binary is the native binary, so a deploy delivers both kinds — and, unlike
+    // `[aws.env]`, they have to have a value here for the deploy to run at all.
+    super::report_runtime_variables(manifest, VariableKind::ALL, "aws", "skyzen deploy");
+
     let Some(config) = manifest.data().aws.as_ref() else {
         output::warn("Skyzen.toml has no [aws] section; the defaults deploy an arm64 function with a Function URL");
         return 0;
@@ -263,8 +328,9 @@ fn event_source_hint(function: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{event_source_hint, prepare};
-    use crate::providers::{Action, Step};
-    use skyzen_manifest::Manifest;
+    use crate::providers::{Action, SecretAction, Step};
+    use secrecy::SecretString;
+    use skyzen_manifest::{Manifest, VarName};
 
     fn manifest(source: &str) -> Manifest {
         Manifest::parse(source, "Skyzen.toml", "/tmp/app").expect("valid manifest")
@@ -313,7 +379,7 @@ mod tests {
              [aws.env]\nRUST_LOG = \"info\"\n",
         );
 
-        assert_eq!(planned.len(), 2, "{planned:?}");
+        assert_eq!(planned.len(), 3, "{planned:?}");
         assert!(planned[0].contains("cargo lambda build"), "{planned:?}");
 
         let deploy = &planned[1];
@@ -322,9 +388,118 @@ mod tests {
         assert!(deploy.contains("--memory 512"), "{deploy}");
         // humantime in, seconds out: that is the unit Lambda takes.
         assert!(deploy.contains("--timeout 45"), "{deploy}");
-        assert!(deploy.contains("--env-var RUST_LOG=info"), "{deploy}");
         assert!(deploy.contains("--enable-function-url"), "{deploy}");
         assert!(deploy.ends_with("skyzen-api)"), "{deploy}");
+    }
+
+    #[test]
+    fn nothing_a_deploy_runs_carries_a_value_on_its_command_line() {
+        // The whole reason `[aws.env]` no longer reaches `cargo lambda deploy`: its command line
+        // is printed by every progress line and by `--dry-run`, and is visible in the process
+        // table of whatever machine runs the deploy.
+        let planned = planned(&Action::Deploy, "[aws]\n\n[aws.env]\nRUST_LOG = \"info\"\n");
+
+        for step in &planned {
+            assert!(!step.contains("--env-var"), "{planned:?}");
+            assert!(!step.contains("info"), "{planned:?}");
+        }
+    }
+
+    #[test]
+    fn a_deploy_ends_by_delivering_the_variables_it_names_and_no_values() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join(".env"), "STRIPE_KEY=sk_live_123\n").expect("write .env");
+        let manifest = Manifest::parse(
+            "[[secret]]\nname = \"STRIPE_KEY\"\n\n[aws]\nfunction_name = \"skyzen-api\"\n\n\
+             [aws.env]\nRUST_LOG = \"info\"\n",
+            dir.path().join("Skyzen.toml"),
+            dir.path(),
+        )
+        .expect("valid manifest");
+
+        let plan = prepare(&Action::Deploy, &manifest, &project()).expect("plan");
+        let last = plan
+            .steps
+            .last()
+            .expect("a deploy delivers its environment");
+        let described = last.describe();
+
+        assert!(matches!(last, Step::Task(_)), "{described}");
+        assert!(described.contains("skyzen-api"), "{described}");
+        assert!(described.contains("RUST_LOG"), "{described}");
+        assert!(described.contains("STRIPE_KEY"), "{described}");
+        assert!(!described.contains("sk_live_123"), "{described}");
+        assert!(!described.contains("info"), "{described}");
+    }
+
+    #[test]
+    fn a_deploy_refuses_when_a_declared_variable_is_set_nowhere() {
+        let error = prepare(
+            &Action::Deploy,
+            &manifest(
+                "[[secret]]\nname = \"SKYZEN_TEST_AWS_UNSET_SECRET\"\n\n\
+                 [[service]]\nname = \"cache\"\ntype = \"kv\"\n\n\
+                 [native.service.cache]\nbackend = \"redis\"\n\
+                 url_env = \"SKYZEN_TEST_AWS_UNSET_URL\"\n",
+            ),
+            &project(),
+        )
+        .expect_err("the deployed function would panic at cold start");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("SKYZEN_TEST_AWS_UNSET_SECRET"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("SKYZEN_TEST_AWS_UNSET_URL"), "{rendered}");
+    }
+
+    #[test]
+    fn setting_one_secret_delivers_that_pair_and_names_no_value() {
+        let plan = prepare(
+            &Action::Secret(SecretAction::Set {
+                name: VarName::try_from("STRIPE_KEY".to_owned()).expect("a name"),
+                value: SecretString::from("sk_live_123"),
+            }),
+            &manifest(
+                "[[secret]]\nname = \"STRIPE_KEY\"\n\n[aws]\nfunction_name = \"skyzen-api\"\n",
+            ),
+            &project(),
+        )
+        .expect("plan");
+
+        let described = plan.steps[0].describe();
+        assert!(described.contains("STRIPE_KEY"), "{described}");
+        assert!(described.contains("skyzen-api"), "{described}");
+        assert!(!described.contains("sk_live_123"), "{described}");
+    }
+
+    #[test]
+    fn listing_reads_the_deployed_functions_own_environment() {
+        let plan = prepare(
+            &Action::Secret(SecretAction::List),
+            &manifest("[aws]\nfunction_name = \"skyzen-api\"\n"),
+            &project(),
+        )
+        .expect("plan");
+
+        assert!(
+            plan.steps[0].describe().contains("skyzen-api"),
+            "{:?}",
+            plan.steps[0]
+        );
+    }
+
+    #[test]
+    fn pushing_with_nothing_declared_says_so_rather_than_calling_aws() {
+        let error = prepare(
+            &Action::Secret(SecretAction::Push),
+            &manifest("[aws]\n"),
+            &project(),
+        )
+        .expect_err("there is nothing to deliver");
+
+        assert!(format!("{error:#}").contains("nothing to push"), "{error}");
     }
 
     #[test]

--- a/cli/src/providers/aws/lambda_env.rs
+++ b/cli/src/providers/aws/lambda_env.rs
@@ -1,0 +1,170 @@
+//! Delivering a Lambda function's environment, in process.
+//!
+//! `cargo lambda deploy` can set environment variables, but only as `--env-var NAME=value` on its
+//! own command line — which is printed by every progress line and every `--dry-run`, and visible
+//! in the process table of whatever machine runs the deploy. So Skyzen does not ask it to: the
+//! upload carries the code, and the environment is delivered straight afterwards through
+//! `UpdateFunctionConfiguration`, where the value only ever exists inside the request body.
+//!
+//! The call is a read-modify-write. `UpdateFunctionConfiguration` replaces the whole map, so a
+//! variable set from the console or by another tool would be deleted by a deploy that never
+//! mentioned it.
+
+use crate::{
+    output,
+    providers::{secrets::Delivery, Task},
+    runtime::block_on,
+};
+use anyhow::{Context, Result};
+use aws_sdk_lambda::{client::Waiters as _, types::Environment, Client};
+use std::{collections::BTreeMap, time::Duration};
+
+/// How long to wait for an update already in flight to finish.
+///
+/// `cargo lambda deploy` returns as soon as Lambda has accepted the code, while the function's
+/// `LastUpdateStatus` is still `InProgress`; a second update during that window is rejected with a
+/// `ResourceConflictException`. Five minutes is the SDK's own default for this waiter.
+const UPDATE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Set a deployed function's environment to what the manifest and the local `.env` say.
+#[derive(Debug)]
+pub struct LambdaEnvironment {
+    /// The function to update, as `deploy` names it.
+    function: String,
+    /// What to deliver.
+    delivery: Delivery,
+}
+
+impl LambdaEnvironment {
+    /// The step that delivers `delivery` to `function`.
+    pub const fn new(function: String, delivery: Delivery) -> Self {
+        Self { function, delivery }
+    }
+}
+
+impl Task for LambdaEnvironment {
+    fn describe(&self) -> String {
+        format!(
+            "set the environment of Lambda function `{}`: {}",
+            self.function,
+            self.delivery.names()
+        )
+    }
+
+    fn run(&self) -> Result<()> {
+        block_on(async {
+            let client = client().await;
+
+            // The deploy that just ran leaves an update in progress, and Lambda refuses a second
+            // one until it has settled.
+            client
+                .wait_until_function_updated_v2()
+                .function_name(&self.function)
+                .wait(UPDATE_TIMEOUT)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Lambda function `{}` did not finish updating within {} seconds",
+                        self.function,
+                        UPDATE_TIMEOUT.as_secs()
+                    )
+                })?;
+
+            let merged = self
+                .delivery
+                .merged_over(existing_variables(&client, &self.function).await?);
+            client
+                .update_function_configuration()
+                .function_name(&self.function)
+                .environment(
+                    Environment::builder()
+                        .set_variables(Some(merged.into_iter().collect()))
+                        .build(),
+                )
+                .send()
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to set the environment of Lambda function `{}`",
+                        self.function
+                    )
+                })?;
+            Ok(())
+        })?
+    }
+}
+
+/// Report the environment variable names a deployed function carries.
+///
+/// Names only: `GetFunctionConfiguration` hands back the values as well, and printing one would
+/// put a delivered secret on a terminal.
+#[derive(Debug)]
+pub struct LambdaEnvironmentNames {
+    /// The function to read.
+    function: String,
+}
+
+impl LambdaEnvironmentNames {
+    /// The step that lists `function`'s environment.
+    pub const fn new(function: String) -> Self {
+        Self { function }
+    }
+}
+
+impl Task for LambdaEnvironmentNames {
+    fn describe(&self) -> String {
+        format!(
+            "list the environment of Lambda function `{}`",
+            self.function
+        )
+    }
+
+    fn run(&self) -> Result<()> {
+        block_on(async {
+            let client = client().await;
+            let variables = existing_variables(&client, &self.function).await?;
+            if variables.is_empty() {
+                output::ok(format!(
+                    "Lambda function `{}` has no environment variables",
+                    self.function
+                ));
+                return Ok(());
+            }
+            for name in variables.keys() {
+                output::ok(name);
+            }
+            Ok(())
+        })?
+    }
+}
+
+/// A Lambda client on the ambient AWS configuration.
+///
+/// The same credential chain `cargo lambda deploy` itself resolves — profile, environment,
+/// instance role — so the two halves of one deploy cannot end up talking to different accounts.
+async fn client() -> Client {
+    Client::new(&aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await)
+}
+
+/// The environment the deployed function already has.
+///
+/// # Errors
+///
+/// Fails when the function cannot be read, which for `secret push` usually means it has not been
+/// deployed yet.
+async fn existing_variables(client: &Client, function: &str) -> Result<BTreeMap<String, String>> {
+    let configuration = client
+        .get_function_configuration()
+        .function_name(function)
+        .send()
+        .await
+        .with_context(|| {
+            format!("failed to read the configuration of Lambda function `{function}`")
+        })?;
+    Ok(configuration
+        .environment
+        .and_then(|environment| environment.variables)
+        .unwrap_or_default()
+        .into_iter()
+        .collect())
+}

--- a/cli/src/providers/azure.rs
+++ b/cli/src/providers/azure.rs
@@ -11,7 +11,8 @@
 mod bundle;
 
 use crate::{
-    environment, output,
+    environment::{self, VariableKind},
+    output,
     project::Project,
     providers::{
         prepare_child_environment, Action, ArtifactBuild, CommandPlan, ProviderPlan, RunMode,
@@ -82,7 +83,7 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
         build: Some(Box::new(build)),
         run_mode: RunMode::Once,
         child_env: if matches!(action, Action::Deploy) {
-            prepare_child_environment(manifest)?
+            prepare_child_environment(manifest, VariableKind::ALL)?.child_env
         } else {
             Vec::new()
         },

--- a/cli/src/providers/azure.rs
+++ b/cli/src/providers/azure.rs
@@ -8,6 +8,7 @@
 //!
 //! [custom handler]: https://learn.microsoft.com/azure/azure-functions/functions-custom-handlers
 
+mod app_settings;
 mod bundle;
 
 use crate::{
@@ -15,11 +16,12 @@ use crate::{
     output,
     project::Project,
     providers::{
-        prepare_child_environment, Action, CommandPlan, CommandStdin, ProviderPlan, RunMode, Step,
-        Task,
+        prepare_child_environment, secrets::Delivery, Action, CommandPlan, CommandStdin,
+        ProviderPlan, RunMode, SecretAction, Step, Task,
     },
 };
 use anyhow::{Context, Result};
+use app_settings::{AppSettingNames, AppSettings, FunctionApp};
 use skyzen_manifest::{AzureSection, Manifest};
 use std::{
     fs,
@@ -40,12 +42,22 @@ pub const DEFAULT_LINUX_TARGET: &str = "x86_64-unknown-linux-musl";
 ///
 /// # Errors
 ///
-/// Fails when the project cannot name the binary to publish, when `deploy` has no `app_name` to
-/// publish to, or when the action has no Azure meaning.
+/// Fails when the project cannot name the binary to publish, when `[azure]` does not say which
+/// Function App to act on, or when the action has no Azure meaning.
 pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Result<ProviderPlan> {
     let config = manifest.data().azure.clone().unwrap_or_default();
     let root_dir = manifest.root_dir().to_path_buf();
     let bundle_dir = root_dir.join(BUNDLE_DIR);
+
+    // Before the binary is looked up: a secret action neither builds nor publishes anything, so a
+    // project that cannot name one is no obstacle to setting a value.
+    if let Action::Secret(secret) = action {
+        return Ok(ProviderPlan {
+            steps: vec![secret_step(secret, manifest, &config)?],
+            ..ProviderPlan::default()
+        });
+    }
+
     let binary = project.binary_target_name()?.to_owned();
 
     let needs_bundle = matches!(action, Action::Build { .. } | Action::Deploy);
@@ -54,12 +66,7 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
             steps: vec![Step::Command(non_bundling_command(
                 action, &config, &root_dir,
             )?)],
-            generated_files: Vec::new(),
-            build: None,
-            run_mode: RunMode::Once,
-            child_env: Vec::new(),
-            watch_root: None,
-            execute_despite_dry_run: false,
+            ..ProviderPlan::default()
         });
     }
 
@@ -74,25 +81,64 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
         require_linux: matches!(action, Action::Deploy),
     };
 
-    let commands = match action {
+    let mut child_env = Vec::new();
+    let steps = match action {
         Action::Build { .. } => Vec::new(),
-        Action::Deploy => vec![publish_command(&config, &bundle_dir)?],
+        Action::Deploy => {
+            // Both are read before anything is built: a deploy that would have nowhere to deliver
+            // its variables, or no value for one of them, must fail before it uploads a binary.
+            let app = function_app(&config)?;
+            let publish = publish_command(&config, &bundle_dir)?;
+            let prepared = prepare_child_environment(manifest, VariableKind::ALL)?;
+            child_env = prepared.child_env;
+            let mut steps = vec![Step::Command(publish)];
+            let delivery = Delivery::from_resolved(&prepared.resolved);
+            if !delivery.is_empty() {
+                steps.push(Step::Task(Box::new(AppSettings::new(app, delivery))));
+            }
+            steps
+        }
         other => unreachable!("{} does not need a bundle", super::action_name(other)),
     };
 
     Ok(ProviderPlan {
-        steps: commands.into_iter().map(Step::Command).collect(),
+        steps,
         generated_files: files,
         build: Some(Box::new(build)),
         run_mode: RunMode::Once,
-        child_env: if matches!(action, Action::Deploy) {
-            prepare_child_environment(manifest, VariableKind::ALL)?.child_env
-        } else {
-            Vec::new()
-        },
+        child_env,
         watch_root: None,
         execute_despite_dry_run: false,
     })
+}
+
+/// The one step a `skyzen secret` action performs.
+///
+/// Functions has no secret store of its own: an app's settings *are* its environment, so every one
+/// of these is the same read-modify-write against them.
+///
+/// # Errors
+///
+/// Fails when `[azure]` does not say which app to talk to, when a declared variable is set
+/// nowhere, or when there is nothing at all to push.
+fn secret_step(action: &SecretAction, manifest: &Manifest, config: &AzureSection) -> Result<Step> {
+    let app = function_app(config)?;
+    let delivery = match action {
+        SecretAction::Set { name, value } => Delivery::one(name.as_str(), value),
+        SecretAction::Push => {
+            let resolved = prepare_child_environment(manifest, VariableKind::ALL)?.resolved;
+            let delivery = Delivery::from_resolved(&resolved);
+            if delivery.is_empty() {
+                anyhow::bail!(
+                    "there is nothing to push: Skyzen.toml declares no [[secret]] and no native \
+                     wiring variable"
+                );
+            }
+            delivery
+        }
+        SecretAction::List => return Ok(Step::Task(Box::new(AppSettingNames::new(app)))),
+    };
+    Ok(Step::Task(Box::new(AppSettings::new(app, delivery))))
 }
 
 /// The one command an action that needs no bundle runs.
@@ -132,10 +178,6 @@ const fn unsupported_hint(action: &Action) -> &'static str {
             ": run it as an ordinary server with `skyzen dev`, or start the host over a built \
              bundle with `func start` from .skyzen/gen/azure"
         }
-        Action::Secret(_) => {
-            ": Functions keeps secrets in the app's settings — `az functionapp config appsettings \
-             set` — or in Key Vault references"
-        }
         Action::Migrate { .. } => {
             ": point `skyzen migrate` at the database directly rather than through the Function App"
         }
@@ -164,6 +206,27 @@ fn app_name(config: &AzureSection) -> Result<String> {
         "missing `app_name` in [azure]; it names the Function App to publish to, and there is \
          nothing to infer it from",
     )
+}
+
+/// The Function App an ARM call addresses.
+///
+/// `func azure functionapp publish` finds an app by name alone, but ARM addresses the settings
+/// resource by its full id, so a deploy — which delivers the runtime variables — and every
+/// `skyzen secret` action need all three parts. Reported together with the same wording as
+/// `app_name`, because a project missing one is usually missing both.
+fn function_app(config: &AzureSection) -> Result<FunctionApp> {
+    Ok(FunctionApp {
+        name: app_name(config)?,
+        subscription_id: config.subscription_id.clone().context(
+            "missing `subscription_id` in [azure]; it is half of the ARM id of the application \
+             settings a deployment delivers its runtime variables through, and there is nothing \
+             to infer it from (`az account show --query id -o tsv`)",
+        )?,
+        resource_group: config.resource_group.clone().context(
+            "missing `resource_group` in [azure]; it is the other half of that ARM id (`az \
+             functionapp list --query \"[].{name:name,group:resourceGroup}\" -o table`)",
+        )?,
+    })
 }
 
 /// Compile the handler and stage it inside the bundle.
@@ -354,6 +417,9 @@ pub fn check_linux_target(manifest_path: &Path) -> usize {
 
 /// Report what `skyzen doctor --provider azure` can tell from the manifest alone.
 pub fn check_manifest(manifest: &Manifest) -> usize {
+    // The Functions host runs the native binary, so a deploy delivers both kinds.
+    super::report_runtime_variables(manifest, VariableKind::ALL, "azure", "skyzen deploy");
+
     let Some(config) = manifest.data().azure.as_ref() else {
         output::failed(
             "azure: Skyzen.toml has no [azure] section; `skyzen deploy` needs `app_name`",
@@ -362,14 +428,15 @@ pub fn check_manifest(manifest: &Manifest) -> usize {
     };
 
     let mut failures = 0;
-    if config.app_name.is_none() {
-        output::failed("azure: [azure] has no `app_name`; there is nothing to publish to");
-        failures += 1;
-    } else {
-        output::ok(format!(
-            "azure: publishing to {}",
-            config.app_name.as_deref().unwrap_or_default()
-        ));
+    match function_app(config) {
+        Ok(app) => output::ok(format!(
+            "azure: publishing to {} in {}/{}",
+            app.name, app.subscription_id, app.resource_group
+        )),
+        Err(error) => {
+            output::failed(format!("azure: {error}"));
+            failures += 1;
+        }
     }
 
     for trigger in &config.queue_triggers {
@@ -385,8 +452,14 @@ pub fn check_manifest(manifest: &Manifest) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{ensure_runs_on_linux, prepare, ELF_MAGIC};
-    use crate::providers::{Action, Step};
-    use skyzen_manifest::Manifest;
+    use crate::providers::{Action, SecretAction, Step};
+    use secrecy::SecretString;
+    use skyzen_manifest::{Manifest, VarName};
+
+    /// An `[azure]` section naming everything a deploy needs.
+    const ADDRESSED: &str = "[azure]\napp_name = \"skyzen-demo\"\n\
+         subscription_id = \"00000000-0000-0000-0000-000000000000\"\n\
+         resource_group = \"skyzen-rg\"\n";
 
     fn manifest(source: &str) -> Manifest {
         Manifest::parse(source, "Skyzen.toml", "/tmp/app").expect("valid manifest")
@@ -401,9 +474,9 @@ mod tests {
     fn a_deploy_publishes_the_generated_bundle_and_builds_the_handler_first() {
         let plan = prepare(
             &Action::Deploy,
-            &manifest(
-                "[azure]\napp_name = \"skyzen-demo\"\ntarget = \"x86_64-unknown-linux-musl\"\n",
-            ),
+            &manifest(&format!(
+                "{ADDRESSED}target = \"x86_64-unknown-linux-musl\"\n"
+            )),
             &project(),
         )
         .expect("plan");
@@ -436,7 +509,7 @@ mod tests {
             &manifest("[azure]\napp_name = \"skyzen-demo\"\n"),
             &project(),
         )
-        .expect("plan");
+        .expect("a build needs no ARM id: it uploads nothing");
 
         assert!(plan.steps.is_empty(), "a build uploads nothing");
         assert!(plan.build.is_some());
@@ -448,6 +521,99 @@ mod tests {
             .expect_err("there is nothing to publish to");
 
         assert!(error.to_string().contains("app_name"), "{error}");
+    }
+
+    #[test]
+    fn a_deploy_that_cannot_address_the_settings_resource_names_the_missing_key() {
+        for (source, missing) in [
+            (
+                "[azure]\napp_name = \"skyzen-demo\"\nresource_group = \"skyzen-rg\"\n",
+                "subscription_id",
+            ),
+            (
+                "[azure]\napp_name = \"skyzen-demo\"\n\
+                 subscription_id = \"00000000-0000-0000-0000-000000000000\"\n",
+                "resource_group",
+            ),
+        ] {
+            let error = prepare(&Action::Deploy, &manifest(source), &project())
+                .expect_err("the runtime variables would have nowhere to go");
+            assert!(error.to_string().contains(missing), "{error}");
+
+            let error = prepare(
+                &Action::Secret(SecretAction::List),
+                &manifest(source),
+                &project(),
+            )
+            .expect_err("nor can a secret action address the app");
+            assert!(error.to_string().contains(missing), "{error}");
+        }
+    }
+
+    #[test]
+    fn a_deploy_ends_by_delivering_the_variables_it_names_and_no_values() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join(".env"), "STRIPE_KEY=sk_live_123\n").expect("write .env");
+        let manifest = Manifest::parse(
+            &format!("[[secret]]\nname = \"STRIPE_KEY\"\n\n{ADDRESSED}"),
+            dir.path().join("Skyzen.toml"),
+            dir.path(),
+        )
+        .expect("valid manifest");
+
+        let plan = prepare(&Action::Deploy, &manifest, &project()).expect("plan");
+        let last = plan.steps.last().expect("a deploy delivers its settings");
+        let described = last.describe();
+
+        assert!(matches!(last, Step::Task(_)), "{described}");
+        assert!(described.contains("skyzen-demo"), "{described}");
+        assert!(described.contains("STRIPE_KEY"), "{described}");
+        assert!(!described.contains("sk_live_123"), "{described}");
+        // The publish still comes first: settings that named a binary nobody uploaded would be
+        // delivered to the previous deployment.
+        assert!(
+            plan.steps[0].describe().contains("functionapp publish"),
+            "{:?}",
+            plan.steps[0]
+        );
+    }
+
+    #[test]
+    fn a_deploy_refuses_when_a_declared_variable_is_set_nowhere() {
+        let error = prepare(
+            &Action::Deploy,
+            &manifest(&format!(
+                "[[secret]]\nname = \"SKYZEN_TEST_AZURE_UNSET_SECRET\"\n\n{ADDRESSED}"
+            )),
+            &project(),
+        )
+        .expect_err("the published handler would panic at startup");
+
+        assert!(
+            format!("{error:#}").contains("SKYZEN_TEST_AZURE_UNSET_SECRET"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn setting_one_secret_delivers_that_pair_and_names_no_value() {
+        let plan = prepare(
+            &Action::Secret(SecretAction::Set {
+                name: VarName::try_from("STRIPE_KEY".to_owned()).expect("a name"),
+                value: SecretString::from("sk_live_123"),
+            }),
+            &manifest(&format!("[[secret]]\nname = \"STRIPE_KEY\"\n\n{ADDRESSED}")),
+            &project(),
+        )
+        .expect("plan");
+
+        let described = plan.steps[0].describe();
+        assert!(described.contains("STRIPE_KEY"), "{described}");
+        assert!(described.contains("skyzen-demo"), "{described}");
+        assert!(!described.contains("sk_live_123"), "{described}");
+        // A secret action publishes nothing, so it generates no bundle either.
+        assert!(plan.generated_files.is_empty());
+        assert!(plan.build.is_none());
     }
 
     #[test]

--- a/cli/src/providers/azure.rs
+++ b/cli/src/providers/azure.rs
@@ -15,7 +15,8 @@ use crate::{
     output,
     project::Project,
     providers::{
-        prepare_child_environment, Action, ArtifactBuild, CommandPlan, ProviderPlan, RunMode,
+        prepare_child_environment, Action, CommandPlan, CommandStdin, ProviderPlan, RunMode, Step,
+        Task,
     },
 };
 use anyhow::{Context, Result};
@@ -50,7 +51,9 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
     let needs_bundle = matches!(action, Action::Build { .. } | Action::Deploy);
     if !needs_bundle {
         return Ok(ProviderPlan {
-            commands: vec![non_bundling_command(action, &config, &root_dir)?],
+            steps: vec![Step::Command(non_bundling_command(
+                action, &config, &root_dir,
+            )?)],
             generated_files: Vec::new(),
             build: None,
             run_mode: RunMode::Once,
@@ -78,7 +81,7 @@ pub fn prepare(action: &Action, manifest: &Manifest, project: &Project) -> Resul
     };
 
     Ok(ProviderPlan {
-        commands,
+        steps: commands.into_iter().map(Step::Command).collect(),
         generated_files: files,
         build: Some(Box::new(build)),
         run_mode: RunMode::Once,
@@ -111,6 +114,7 @@ fn non_bundling_command(
                 program: "func".to_owned(),
                 args,
                 cwd: Some(root_dir.to_path_buf()),
+                stdin: CommandStdin::Inherit,
             })
         }
         other => anyhow::bail!(
@@ -150,6 +154,7 @@ fn publish_command(config: &AzureSection, bundle_dir: &Path) -> Result<CommandPl
             app_name(config)?,
         ],
         cwd: Some(bundle_dir.to_path_buf()),
+        stdin: CommandStdin::Inherit,
     })
 }
 
@@ -205,11 +210,12 @@ impl HandlerBuild {
             program: "cargo".to_owned(),
             args,
             cwd: Some(self.root_dir.clone()),
+            stdin: CommandStdin::Inherit,
         }
     }
 }
 
-impl ArtifactBuild for HandlerBuild {
+impl Task for HandlerBuild {
     fn describe(&self) -> String {
         format!(
             "{} && stage {} into {}",
@@ -379,7 +385,7 @@ pub fn check_manifest(manifest: &Manifest) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{ensure_runs_on_linux, prepare, ELF_MAGIC};
-    use crate::providers::{Action, CommandPlan};
+    use crate::providers::{Action, Step};
     use skyzen_manifest::Manifest;
 
     fn manifest(source: &str) -> Manifest {
@@ -410,7 +416,7 @@ mod tests {
         );
         assert!(described.contains("stage demo"), "{described}");
 
-        let commands: Vec<String> = plan.commands.iter().map(CommandPlan::display).collect();
+        let commands: Vec<String> = plan.steps.iter().map(Step::describe).collect();
         assert_eq!(commands.len(), 1);
         assert!(
             commands[0].contains("func azure functionapp publish skyzen-demo"),
@@ -432,7 +438,7 @@ mod tests {
         )
         .expect("plan");
 
-        assert!(plan.commands.is_empty(), "a build uploads nothing");
+        assert!(plan.steps.is_empty(), "a build uploads nothing");
         assert!(plan.build.is_some());
     }
 
@@ -456,11 +462,11 @@ mod tests {
         .expect("plan");
 
         assert!(
-            plan.commands[0]
-                .display()
+            plan.steps[0]
+                .describe()
                 .contains("func azure functionapp logstream skyzen-demo"),
             "{:?}",
-            plan.commands[0]
+            plan.steps[0]
         );
     }
 

--- a/cli/src/providers/azure/app_settings.rs
+++ b/cli/src/providers/azure/app_settings.rs
@@ -1,0 +1,329 @@
+//! Delivering a Function App's application settings over ARM.
+//!
+//! A custom handler reads its configuration from the process environment, and on Functions that
+//! environment *is* the app's settings. There is no Rust SDK for the `Microsoft.Web` provider, so
+//! this speaks the two REST calls directly: `config/appsettings/list` to read and
+//! `config/appsettings` to write. The write is a **full replace**, which is why every path here is
+//! a read-modify-write — the host's own `FUNCTIONS_WORKER_RUNTIME` and `AzureWebJobsStorage` live
+//! in the same map, and a PUT that did not carry them would take the app down.
+//!
+//! Authentication is the Azure CLI's own token (`az account get-access-token`), so a deploy uses
+//! the identity the developer already logged in with and Skyzen never handles a credential.
+
+use crate::{
+    output,
+    providers::{secrets::Delivery, Task},
+    runtime::block_on,
+};
+use anyhow::{Context, Result};
+use secrecy::{ExposeSecret as _, SecretString};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    process::{Command, Stdio},
+};
+
+/// The ARM API version the two settings calls are made against.
+const API_VERSION: &str = "2022-03-01";
+
+/// The ARM endpoint, which is also the audience the access token is issued for.
+const MANAGEMENT_ENDPOINT: &str = "https://management.azure.com/";
+
+/// The Function App one delivery acts on.
+///
+/// All three parts are needed to address it: application settings are a child resource of the
+/// site, and a site is identified by subscription, resource group and name.
+#[derive(Debug, Clone)]
+pub struct FunctionApp {
+    /// The subscription the app lives in.
+    pub subscription_id: String,
+    /// The resource group inside it.
+    pub resource_group: String,
+    /// The Function App's name.
+    pub name: String,
+}
+
+impl FunctionApp {
+    /// The settings resource's URL, for the given verb's path suffix.
+    fn url(&self, suffix: &str) -> String {
+        format!(
+            "{MANAGEMENT_ENDPOINT}subscriptions/{}/resourceGroups/{}/providers/Microsoft.Web/\
+             sites/{}/config/appsettings{suffix}?api-version={API_VERSION}",
+            self.subscription_id, self.resource_group, self.name
+        )
+    }
+}
+
+/// Set a Function App's application settings to what the manifest and the local `.env` say.
+#[derive(Debug)]
+pub struct AppSettings {
+    /// The app to update.
+    app: FunctionApp,
+    /// What to deliver.
+    delivery: Delivery,
+}
+
+impl AppSettings {
+    /// The step that delivers `delivery` to `app`.
+    pub const fn new(app: FunctionApp, delivery: Delivery) -> Self {
+        Self { app, delivery }
+    }
+}
+
+impl Task for AppSettings {
+    fn describe(&self) -> String {
+        format!(
+            "set the application settings of Function App `{}`: {}",
+            self.app.name,
+            self.delivery.names()
+        )
+    }
+
+    fn run(&self) -> Result<()> {
+        let token = access_token()?;
+        block_on(async {
+            let client = reqwest::Client::new();
+            let existing = list(&client, &self.app, &token).await?;
+            let merged = self.delivery.merged_over(existing);
+
+            // The one place a delivered value is exposed: it goes into this body and nowhere else.
+            let response = client
+                .put(self.app.url(""))
+                .bearer_auth(token.expose_secret())
+                .json(&AppSettingsDocument {
+                    properties: &merged,
+                })
+                .send()
+                .await
+                .context("failed to write the Function App's application settings")?;
+            check(response, "write the application settings").await?;
+            Ok(())
+        })?
+    }
+}
+
+/// Report the application setting names a Function App carries.
+///
+/// Names only: the list call hands back the values as well, and printing one would put a delivered
+/// secret on a terminal.
+#[derive(Debug)]
+pub struct AppSettingNames {
+    /// The app to read.
+    app: FunctionApp,
+}
+
+impl AppSettingNames {
+    /// The step that lists `app`'s settings.
+    pub const fn new(app: FunctionApp) -> Self {
+        Self { app }
+    }
+}
+
+impl Task for AppSettingNames {
+    fn describe(&self) -> String {
+        format!(
+            "list the application settings of Function App `{}`",
+            self.app.name
+        )
+    }
+
+    fn run(&self) -> Result<()> {
+        let token = access_token()?;
+        block_on(async {
+            let settings = list(&reqwest::Client::new(), &self.app, &token).await?;
+            if settings.is_empty() {
+                output::ok(format!(
+                    "Function App `{}` has no application settings",
+                    self.app.name
+                ));
+                return Ok(());
+            }
+            for name in settings.keys() {
+                output::ok(name);
+            }
+            Ok(())
+        })?
+    }
+}
+
+/// The settings the app already has.
+///
+/// A POST rather than a GET, because ARM treats reading values as an action rather than a
+/// projection of the resource.
+///
+/// # Errors
+///
+/// Fails when the request cannot be sent, when ARM refuses it, or when its answer is not the
+/// document this expects.
+async fn list(
+    client: &reqwest::Client,
+    app: &FunctionApp,
+    token: &SecretString,
+) -> Result<BTreeMap<String, String>> {
+    let response = client
+        .post(app.url("/list"))
+        .bearer_auth(token.expose_secret())
+        .header(reqwest::header::CONTENT_LENGTH, 0)
+        .send()
+        .await
+        .context("failed to read the Function App's application settings")?;
+    let body = check(response, "read the application settings").await?;
+    let document: OwnedAppSettingsDocument = serde_json::from_str(&body)
+        .context("the application settings ARM returned are not the document Skyzen expects")?;
+    Ok(document.properties)
+}
+
+/// The body both calls carry, and the answer both of them give.
+#[derive(Debug, Serialize)]
+struct AppSettingsDocument<'a> {
+    /// The whole settings map: ARM replaces what the app has with exactly this.
+    properties: &'a BTreeMap<String, String>,
+}
+
+/// The same document, read back.
+#[derive(Debug, Deserialize)]
+struct OwnedAppSettingsDocument {
+    /// A Function App with no settings at all still answers, with this absent.
+    #[serde(default)]
+    properties: BTreeMap<String, String>,
+}
+
+/// What ARM says when it refuses.
+#[derive(Debug, Deserialize)]
+struct ArmErrorDocument {
+    /// Absent when the failure came from a layer that does not use ARM's error shape.
+    error: Option<ArmError>,
+}
+
+/// The error body itself.
+#[derive(Debug, Deserialize)]
+struct ArmError {
+    /// The human-readable reason, which is the one part worth repeating.
+    message: Option<String>,
+}
+
+/// The response's body, or an error naming the status and what ARM said about it.
+///
+/// The request body is never echoed: on the write call it is the values themselves.
+///
+/// # Errors
+///
+/// Fails for any non-2xx status, and when the body cannot be read.
+async fn check(response: reqwest::Response, what: &str) -> Result<String> {
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .with_context(|| format!("failed to read Azure's answer when asked to {what}"))?;
+    if status.is_success() {
+        return Ok(body);
+    }
+
+    let reason = serde_json::from_str::<ArmErrorDocument>(&body)
+        .ok()
+        .and_then(|document| document.error?.message);
+    match reason {
+        Some(message) => anyhow::bail!("Azure refused to {what} ({status}): {message}"),
+        None => anyhow::bail!("Azure refused to {what} ({status})"),
+    }
+}
+
+/// A bearer token for ARM, from the Azure CLI's own logged-in identity.
+///
+/// `func azure functionapp publish` authenticates the same way, so a deploy that can publish can
+/// also deliver its settings — there is no second credential to configure.
+///
+/// # Errors
+///
+/// Fails when `az` is not installed, when nobody is logged in, or when its answer is not the JSON
+/// document it documents.
+fn access_token() -> Result<SecretString> {
+    let output = Command::new("az")
+        .args([
+            "account",
+            "get-access-token",
+            "--resource",
+            MANAGEMENT_ENDPOINT,
+            "-o",
+            "json",
+        ])
+        .stdin(Stdio::null())
+        .stderr(Stdio::inherit())
+        .output()
+        .context(
+            "failed to run `az`; install the Azure CLI (https://aka.ms/azure-cli) and run \
+             `az login`",
+        )?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`az account get-access-token` failed with status {}; run `az login`",
+            output.status
+        );
+    }
+
+    let document: AccessTokenDocument = serde_json::from_slice(&output.stdout)
+        .context("`az account get-access-token -o json` did not print the document it documents")?;
+    // Straight into the wrapper: from here the token only reaches an `Authorization` header.
+    Ok(SecretString::from(document.access_token))
+}
+
+/// What `az account get-access-token -o json` prints.
+#[derive(Debug, Deserialize)]
+struct AccessTokenDocument {
+    /// The bearer token itself. The other keys — expiry, subscription, tenant — say nothing this
+    /// needs, and `deny_unknown_fields` would break on the next one the CLI adds.
+    #[serde(rename = "accessToken")]
+    access_token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AppSettingsDocument, FunctionApp, OwnedAppSettingsDocument};
+    use std::collections::BTreeMap;
+
+    fn app() -> FunctionApp {
+        FunctionApp {
+            subscription_id: "00000000-0000-0000-0000-000000000000".to_owned(),
+            resource_group: "skyzen-rg".to_owned(),
+            name: "skyzen-demo".to_owned(),
+        }
+    }
+
+    #[test]
+    fn the_two_calls_address_the_same_settings_resource() {
+        assert_eq!(
+            app().url("/list"),
+            "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/\
+             resourceGroups/skyzen-rg/providers/Microsoft.Web/sites/skyzen-demo/config/\
+             appsettings/list?api-version=2022-03-01"
+        );
+        assert!(app().url("").contains("/config/appsettings?api-version="));
+    }
+
+    #[test]
+    fn the_body_is_the_whole_settings_map_under_properties() {
+        let settings = BTreeMap::from([("STRIPE_KEY".to_owned(), "sk_live_123".to_owned())]);
+        let rendered = serde_json::to_value(AppSettingsDocument {
+            properties: &settings,
+        })
+        .expect("the body serializes");
+
+        assert_eq!(rendered["properties"]["STRIPE_KEY"], "sk_live_123");
+        assert_eq!(
+            rendered.as_object().expect("an object").len(),
+            1,
+            "ARM replaces the whole map, so `properties` is the only key it reads"
+        );
+    }
+
+    #[test]
+    fn an_app_with_no_settings_reads_back_as_an_empty_map() {
+        let document: OwnedAppSettingsDocument = serde_json::from_str("{}").expect("parses");
+        assert!(document.properties.is_empty());
+
+        let document: OwnedAppSettingsDocument =
+            serde_json::from_str(r#"{"id":"/subscriptions/x","properties":{"A":"1"}}"#)
+                .expect("parses");
+        assert_eq!(document.properties.get("A").map(String::as_str), Some("1"));
+    }
+}

--- a/cli/src/providers/azure/bundle.rs
+++ b/cli/src/providers/azure/bundle.rs
@@ -3,7 +3,7 @@
 //! Rendered from typed structs through `serde_json` rather than assembled as text, so a key that
 //! is renamed or dropped fails the build instead of producing a bundle the host silently ignores.
 
-use crate::providers::GeneratedFile;
+use crate::providers::{FileContents, GeneratedFile};
 use anyhow::{Context, Result};
 use serde::Serialize;
 use skyzen_manifest::{AzureQueueTrigger, AzureSection, HTTP_FUNCTION_NAME};
@@ -34,25 +34,25 @@ pub fn render(
     let mut files = vec![
         GeneratedFile {
             path: bundle_dir.join("host.json"),
-            contents: to_json(&HostJson::new(config, binary))?,
+            contents: FileContents::Public(to_json(&HostJson::new(config, binary))?),
         },
         GeneratedFile {
             path: bundle_dir.join("local.settings.json"),
-            contents: to_json(&LocalSettings::default())?,
+            contents: FileContents::Public(to_json(&LocalSettings::default())?),
         },
         GeneratedFile {
             // Every HTTP request arrives through this one function: its route is a wildcard and
             // it accepts every method, so routing stays the application's own router's job. The
             // name is reserved in the schema, so no queue trigger can take this directory.
             path: bundle_dir.join(HTTP_FUNCTION_NAME).join("function.json"),
-            contents: to_json(&FunctionJson::http())?,
+            contents: FileContents::Public(to_json(&FunctionJson::http())?),
         },
     ];
 
     for trigger in &config.queue_triggers {
         files.push(GeneratedFile {
             path: bundle_dir.join(&trigger.function).join("function.json"),
-            contents: to_json(&FunctionJson::queue(trigger))?,
+            contents: FileContents::Public(to_json(&FunctionJson::queue(trigger))?),
         });
     }
 
@@ -268,7 +268,7 @@ struct Binding {
 
 #[cfg(test)]
 mod tests {
-    use super::render;
+    use super::{render, FileContents};
     use skyzen_manifest::Manifest;
     use std::path::{Path, PathBuf};
 
@@ -290,9 +290,12 @@ mod tests {
         .expect("the bundle renders")
         .into_iter()
         .map(|file| {
-            let parsed = serde_json::from_str(&file.contents)
+            let FileContents::Public(contents) = &file.contents else {
+                panic!("{} is configuration, not values", file.path.display());
+            };
+            let parsed = serde_json::from_str(contents)
                 .unwrap_or_else(|error| panic!("{} is not JSON: {error}", file.path.display()));
-            (file.path, parsed)
+            (file.path.clone(), parsed)
         })
         .collect()
     }

--- a/cli/src/providers/cloudflare/build.rs
+++ b/cli/src/providers/cloudflare/build.rs
@@ -117,7 +117,7 @@ pub struct BuildPlan {
     pub optimize: bool,
 }
 
-impl crate::providers::ArtifactBuild for BuildPlan {
+impl crate::providers::Task for BuildPlan {
     /// A one-line description for progress output and `--dry-run`.
     fn describe(&self) -> String {
         format!(

--- a/cli/src/providers/cloudflare/mod.rs
+++ b/cli/src/providers/cloudflare/mod.rs
@@ -3,17 +3,20 @@
 pub mod build;
 pub mod ids;
 pub mod provision;
+mod secrets;
 pub mod wrangler;
 
 use crate::{
-    cli::SecretCommand,
     project::{Project, WASM_TARGET},
     providers::{
-        Action, CommandPlan, CommandStdin, FileContents, GeneratedFile, ProviderPlan, RunMode, Step,
+        Action, CommandPlan, CommandStdin, FileContents, GeneratedFile, ProviderPlan, RunMode,
+        SecretAction, Step,
     },
 };
+
 use anyhow::{Context, Result};
 use build::{BuildPlan, DurableObjectExport};
+use secrets::SecretDelivery;
 use skyzen_manifest::{CloudflareSection, Manifest, ServiceType, SkyzenManifest};
 use std::{
     collections::BTreeSet,
@@ -45,10 +48,11 @@ pub fn prepare(
     ensure_bindings_line_up(manifest.data(), config)?;
 
     let wrangler_path = manifest.root_dir().join(WRANGLER_CONFIG_PATH);
-    let wrangler_dir = wrangler_path
+    let wrangler_dir_path = wrangler_path
         .parent()
         .context("the generated wrangler.toml has no parent directory")?
         .to_path_buf();
+    let wrangler_dir = wrangler_dir_path.clone();
 
     let needs_artifacts = matches!(
         action,
@@ -102,14 +106,16 @@ pub fn prepare(
         .iter()
         .map(|entry| entry.database_name.clone())
         .collect();
-    let commands = wrangler_commands(
+    let planned = plan_work(&WorkRequest {
         action,
-        &wrangler_path,
-        manifest.root_dir(),
+        manifest,
+        config,
+        wrangler_path: &wrangler_path,
+        wrangler_dir: &wrangler_dir_path,
         environment,
         dry_run,
-        &database_names,
-    )?;
+        databases: &database_names,
+    })?;
     let run_mode = if matches!(action, Action::Dev { .. }) {
         // wrangler picks up the regenerated `dist/` on its own, so a source change re-runs the
         // build while `wrangler dev` keeps running — restarting it would drop local state and
@@ -119,12 +125,15 @@ pub fn prepare(
         RunMode::Once
     };
 
+    let mut generated_files = vec![GeneratedFile {
+        path: wrangler_path,
+        contents: FileContents::Public(rendered),
+    }];
+    generated_files.extend(planned.generated_files);
+
     Ok(ProviderPlan {
-        steps: commands.into_iter().map(Step::Command).collect(),
-        generated_files: vec![GeneratedFile {
-            path: wrangler_path,
-            contents: FileContents::Public(rendered),
-        }],
+        steps: planned.steps,
+        generated_files,
         build: boxed_build,
         run_mode,
         child_env: Vec::new(),
@@ -133,88 +142,169 @@ pub fn prepare(
     })
 }
 
-/// The wrangler invocations one action needs.
-fn wrangler_commands(
-    action: &Action,
-    wrangler_path: &Path,
-    root_dir: &Path,
-    environment: Option<&str>,
+/// Everything the work for one action is planned from.
+#[derive(Debug)]
+struct WorkRequest<'a> {
+    /// What was asked for.
+    action: &'a Action,
+    /// The project.
+    manifest: &'a Manifest,
+    /// The selected environment's Cloudflare section.
+    config: &'a CloudflareSection,
+    /// The generated wrangler configuration every invocation is pointed at.
+    wrangler_path: &'a Path,
+    /// Its directory, which is where wrangler resolves `.dev.vars` against.
+    wrangler_dir: &'a Path,
+    /// The `--env` the user selected, if any.
+    environment: Option<&'a str>,
+    /// Whether this is a dry run.
     dry_run: bool,
-    databases: &[String],
-) -> Result<Vec<CommandPlan>> {
-    let config_args = || -> Result<Vec<String>> {
-        let mut args = vec!["--config".to_owned(), path_string(wrangler_path)?];
-        if let Some(environment) = environment {
-            args.push("--env".to_owned());
-            args.push(environment.to_owned());
+    /// The D1 databases the manifest declares, for `migrate`.
+    databases: &'a [String],
+}
+
+/// The work one action performs, and the files it needs written first.
+#[derive(Debug, Default)]
+struct PlannedWork {
+    /// The steps, in order.
+    steps: Vec<Step>,
+    /// Files beyond the generated `wrangler.toml`.
+    generated_files: Vec<GeneratedFile>,
+}
+
+impl PlannedWork {
+    /// The plan for an action that only runs commands.
+    fn from_commands(commands: Vec<CommandPlan>) -> Self {
+        Self {
+            steps: commands.into_iter().map(Step::Command).collect(),
+            generated_files: Vec::new(),
         }
-        Ok(args)
+    }
+}
+
+/// The wrangler invocations and local work one action needs.
+fn plan_work(request: &WorkRequest<'_>) -> Result<PlannedWork> {
+    let config_path = path_string(request.wrangler_path)?;
+    let mut config_args = vec!["--config".to_owned(), config_path.clone()];
+    if let Some(environment) = request.environment {
+        config_args.push("--env".to_owned());
+        config_args.push(environment.to_owned());
+    }
+    let root_dir = request.manifest.root_dir();
+
+    let command = |head: &[&str], extra: &[String]| {
+        let mut args: Vec<String> = head.iter().map(|part| (*part).to_owned()).collect();
+        args.extend(config_args.iter().cloned());
+        args.extend(extra.iter().cloned());
+        CommandPlan {
+            program: "wrangler".to_owned(),
+            args,
+            cwd: Some(root_dir.to_path_buf()),
+            stdin: CommandStdin::Inherit,
+        }
     };
 
-    let command = |args: Vec<String>| CommandPlan {
-        program: "wrangler".to_owned(),
-        args,
-        cwd: Some(root_dir.to_path_buf()),
-        stdin: CommandStdin::Inherit,
+    let secrets = SecretDelivery {
+        manifest: request.manifest,
+        config: request.config,
+        config_args: &config_args,
+        config_path: &config_path,
+        cwd: root_dir,
     };
 
-    let commands = match action {
+    let work = match request.action {
         // `build` produces artifacts and stops; there is nothing for wrangler to do.
-        Action::Build { .. } => Vec::new(),
+        Action::Build { .. } => PlannedWork::default(),
         Action::Dev { runner_args } => {
-            let mut args = vec!["dev".to_owned(), "--local".to_owned()];
-            args.extend(config_args()?);
-            args.extend(runner_args.iter().cloned());
-            vec![command(args)]
+            // Every declared secret, store-backed ones included: `wrangler dev` serves from a
+            // local store that starts out empty however full the account's is.
+            let resolved = secrets.all()?;
+            let (mut steps, dev_vars) = secrets.local_work(&resolved, request.dev_vars_path())?;
+            steps.push(Step::Command(command(&["dev", "--local"], runner_args)));
+            PlannedWork {
+                steps,
+                generated_files: dev_vars.into_iter().collect(),
+            }
         }
         // One `wrangler d1 migrations` invocation per declared database — `apply` to run the
         // pending files, `list` to report them, which is D1's own `migrate status`. The migrations
         // directory comes from the generated config, so `migrations_dir` is set the same way every
         // other wrangler key is.
-        Action::Migrate { local, status } => databases
-            .iter()
-            .map(|database| {
-                let mut args = vec![
-                    "d1".to_owned(),
-                    "migrations".to_owned(),
-                    if *status { "list" } else { "apply" }.to_owned(),
-                    database.clone(),
-                ];
-                args.extend(config_args()?);
-                args.push(if *local { "--local" } else { "--remote" }.to_owned());
-                Ok(command(args))
-            })
-            .collect::<Result<Vec<_>>>()?,
+        Action::Migrate { local, status } => PlannedWork::from_commands(
+            request
+                .databases
+                .iter()
+                .map(|database| {
+                    command(
+                        &[
+                            "d1",
+                            "migrations",
+                            if *status { "list" } else { "apply" },
+                            database,
+                        ],
+                        &[if *local { "--local" } else { "--remote" }.to_owned()],
+                    )
+                })
+                .collect(),
+        ),
         Action::Deploy => {
-            let mut args = vec!["deploy".to_owned()];
-            args.extend(config_args()?);
-            if dry_run {
-                // Unlike every other command, `deploy --dry-run` runs the real build and hands the
-                // real bundle to wrangler; only the upload is skipped. The previous behaviour
-                // skipped the build entirely, so it validated nothing.
-                args.push("--dry-run".to_owned());
+            // Resolved before anything is uploaded, and under `--dry-run` too: a deployment that
+            // ships half its configuration fails at cold start, where the message is a panic in a
+            // log rather than a list of manifest entries.
+            let resolved = secrets.classic()?;
+            let mut commands = vec![command(
+                &["deploy"],
+                &if request.dry_run {
+                    // Unlike every other command, `deploy --dry-run` runs the real build and hands
+                    // the real bundle to wrangler; only the upload is skipped.
+                    vec!["--dry-run".to_owned()]
+                } else {
+                    Vec::new()
+                },
+            )];
+            // Values are attached to the Worker the upload just created, so there is nothing to
+            // attach them to when nothing was uploaded.
+            if !request.dry_run {
+                commands.extend(secrets.bulk_step(&resolved)?);
             }
-            vec![command(args)]
+            PlannedWork::from_commands(commands)
         }
         Action::Logs { wrangler_args } => {
-            let mut args = vec!["tail".to_owned()];
-            args.extend(config_args()?);
-            args.extend(wrangler_args.iter().cloned());
-            vec![command(args)]
+            PlannedWork::from_commands(vec![command(&["tail"], wrangler_args)])
         }
-        Action::Secret(SecretCommand::Set { name }) => {
-            let mut args = vec!["secret".to_owned(), "put".to_owned(), name.clone()];
-            args.extend(config_args()?);
-            vec![command(args)]
+        Action::Secret(SecretAction::Set { name, value }) => PlannedWork {
+            steps: vec![secrets.set_step(name, value)],
+            generated_files: Vec::new(),
+        },
+        Action::Secret(SecretAction::Push) => {
+            let resolved = secrets.classic()?;
+            let bulk = secrets.bulk_step(&resolved)?.context(
+                "there is no classic [[secret]] to push. A `[cloudflare.secret.<NAME>]` entry is \
+                 backed by Secrets Store, which is externally managed: write one with `skyzen \
+                 secret set <NAME>`",
+            )?;
+            PlannedWork::from_commands(vec![bulk])
         }
-        Action::Secret(SecretCommand::List) => {
-            let mut args = vec!["secret".to_owned(), "list".to_owned()];
-            args.extend(config_args()?);
-            vec![command(args)]
+        Action::Secret(SecretAction::List) => {
+            PlannedWork::from_commands(vec![command(&["secret", "list"], &[])])
         }
     };
 
-    Ok(commands)
+    Ok(work)
+}
+
+impl WorkRequest<'_> {
+    /// Where `wrangler dev` reads local values from.
+    ///
+    /// Beside the generated configuration, because that is what wrangler resolves the name
+    /// against. With `--env`, the suffixed name: wrangler loads *only* `.dev.vars.<env>` when it
+    /// exists, so writing the plain name under a named environment would be read by nothing.
+    fn dev_vars_path(&self) -> PathBuf {
+        self.wrangler_dir.join(self.environment.map_or_else(
+            || ".dev.vars".to_owned(),
+            |environment| format!(".dev.vars.{environment}"),
+        ))
+    }
 }
 
 /// Fail when a portable capability's Cloudflare wiring does not line up with its binding.
@@ -412,16 +502,60 @@ fn path_string(path: &Path) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{binding_problems, collect_local_durable_exports, wrangler_commands};
-    use crate::{
-        cli::SecretCommand,
-        providers::{Action, CommandPlan},
+    use super::{
+        binding_problems, collect_local_durable_exports, plan_work, PlannedWork, WorkRequest,
     };
-    use skyzen_manifest::Manifest;
-    use std::path::Path;
+    use crate::{
+        environment,
+        providers::{Action, CommandPlan, CommandStdin, FileContents, SecretAction, Step},
+    };
+    use secrecy::SecretString;
+    use skyzen_manifest::{Manifest, VarName};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
 
     fn manifest(source: &str) -> Manifest {
         Manifest::parse(source, "Skyzen.toml", "/tmp/app").expect("valid manifest")
+    }
+
+    /// A `[cloudflare]` section with nothing in it but the key every manifest needs, and a named
+    /// environment for the tests that select one.
+    const SECTION: &str =
+        "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n[cloudflare.env.staging]\n";
+
+    /// A project whose root holds `dotenv`, so a declared secret resolves without the test having
+    /// to mutate the process environment (which every other test in the binary shares).
+    fn project(source: &str, dotenv: &str) -> (TempDir, Manifest) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join(".env"), dotenv).expect("write .env");
+        let manifest = Manifest::parse(source, dir.path().join("Skyzen.toml"), dir.path())
+            .expect("valid manifest");
+        (dir, manifest)
+    }
+
+    /// The work one action plans, as the CLI would plan it.
+    fn work(
+        action: &Action,
+        manifest: &Manifest,
+        environment: Option<&str>,
+        dry_run: bool,
+    ) -> anyhow::Result<PlannedWork> {
+        let wrangler_path = manifest.root_dir().join(super::WRANGLER_CONFIG_PATH);
+        let wrangler_dir: PathBuf = wrangler_path.parent().expect("a parent").to_path_buf();
+        let config = manifest
+            .cloudflare(environment)
+            .expect("base")
+            .expect("cloudflare section");
+        plan_work(&WorkRequest {
+            action,
+            manifest,
+            config,
+            wrangler_path: &wrangler_path,
+            wrangler_dir: &wrangler_dir,
+            environment,
+            dry_run,
+            databases: &["app".to_owned()],
+        })
     }
 
     fn problems(source: &str) -> Vec<String> {
@@ -480,18 +614,12 @@ mod tests {
     }
 
     fn planned(action: &Action, environment: Option<&str>, dry_run: bool) -> Vec<String> {
-        wrangler_commands(
-            action,
-            Path::new("/tmp/app/.skyzen/gen/wrangler.toml"),
-            Path::new("/tmp/app"),
-            environment,
-            dry_run,
-            &["app".to_owned()],
-        )
-        .expect("commands")
-        .iter()
-        .map(CommandPlan::display)
-        .collect()
+        work(action, &manifest(SECTION), environment, dry_run)
+            .expect("commands")
+            .steps
+            .iter()
+            .map(Step::describe)
+            .collect()
     }
 
     fn rendered(action: &Action, environment: Option<&str>, dry_run: bool) -> String {
@@ -529,14 +657,8 @@ mod tests {
         assert!(logs.contains("wrangler tail"), "{logs}");
         assert!(logs.contains("--format json)"), "{logs}");
 
-        let secret = rendered(
-            &Action::Secret(SecretCommand::Set {
-                name: "API_KEY".to_owned(),
-            }),
-            None,
-            false,
-        );
-        assert!(secret.contains("wrangler secret put API_KEY"), "{secret}");
+        let list = rendered(&Action::Secret(SecretAction::List), None, false);
+        assert!(list.contains("wrangler secret list"), "{list}");
     }
 
     #[test]
@@ -596,5 +718,222 @@ mod tests {
             "{status:?}"
         );
         assert!(status[0].contains("--remote"), "{status:?}");
+    }
+
+    /// A declared secret, and the same secret backed by a Secrets Store entry.
+    const CLASSIC: &str = "[[secret]]\nname = \"STRIPE_KEY\"\n\n[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+         [cloudflare.env.staging]\n";
+    const STORE_BACKED: &str = "[[secret]]\nname = \"STRIPE_KEY\"\n\n[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+         [cloudflare.secret.STRIPE_KEY]\nstore_id = \"store_1\"\nsecret_name = \"stripe-key\"\n";
+
+    /// The commands of a plan, with what each carries on its standard input.
+    fn commands(work: &PlannedWork) -> Vec<&CommandPlan> {
+        work.steps
+            .iter()
+            .filter_map(|step| match step {
+                Step::Command(command) => Some(command),
+                Step::Task(_) => None,
+            })
+            .collect()
+    }
+
+    /// What a command was given to write to the process's standard input.
+    fn stdin(command: &CommandPlan) -> Option<&str> {
+        match &command.stdin {
+            CommandStdin::Inherit => None,
+            CommandStdin::Secret(value) => Some(environment::expose(value)),
+        }
+    }
+
+    #[test]
+    fn a_deploy_delivers_the_declared_secrets_after_the_upload() {
+        let (_dir, manifest) = project(CLASSIC, "STRIPE_KEY=sk_live_123\n");
+        let planned = work(&Action::Deploy, &manifest, None, false).expect("plan");
+
+        let commands = commands(&planned);
+        assert_eq!(commands.len(), 2, "{planned:?}");
+        assert!(commands[0].display().contains("wrangler deploy"));
+        // After the upload: the values are attached to the Worker it created.
+        assert!(
+            commands[1].display().contains("wrangler secret bulk"),
+            "{:?}",
+            commands[1].display()
+        );
+        assert_eq!(stdin(commands[1]), Some(r#"{"STRIPE_KEY":"sk_live_123"}"#));
+        // The whole point of standard input: the rendering carries none of it.
+        assert!(!commands[1].display().contains("sk_live_123"));
+    }
+
+    #[test]
+    fn a_deploy_refuses_when_a_declared_secret_is_set_nowhere() {
+        let (_dir, manifest) = project(CLASSIC, "");
+        let error = work(&Action::Deploy, &manifest, None, false)
+            .expect_err("the value is set nowhere, and a Worker without it panics at cold start");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("STRIPE_KEY"), "{rendered}");
+        assert!(rendered.contains("[[secret]] STRIPE_KEY"), "{rendered}");
+    }
+
+    #[test]
+    fn a_deploy_needs_neither_a_store_backed_secret_nor_a_native_wiring_variable() {
+        // A Secrets Store entry is bound rather than uploaded, and a Worker resolves its services
+        // from bindings — so demanding either value would refuse a complete deployment.
+        let source = format!(
+            "{STORE_BACKED}\n[[database]]\nname = \"main\"\ntype = \"sql\"\n\n\
+             [native.database.main]\nbackend = \"postgres\"\nurl_env = \"JOURNAL_URL\"\n"
+        );
+        let (_dir, manifest) = project(&source, "");
+        let planned = work(&Action::Deploy, &manifest, None, false).expect("plan");
+
+        let commands = commands(&planned);
+        assert_eq!(commands.len(), 1, "nothing to deliver: {planned:?}");
+        assert!(commands[0].display().contains("wrangler deploy"));
+    }
+
+    #[test]
+    fn a_dry_run_deploy_uploads_nothing_and_so_delivers_nothing() {
+        let (_dir, manifest) = project(CLASSIC, "STRIPE_KEY=sk_live_123\n");
+        let planned = work(&Action::Deploy, &manifest, None, true).expect("plan");
+
+        let commands = commands(&planned);
+        assert_eq!(commands.len(), 1, "{planned:?}");
+        assert!(commands[0].display().contains("--dry-run"));
+    }
+
+    #[test]
+    fn dev_writes_the_declared_secrets_where_wrangler_reads_them() {
+        let (_dir, manifest) = project(CLASSIC, "STRIPE_KEY=sk_live_123\n");
+        let planned = work(
+            &Action::Dev {
+                runner_args: Vec::new(),
+            },
+            &manifest,
+            None,
+            false,
+        )
+        .expect("plan");
+
+        assert_eq!(planned.generated_files.len(), 1);
+        let file = &planned.generated_files[0];
+        assert_eq!(file.path, manifest.root_dir().join(".skyzen/gen/.dev.vars"));
+        let FileContents::Secret(contents) = &file.contents else {
+            panic!("a file of values is not public: {:?}", file.contents);
+        };
+        assert_eq!(environment::expose(contents), "STRIPE_KEY='sk_live_123'\n");
+    }
+
+    #[test]
+    fn a_named_environment_writes_the_file_wrangler_actually_loads() {
+        // wrangler loads `.dev.vars.<env>` *instead of* `.dev.vars` when it exists, so writing the
+        // plain name under `--env staging` would be read by nothing.
+        let (_dir, manifest) = project(CLASSIC, "STRIPE_KEY=sk_live_123\n");
+        let planned = work(
+            &Action::Dev {
+                runner_args: Vec::new(),
+            },
+            &manifest,
+            Some("staging"),
+            false,
+        )
+        .expect("plan");
+
+        assert_eq!(
+            planned.generated_files[0].path,
+            manifest.root_dir().join(".skyzen/gen/.dev.vars.staging")
+        );
+    }
+
+    #[test]
+    fn dev_seeds_a_store_backed_secret_before_wrangler_starts() {
+        let (_dir, manifest) = project(STORE_BACKED, "STRIPE_KEY=sk_live_123\n");
+        let planned = work(
+            &Action::Dev {
+                runner_args: Vec::new(),
+            },
+            &manifest,
+            None,
+            false,
+        )
+        .expect("plan");
+
+        // Nothing classic is left, so there is no file to write.
+        assert!(planned.generated_files.is_empty(), "{planned:?}");
+        let described: Vec<String> = planned.steps.iter().map(Step::describe).collect();
+        assert_eq!(described.len(), 2, "{described:?}");
+        assert!(described[0].contains("wrangler's local"), "{described:?}");
+        assert!(described[0].contains("stripe-key"), "{described:?}");
+        assert!(!described[0].contains("sk_live_123"), "{described:?}");
+        // The supervised process is last, so the store is seeded by the time it reads it.
+        assert!(
+            described[1].contains("wrangler dev --local"),
+            "{described:?}"
+        );
+    }
+
+    #[test]
+    fn setting_a_classic_secret_hands_wrangler_the_value_on_standard_input() {
+        let (_dir, manifest) = project(CLASSIC, "");
+        let planned = work(
+            &Action::Secret(SecretAction::Set {
+                name: VarName::try_from("STRIPE_KEY".to_owned()).expect("a name"),
+                value: SecretString::from("sk_live_123"),
+            }),
+            &manifest,
+            None,
+            false,
+        )
+        .expect("plan");
+
+        let commands = commands(&planned);
+        assert_eq!(commands.len(), 1);
+        assert!(commands[0]
+            .display()
+            .contains("wrangler secret put STRIPE_KEY"));
+        assert!(!commands[0].display().contains("sk_live_123"));
+        assert_eq!(stdin(commands[0]), Some("sk_live_123"));
+    }
+
+    #[test]
+    fn setting_a_store_backed_secret_writes_the_account_store_rather_than_the_worker() {
+        let (_dir, manifest) = project(STORE_BACKED, "");
+        let planned = work(
+            &Action::Secret(SecretAction::Set {
+                name: VarName::try_from("STRIPE_KEY".to_owned()).expect("a name"),
+                value: SecretString::from("sk_live_123"),
+            }),
+            &manifest,
+            None,
+            false,
+        )
+        .expect("plan");
+
+        assert!(commands(&planned).is_empty(), "the id is not known yet");
+        let described = planned.steps[0].describe();
+        assert!(described.contains("the account's"), "{described}");
+        assert!(described.contains("store_1"), "{described}");
+        assert!(!described.contains("sk_live_123"), "{described}");
+    }
+
+    #[test]
+    fn push_delivers_every_classic_secret_without_rebuilding() {
+        let (_dir, manifest) = project(CLASSIC, "STRIPE_KEY=sk_live_123\n");
+        let planned =
+            work(&Action::Secret(SecretAction::Push), &manifest, None, false).expect("plan");
+
+        let commands = commands(&planned);
+        assert_eq!(commands.len(), 1);
+        assert!(commands[0].display().contains("wrangler secret bulk"));
+        assert_eq!(stdin(commands[0]), Some(r#"{"STRIPE_KEY":"sk_live_123"}"#));
+    }
+
+    #[test]
+    fn push_with_only_store_backed_secrets_says_what_writes_one_instead() {
+        let (_dir, manifest) = project(STORE_BACKED, "");
+        let error = work(&Action::Secret(SecretAction::Push), &manifest, None, false)
+            .expect_err("there is nothing a bulk upload could deliver");
+        assert!(
+            format!("{error:#}").contains("skyzen secret set"),
+            "{error:#}"
+        );
     }
 }

--- a/cli/src/providers/cloudflare/mod.rs
+++ b/cli/src/providers/cloudflare/mod.rs
@@ -8,7 +8,9 @@ pub mod wrangler;
 use crate::{
     cli::SecretCommand,
     project::{Project, WASM_TARGET},
-    providers::{Action, CommandPlan, FileContents, GeneratedFile, ProviderPlan, RunMode},
+    providers::{
+        Action, CommandPlan, CommandStdin, FileContents, GeneratedFile, ProviderPlan, RunMode, Step,
+    },
 };
 use anyhow::{Context, Result};
 use build::{BuildPlan, DurableObjectExport};
@@ -64,7 +66,7 @@ pub fn prepare(
     // Kept typed for the entry path below, and boxed into the plan for the CLI to run.
     let boxed_build = build
         .clone()
-        .map(|plan| Box::new(plan) as Box<dyn crate::providers::ArtifactBuild>);
+        .map(|plan| Box::new(plan) as Box<dyn crate::providers::Task>);
 
     let entry_js_path = build.as_ref().map_or_else(
         || manifest.root_dir().join(entry_relative_path(config)),
@@ -118,7 +120,7 @@ pub fn prepare(
     };
 
     Ok(ProviderPlan {
-        commands,
+        steps: commands.into_iter().map(Step::Command).collect(),
         generated_files: vec![GeneratedFile {
             path: wrangler_path,
             contents: FileContents::Public(rendered),
@@ -153,6 +155,7 @@ fn wrangler_commands(
         program: "wrangler".to_owned(),
         args,
         cwd: Some(root_dir.to_path_buf()),
+        stdin: CommandStdin::Inherit,
     };
 
     let commands = match action {

--- a/cli/src/providers/cloudflare/mod.rs
+++ b/cli/src/providers/cloudflare/mod.rs
@@ -8,7 +8,7 @@ pub mod wrangler;
 use crate::{
     cli::SecretCommand,
     project::{Project, WASM_TARGET},
-    providers::{Action, CommandPlan, GeneratedFile, ProviderPlan, RunMode},
+    providers::{Action, CommandPlan, FileContents, GeneratedFile, ProviderPlan, RunMode},
 };
 use anyhow::{Context, Result};
 use build::{BuildPlan, DurableObjectExport};
@@ -121,7 +121,7 @@ pub fn prepare(
         commands,
         generated_files: vec![GeneratedFile {
             path: wrangler_path,
-            contents: rendered,
+            contents: FileContents::Public(rendered),
         }],
         build: boxed_build,
         run_mode,

--- a/cli/src/providers/cloudflare/mod.rs
+++ b/cli/src/providers/cloudflare/mod.rs
@@ -639,8 +639,10 @@ mod tests {
             false,
         );
         assert!(dev.contains("wrangler dev --local"), "{dev}");
+        // Joined the way the plan joins it, so the separator is the host's on every platform.
+        let config = PathBuf::from("/tmp/app").join(super::WRANGLER_CONFIG_PATH);
         assert!(
-            dev.contains("--config /tmp/app/.skyzen/gen/wrangler.toml"),
+            dev.contains(&format!("--config {}", config.display())),
             "{dev}"
         );
         assert!(dev.contains("--env staging"), "{dev}");

--- a/cli/src/providers/cloudflare/secrets.rs
+++ b/cli/src/providers/cloudflare/secrets.rs
@@ -1,0 +1,569 @@
+//! Delivering `[[secret]]` values to a Worker.
+//!
+//! Two shapes, chosen per secret by the manifest: a *classic* Worker secret, which `wrangler
+//! secret bulk` uploads with the deployment and `.dev.vars` supplies locally, and a Secrets Store
+//! entry declared by `[cloudflare.secret.<NAME>]`, which the Worker binds rather than carries.
+//!
+//! A value never reaches a command line. `wrangler secret put`, `wrangler secret bulk` and the
+//! `secrets-store` commands all read from standard input when standard input is not a terminal, so
+//! everything here plans a [`CommandPlan`] whose [`CommandStdin::Secret`] carries the value and
+//! whose printed form carries none of it.
+
+use crate::{
+    environment::{self, ResolvedVariables, VariableKind},
+    providers::{
+        resolve_variables, run_command, CommandPlan, CommandStdin, FileContents, GeneratedFile,
+        Step, Task,
+    },
+};
+use anyhow::{Context, Result};
+use askama::Template;
+use regex::Regex;
+use secrecy::SecretString;
+use skyzen_manifest::{CloudflareSecretSection, CloudflareSection, Manifest, VarName};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+/// How many entries one `secrets-store secret list` page asks for.
+const PAGE_SIZE: usize = 100;
+
+/// The scopes a Secrets Store secret needs to be readable from a Worker.
+const WORKER_SCOPES: &str = "workers";
+
+/// Everything the secret sinks for one selected environment need.
+#[derive(Debug)]
+pub struct SecretDelivery<'a> {
+    /// The project, for its declarations and its `.env` files.
+    pub manifest: &'a Manifest,
+    /// The selected environment's Cloudflare section, which says which secrets are store-backed.
+    pub config: &'a CloudflareSection,
+    /// `--config <path> [--env <name>]`, as every other wrangler invocation takes it.
+    pub config_args: &'a [String],
+    /// The generated `wrangler.toml`, which is also what makes the local store the one
+    /// `wrangler dev` reads.
+    pub config_path: &'a str,
+    /// Where to run wrangler.
+    pub cwd: &'a Path,
+}
+
+impl SecretDelivery<'_> {
+    /// Whether `[cloudflare.secret.<name>]` backs this secret with a Secrets Store entry.
+    fn store_backed(&self, name: &VarName) -> Option<&CloudflareSecretSection> {
+        self.config.secret.get(name)
+    }
+
+    /// Every declared secret that is a classic Worker secret, resolved.
+    ///
+    /// Store-backed secrets are left out rather than resolved and skipped: they are externally
+    /// managed, so demanding a local value would refuse a deployment that is complete.
+    ///
+    /// # Errors
+    ///
+    /// Fails when one of them is set nowhere, naming every one that is.
+    pub fn classic(&self) -> Result<ResolvedVariables> {
+        resolve_variables(self.manifest, &[VariableKind::Secret], |variable| {
+            self.store_backed(&variable.name).is_none()
+        })
+    }
+
+    /// Every declared secret, resolved.
+    ///
+    /// # Errors
+    ///
+    /// Fails when one of them is set nowhere, naming every one that is.
+    pub fn all(&self) -> Result<ResolvedVariables> {
+        resolve_variables(self.manifest, &[VariableKind::Secret], |_| true)
+    }
+
+    /// One wrangler invocation carrying the generated configuration.
+    fn wrangler(&self, head: &[&str], args: &[String]) -> CommandPlan {
+        let mut all: Vec<String> = head.iter().map(|part| (*part).to_owned()).collect();
+        all.extend(args.iter().cloned());
+        CommandPlan {
+            program: "wrangler".to_owned(),
+            args: all,
+            cwd: Some(self.cwd.to_path_buf()),
+            stdin: CommandStdin::Inherit,
+        }
+    }
+
+    /// The arguments a `secrets-store` command takes.
+    ///
+    /// `--env` is not one of them: a store entry belongs to an account, not to a Worker
+    /// environment, and the configuration is only named so that the local store is the one
+    /// `wrangler dev` reads.
+    fn store_args(&self) -> Vec<String> {
+        vec!["--config".to_owned(), self.config_path.to_owned()]
+    }
+
+    /// `wrangler secret bulk`, reading `{"NAME":"value"}` on its standard input.
+    ///
+    /// `None` when there is nothing to deliver, because an empty document is an error to wrangler
+    /// and a project with no classic secrets has nothing to say about them.
+    ///
+    /// # Errors
+    ///
+    /// Fails only when the values cannot be encoded as JSON.
+    pub fn bulk_step(&self, resolved: &ResolvedVariables) -> Result<Option<CommandPlan>> {
+        if resolved.is_empty() {
+            return Ok(None);
+        }
+
+        // The one place these values are exposed: from here they go to wrangler's standard input
+        // and nowhere else.
+        let payload: BTreeMap<&str, &str> = resolved
+            .iter()
+            .map(|(name, value)| (name.as_str(), environment::expose(value)))
+            .collect();
+        let json = serde_json::to_string(&payload)
+            .context("failed to encode the secrets for `wrangler secret bulk`")?;
+
+        Ok(Some(
+            self.wrangler(&["secret", "bulk"], self.config_args)
+                .with_stdin(SecretString::from(json)),
+        ))
+    }
+
+    /// The work `skyzen secret set NAME` performs.
+    ///
+    /// A Secrets Store entry is externally managed, so `set` is the only command that writes one —
+    /// and it writes it in the account's store rather than in the Worker's own secrets.
+    pub fn set_step(&self, name: &VarName, value: &SecretString) -> Step {
+        self.store_backed(name).map_or_else(
+            || {
+                Step::Command(
+                    self.wrangler(&["secret", "put", name.as_str()], self.config_args)
+                        .with_stdin(environment::duplicate(value)),
+                )
+            },
+            |section| Step::Task(Box::new(self.seed(name, section, value, Store::Remote))),
+        )
+    }
+
+    /// The steps and the file `wrangler dev` needs before it can resolve a secret.
+    ///
+    /// Classic secrets go into a `.dev.vars` beside the generated configuration, which is where
+    /// wrangler looks for local values; store-backed ones are seeded into wrangler's *local*
+    /// store, which starts out empty however full the account's is.
+    ///
+    /// # Errors
+    ///
+    /// Fails when a value cannot be written as a dotenv entry, or when the file cannot be
+    /// rendered.
+    pub fn local_work(
+        &self,
+        resolved: &ResolvedVariables,
+        dev_vars_path: PathBuf,
+    ) -> Result<(Vec<Step>, Option<GeneratedFile>)> {
+        let mut steps = Vec::new();
+        let mut classic = Vec::new();
+        for (name, value) in resolved {
+            match self.store_backed(name) {
+                Some(section) => {
+                    steps.push(Step::Task(Box::new(self.seed(
+                        name,
+                        section,
+                        value,
+                        Store::Local,
+                    ))));
+                }
+                None => classic.push(DotenvEntry {
+                    name: name.to_string(),
+                    value: quote_dotenv_value(environment::expose(value)).with_context(|| {
+                        format!("failed to write the value of [[secret]] {name} to .dev.vars")
+                    })?,
+                }),
+            }
+        }
+
+        if classic.is_empty() {
+            return Ok((steps, None));
+        }
+        let rendered = DevVarsTemplate { entries: classic }
+            .render()
+            .context("failed to render .dev.vars")?;
+        Ok((
+            steps,
+            Some(GeneratedFile {
+                path: dev_vars_path,
+                contents: FileContents::Secret(SecretString::from(rendered)),
+            }),
+        ))
+    }
+
+    /// The task that writes one Secrets Store entry.
+    fn seed(
+        &self,
+        binding: &VarName,
+        section: &CloudflareSecretSection,
+        value: &SecretString,
+        store: Store,
+    ) -> SeedSecretsStoreSecret {
+        SeedSecretsStoreSecret {
+            store_id: section.store_id.clone(),
+            secret_name: section.secret_name.clone(),
+            binding: binding.clone(),
+            args: self.store_args(),
+            store,
+            cwd: self.cwd.to_path_buf(),
+            value: environment::duplicate(value),
+        }
+    }
+}
+
+/// Which Secrets Store a task writes to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Store {
+    /// The one `wrangler dev` serves from, which lives beside the configuration.
+    Local,
+    /// The account's, which a deployed Worker binds.
+    Remote,
+}
+
+impl Store {
+    /// The flag that selects it. wrangler's `secrets-store` commands act locally by default.
+    fn flags(self) -> Vec<String> {
+        match self {
+            Self::Local => Vec::new(),
+            Self::Remote => vec!["--remote".to_owned()],
+        }
+    }
+
+    /// How the store is named in a description.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Local => "wrangler's local",
+            Self::Remote => "the account's",
+        }
+    }
+}
+
+/// Put one Secrets Store entry's value in place.
+///
+/// A task rather than a command because wrangler has no "write by name": `secrets-store secret
+/// update` addresses an entry by an id that only `secrets-store secret list` knows, so what runs
+/// second depends on what the first answered.
+#[derive(Debug)]
+struct SeedSecretsStoreSecret {
+    /// The store to write in.
+    store_id: String,
+    /// The entry's name inside that store.
+    secret_name: String,
+    /// The `[[secret]]` this backs, for the description.
+    binding: VarName,
+    /// `--config <path>`, shared by all three commands.
+    args: Vec<String>,
+    /// Which store to write.
+    store: Store,
+    /// Where to run wrangler.
+    cwd: PathBuf,
+    /// The value.
+    value: SecretString,
+}
+
+impl Task for SeedSecretsStoreSecret {
+    fn describe(&self) -> String {
+        format!(
+            "seed {} Secrets Store entry `{}` in store {} for [[secret]] {}",
+            self.store.label(),
+            self.secret_name,
+            self.store_id,
+            self.binding
+        )
+    }
+
+    fn run(&self) -> Result<()> {
+        // An entry is written by id, so an existing one is updated and a first run creates it. An
+        // update carries the value alone: the scopes and the comment of an entry Skyzen did not
+        // create are somebody else's, and `--scopes` would replace them.
+        let command = self.existing_id()?.map_or_else(
+            || {
+                self.command(&[
+                    "create",
+                    &self.store_id,
+                    "--name",
+                    &self.secret_name,
+                    "--scopes",
+                    WORKER_SCOPES,
+                ])
+            },
+            |id| self.command(&["update", &self.store_id, "--secret-id", &id]),
+        );
+        run_command(
+            &command.with_stdin(environment::duplicate(&self.value)),
+            &[],
+        )
+    }
+}
+
+impl SeedSecretsStoreSecret {
+    /// One `wrangler secrets-store secret <verb> …` invocation.
+    fn command(&self, head: &[&str]) -> CommandPlan {
+        let mut args = vec!["secrets-store".to_owned(), "secret".to_owned()];
+        args.extend(head.iter().map(|part| (*part).to_owned()));
+        args.extend(self.store.flags());
+        args.extend(self.args.iter().cloned());
+        CommandPlan {
+            program: "wrangler".to_owned(),
+            args,
+            cwd: Some(self.cwd.clone()),
+            stdin: CommandStdin::Inherit,
+        }
+    }
+
+    /// The id of the entry named `secret_name`, when the store already holds one.
+    ///
+    /// # Errors
+    ///
+    /// Fails when wrangler cannot be run, when it fails for a reason other than the store being
+    /// empty, or when its table cannot be read.
+    fn existing_id(&self) -> Result<Option<String>> {
+        let mut page = 1_usize;
+        loop {
+            let listing = self.command(&[
+                "list",
+                &self.store_id,
+                "--per-page",
+                &PAGE_SIZE.to_string(),
+                "--page",
+                &page.to_string(),
+            ]);
+            let output = Command::new(&listing.program)
+                .args(&listing.args)
+                .current_dir(&self.cwd)
+                .stdin(Stdio::null())
+                .output()
+                .context("failed to launch wrangler to list a Secrets Store")?;
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !output.status.success() {
+                // wrangler reports an empty page as a failure rather than an empty table, which
+                // for a store nothing has been written to yet is the normal first run.
+                if is_empty_listing(&stdout) || is_empty_listing(&stderr) {
+                    return Ok(None);
+                }
+                anyhow::bail!(
+                    "`{}` failed:\n{}",
+                    listing.display(),
+                    if stderr.trim().is_empty() {
+                        stdout.trim()
+                    } else {
+                        stderr.trim()
+                    }
+                );
+            }
+
+            let rows = parse_secret_rows(&stdout)?;
+            if let Some(row) = rows.iter().find(|row| row.name == self.secret_name) {
+                return Ok(Some(row.id.clone()));
+            }
+            if rows.len() < PAGE_SIZE {
+                return Ok(None);
+            }
+            page += 1;
+        }
+    }
+}
+
+/// Whether wrangler's answer means "this store holds nothing", which is not an error.
+fn is_empty_listing(text: &str) -> bool {
+    text.contains("returned no secrets")
+}
+
+/// One row of the table `wrangler secrets-store secret list` prints.
+#[derive(Debug, PartialEq, Eq)]
+struct SecretRow {
+    /// The entry's name.
+    name: String,
+    /// The id `secrets-store secret update` addresses it by.
+    id: String,
+}
+
+/// Read the rows out of wrangler's listing.
+///
+/// The command has no machine-readable mode: it renders a `cli-table3` box-drawing table whose
+/// columns are Name, ID, Comment, Scopes, Status, Created and Modified. The header row is what the
+/// two columns of interest are located by, so a column added between them changes nothing here.
+///
+/// # Errors
+///
+/// Fails when a table was printed but its header names neither `Name` nor `ID`, which means
+/// wrangler's output has changed shape and a "no such entry" answer would be a guess.
+fn parse_secret_rows(text: &str) -> Result<Vec<SecretRow>> {
+    // Colour is off when wrangler's output is a pipe, but `FORCE_COLOR` overrides that, and a
+    // coloured cell would compare unequal to the name being looked for.
+    let ansi = Regex::new(r"\x1b\[[0-9;]*m").context("failed to build the ANSI escape pattern")?;
+    let mut rows = text.lines().filter_map(|line| {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('│') {
+            return None;
+        }
+        Some(
+            trimmed
+                .trim_matches('│')
+                .split('│')
+                .map(|cell| ansi.replace_all(cell, "").trim().to_owned())
+                .collect::<Vec<_>>(),
+        )
+    });
+
+    let Some(header) = rows.next() else {
+        return Ok(Vec::new());
+    };
+    let column = |title: &str| header.iter().position(|cell| cell == title);
+    let (Some(name), Some(id)) = (column("Name"), column("ID")) else {
+        anyhow::bail!(
+            "`wrangler secrets-store secret list` printed a table with no `Name` and `ID` \
+             columns, so Skyzen cannot tell whether the secret already exists:\n{}",
+            text.trim()
+        );
+    };
+
+    Ok(rows
+        .filter_map(|cells| {
+            Some(SecretRow {
+                name: cells.get(name)?.clone(),
+                id: cells.get(id)?.clone(),
+            })
+        })
+        .collect())
+}
+
+/// One line of a `.dev.vars` file, with its value already quoted.
+#[derive(Debug)]
+struct DotenvEntry {
+    /// The variable's name.
+    name: String,
+    /// The value, quoted for a dotenv reader.
+    value: String,
+}
+
+#[derive(Template)]
+#[template(path = "dev_vars.tmpl", escape = "none")]
+struct DevVarsTemplate {
+    /// The entries to write, in name order.
+    entries: Vec<DotenvEntry>,
+}
+
+/// Quote one value so that a dotenv reader hands back exactly it.
+///
+/// wrangler parses `.dev.vars` with npm's `dotenv`, which strips the surrounding quotes and, for a
+/// *double*-quoted value, turns `\n` and `\r` into real characters while leaving every other
+/// backslash exactly where it is. It has no `\"` or `\\` escape, so escaping a quote or a
+/// backslash the way a Rust or shell reader expects would put a literal backslash into the value.
+/// A *single*-quoted value carries no escapes at all in either that parser or Rust's `dotenvy`, so
+/// it is the faithful form for anything without a `'` in it — backslashes, double quotes and real
+/// newlines included. A value that does contain one falls back to double quotes, which is faithful
+/// as long as it carries neither a backslash nor a double quote.
+///
+/// # Errors
+///
+/// Fails for a value holding a single quote together with a double quote or a backslash: no
+/// quoting survives that round trip, and writing an approximation would hand the application a
+/// different secret than the one that was set.
+fn quote_dotenv_value(value: &str) -> Result<String> {
+    if !value.contains('\'') {
+        return Ok(format!("'{value}'"));
+    }
+    if !value.contains(['"', '\\']) {
+        return Ok(format!("\"{value}\""));
+    }
+    anyhow::bail!(
+        "the value holds a single quote together with a double quote or a backslash, and \
+         wrangler's `.dev.vars` reader has no escape that survives that round trip. Use a value \
+         without that combination for local development; the deployed value is unaffected."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_empty_listing, parse_secret_rows, quote_dotenv_value, SecretRow};
+
+    /// The table wrangler renders, with the columns its `logger.table` derives from a listing.
+    const LISTING: &str = "🔐 Listing secrets... (store-id: store_1, page: 1, per-page: 100)\n\
+         ┌───────────┬──────────┬─────────┬────────┬────────┬─────────┬──────────┐\n\
+         │ Name      │ ID       │ Comment │ Scopes │ Status │ Created │ Modified │\n\
+         ├───────────┼──────────┼─────────┼────────┼────────┼─────────┼──────────┤\n\
+         │ stripe-key│ id_one   │         │ workers│ active │ …       │ …        │\n\
+         ├───────────┼──────────┼─────────┼────────┼────────┼─────────┼──────────┤\n\
+         │ other     │ id_two   │         │ workers│ active │ …       │ …        │\n\
+         └───────────┴──────────┴─────────┴────────┴────────┴─────────┴──────────┘\n";
+
+    #[test]
+    fn the_listing_is_read_through_its_header_row() {
+        let rows = parse_secret_rows(LISTING).expect("a table wrangler could have printed");
+        assert_eq!(
+            rows,
+            [
+                SecretRow {
+                    name: "stripe-key".to_owned(),
+                    id: "id_one".to_owned()
+                },
+                SecretRow {
+                    name: "other".to_owned(),
+                    id: "id_two".to_owned()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_coloured_listing_reads_the_same() {
+        let coloured = LISTING.replace("stripe-key", "\u{1b}[34mstripe-key\u{1b}[39m");
+        let rows = parse_secret_rows(&coloured).expect("colour is not part of a name");
+        assert_eq!(rows[0].name, "stripe-key");
+    }
+
+    #[test]
+    fn a_table_whose_columns_cannot_be_found_is_an_error_rather_than_a_guess() {
+        let error = parse_secret_rows("│ Identifier │ Value │\n│ a │ b │\n")
+            .expect_err("Skyzen cannot tell whether the secret exists");
+        assert!(error.to_string().contains("Name"), "{error}");
+    }
+
+    #[test]
+    fn an_empty_store_is_reported_as_a_failure_and_is_not_one() {
+        assert!(is_empty_listing(
+            "✘ [ERROR] List request returned no secrets."
+        ));
+        assert!(!is_empty_listing("✘ [ERROR] Authentication error"));
+    }
+
+    #[test]
+    fn a_quoted_value_is_read_back_as_itself() {
+        for value in [
+            "sk_live_123",
+            r"back\slash",
+            "with \"double\" quotes",
+            "line\nbreak",
+            "with 'single' quotes",
+            "  padded  ",
+            "",
+        ] {
+            let quoted = quote_dotenv_value(value).expect("representable");
+            let dir = tempfile::tempdir().expect("temp dir");
+            let path = dir.path().join(".dev.vars");
+            std::fs::write(&path, format!("STRIPE_KEY={quoted}\n")).expect("write");
+
+            let parsed: Vec<(String, String)> = dotenvy::from_path_iter(&path)
+                .expect("read")
+                .map(|entry| entry.expect("parse"))
+                .collect();
+            assert_eq!(
+                parsed,
+                [("STRIPE_KEY".to_owned(), value.to_owned())],
+                "{value:?} was written as {quoted}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_value_no_quoting_survives_is_refused_rather_than_corrupted() {
+        let error = quote_dotenv_value("both ' and \" quotes").expect_err("not representable");
+        assert!(error.to_string().contains("single quote"), "{error}");
+    }
+}

--- a/cli/src/providers/cloudflare/wrangler.rs
+++ b/cli/src/providers/cloudflare/wrangler.rs
@@ -165,11 +165,13 @@ fn section_config(
                 environment: entry.environment.clone(),
             })
             .collect(),
+        // The binding is the `[[secret]]` name: it is what the map is keyed by, what the
+        // application reads the secret under, and what wrangler creates the `env.NAME` object as.
         secrets_store_secrets: config
-            .secrets_store_secrets
+            .secret
             .iter()
-            .map(|entry| WranglerSecretsStoreSecret {
-                binding: entry.binding.clone(),
+            .map(|(binding, entry)| WranglerSecretsStoreSecret {
+                binding: binding.to_string(),
                 store_id: entry.store_id.clone(),
                 secret_name: entry.secret_name.clone(),
             })
@@ -522,7 +524,8 @@ mod tests {
     #[test]
     fn renders_every_modelled_binding_kind() {
         let rendered = render_base(
-            "[cloudflare]\nname = \"skyzen-worker\"\nmain = \"dist/worker.js\"\n\
+            "[[secret]]\nname = \"API_KEY\"\n\n\
+             [cloudflare]\nname = \"skyzen-worker\"\nmain = \"dist/worker.js\"\n\
              compatibility_date = \"2025-02-01\"\ncompatibility_flags = [\"nodejs_compat\"]\n\
              account_id = \"abc\"\nworkers_dev = true\n\n\
              [cloudflare.vars]\nAPP_ENV = \"dev\"\n\n\
@@ -534,7 +537,7 @@ mod tests {
              [[cloudflare.queues.consumers]]\nqueue = \"jobs\"\nmax_batch_size = 10\ndead_letter_queue = \"jobs-dlq\"\n\n\
              [[cloudflare.services]]\nbinding = \"AUTH\"\nservice = \"auth-worker\"\nenvironment = \"production\"\n\n\
              [cloudflare.assets]\ndirectory = \"public\"\nbinding = \"ASSETS\"\nnot_found_handling = \"single-page-application\"\n\n\
-             [[cloudflare.secrets_store_secrets]]\nbinding = \"API_KEY\"\nstore_id = \"store\"\nsecret_name = \"api-key\"\n\n\
+             [cloudflare.secret.API_KEY]\nstore_id = \"store\"\nsecret_name = \"api-key\"\n\n\
              [[cloudflare.durable_objects.bindings]]\nname = \"STATE\"\nclass_name = \"State\"\n\n\
              [[cloudflare.durable_objects.migrations]]\ntag = \"v1\"\nnew_sqlite_classes = [\"State\"]\n",
             IdPolicy::RequireProvisioned,

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -10,14 +10,14 @@ mod native;
 
 use crate::{
     capabilities,
-    cli::{Provider, SecretCommand},
-    environment::{self, ResolvedVariables, VariableKind},
+    cli::Provider,
+    environment::{self, ResolvedVariables, RuntimeVariable, VariableKind},
     output,
     project::{Project, WASM_TARGET},
 };
 use anyhow::{Context, Result};
 use secrecy::{ExposeSecret as _, SecretString};
-use skyzen_manifest::Manifest;
+use skyzen_manifest::{Manifest, SkyzenManifest, VarName};
 use std::{
     fmt::Debug,
     io::Write as _,
@@ -27,7 +27,7 @@ use std::{
 
 /// What the user asked the CLI to do, once `new`, `add` and `completions` — which need no
 /// provider — have been handled.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum Action {
     /// Produce deployment artifacts and stop.
     Build {
@@ -47,7 +47,7 @@ pub enum Action {
         wrangler_args: Vec<String>,
     },
     /// Manage the deployed application's secrets.
-    Secret(SecretCommand),
+    Secret(SecretAction),
     /// Apply pending SQL migrations, or report which are still pending.
     Migrate {
         /// Act on the local emulator rather than the deployed database.
@@ -55,6 +55,26 @@ pub enum Action {
         /// Report what is applied and what is pending instead of applying anything.
         status: bool,
     },
+}
+
+/// One `skyzen secret` operation, carrying the value the user piped in when there is one.
+///
+/// `main` reads the value from the CLI's own standard input before any provider is asked for a
+/// plan: every provider then sees the same thing, and no provider has to know how a terminal
+/// prompts.
+#[derive(Debug)]
+pub enum SecretAction {
+    /// Set one secret's value.
+    Set {
+        /// The secret's name, checked against the manifest's `[[secret]]` entries before dispatch.
+        name: VarName,
+        /// The value to deliver.
+        value: SecretString,
+    },
+    /// Deliver every declared secret's local value, without rebuilding anything.
+    Push,
+    /// List the secrets the deployment has.
+    List,
 }
 
 impl Action {
@@ -108,9 +128,6 @@ impl CommandPlan {
     }
 
     /// The same command, with `value` written to its standard input.
-    // `expect` rather than `allow` so the marker removes itself: the Cloudflare secret sinks are
-    // the first callers, and the compiler points here the moment they exist.
-    #[expect(dead_code, reason = "the first caller is `skyzen secret set`")]
     #[must_use]
     pub fn with_stdin(mut self, value: SecretString) -> Self {
         self.stdin = CommandStdin::Secret(value);
@@ -128,7 +145,6 @@ pub enum CommandStdin {
     #[default]
     Inherit,
     /// A value written to the process, after which the pipe is closed.
-    #[expect(dead_code, reason = "the first caller is `skyzen secret set`")]
     Secret(SecretString),
 }
 
@@ -155,7 +171,7 @@ impl CommandStdin {
             .stdin
             .take()
             .context("the process was started without a standard input pipe")?;
-        let value = SecretString::from(value.expose_secret().to_owned());
+        let value = environment::duplicate(value);
         std::thread::spawn(move || {
             if let Err(error) = pipe.write_all(value.expose_secret().as_bytes()) {
                 output::warn(format!(
@@ -173,10 +189,6 @@ pub enum Step {
     /// An external process to run.
     Command(CommandPlan),
     /// Work the CLI performs itself.
-    #[expect(
-        dead_code,
-        reason = "the first planned task seeds a local Secrets Store entry"
-    )]
     Task(Box<dyn Task>),
 }
 
@@ -244,18 +256,7 @@ pub enum FileContents {
     /// Configuration, printed verbatim by `--dry-run`.
     Public(String),
     /// Values, never printed and written with owner-only permissions.
-    // Nothing in the binary builds one yet — the Cloudflare `.dev.vars` writer is the first that
-    // will. `expect` rather than `allow` so the marker removes itself: the compiler points at
-    // this line the moment it stops being true. Only outside `cfg(test)`, where the dry-run test
-    // already constructs one.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the first secret-valued generated file is `.dev.vars`"
-        )
-    )]
-    Secret(secrecy::SecretString),
+    Secret(SecretString),
 }
 
 /// How the supervised process and the build relate while `dev` is running.
@@ -402,6 +403,9 @@ pub fn prepare(
     }
 
     let manifest = load_or_empty(manifest_path)?;
+    if let Action::Secret(SecretAction::Set { name, .. }) = action {
+        ensure_declared_secret(manifest.data(), name)?;
+    }
     let project = Project::load(manifest.root_dir())?;
     capabilities::ensure_present(manifest.data(), &project)?;
 
@@ -852,10 +856,59 @@ pub fn prepare_child_environment(
     })
 }
 
+/// Resolve the runtime variables of the given kinds that `wanted` accepts.
+///
+/// The filter is what lets a provider leave out a variable it must not demand: a Cloudflare
+/// deployment binds a Secrets Store secret rather than uploading it, so requiring the value
+/// locally would refuse a deployment whose configuration is complete.
+///
+/// # Errors
+///
+/// Fails when a dotenv file cannot be read, or when a wanted variable is set nowhere.
+pub fn resolve_variables(
+    manifest: &Manifest,
+    kinds: &[VariableKind],
+    wanted: impl Fn(&RuntimeVariable) -> bool,
+) -> Result<ResolvedVariables> {
+    let loaded = environment::Environment::load(manifest.root_dir())
+        .context("failed to load the project's .env files")?;
+    let mut variables = environment::runtime_variables_of(manifest.data(), kinds);
+    variables.retain(wanted);
+    loaded.resolve(&variables)
+}
+
+/// Refuse a `secret set` for a name the manifest does not declare.
+///
+/// A name is what the application reads through its generated `Secret` extractor, so a name
+/// nothing declares would upload a value no code can reach — and the typo would only show up as a
+/// missing secret at cold start.
+fn ensure_declared_secret(manifest: &SkyzenManifest, name: &VarName) -> Result<()> {
+    if manifest.secret.iter().any(|entry| entry.name == *name) {
+        return Ok(());
+    }
+
+    let declared = manifest
+        .secret
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect::<Vec<_>>();
+    if declared.is_empty() {
+        anyhow::bail!(
+            "`{name}` is not a declared secret: Skyzen.toml has no [[secret]] entries. Add one \
+             (`[[secret]]` with `name = \"{name}\"`) so the application can read it."
+        );
+    }
+    anyhow::bail!(
+        "`{name}` is not a declared secret; Skyzen.toml declares: {}",
+        declared.join(", ")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Action, CommandPlan, CommandStdin};
     use crate::cli::Provider;
+    use skyzen_manifest::VarName;
     use std::path::PathBuf;
 
     #[test]
@@ -943,5 +996,57 @@ mod tests {
             stdin: CommandStdin::Inherit,
         };
         assert_eq!(plan.display(), "(cd /tmp/app && wrangler dev)");
+    }
+
+    #[test]
+    fn what_a_command_carries_on_standard_input_is_not_part_of_its_rendering() {
+        // The whole reason values travel on standard input: `--dry-run` and every progress line
+        // print a command in full, and neither may print a secret.
+        let plan = CommandPlan {
+            program: "wrangler".to_owned(),
+            args: vec!["secret".to_owned(), "bulk".to_owned()],
+            cwd: None,
+            stdin: CommandStdin::Inherit,
+        }
+        .with_stdin(secrecy::SecretString::from(
+            r#"{"STRIPE_KEY":"sk_live_123"}"#,
+        ));
+
+        assert_eq!(plan.display(), "wrangler secret bulk");
+        assert!(!plan.display().contains("sk_live_123"));
+        assert!(!super::Step::Command(plan)
+            .describe()
+            .contains("sk_live_123"));
+    }
+
+    #[test]
+    fn a_secret_no_entry_declares_is_refused_with_the_names_that_are() {
+        let manifest = skyzen_manifest::Manifest::parse(
+            "[[secret]]\nname = \"STRIPE_KEY\"\n\n[[secret]]\nname = \"JWT_SIGNING_KEY\"\n",
+            "Skyzen.toml",
+            "/tmp/app",
+        )
+        .expect("valid manifest");
+        let name = |text: &str| VarName::try_from(text.to_owned()).expect("a name");
+
+        super::ensure_declared_secret(manifest.data(), &name("STRIPE_KEY")).expect("declared");
+
+        let error = super::ensure_declared_secret(manifest.data(), &name("STRIPE_KEYY"))
+            .expect_err("a typo must not upload a value no code can read");
+        let rendered = error.to_string();
+        assert!(rendered.contains("STRIPE_KEY"), "{rendered}");
+        assert!(rendered.contains("JWT_SIGNING_KEY"), "{rendered}");
+    }
+
+    #[test]
+    fn a_project_declaring_no_secrets_says_how_to_declare_one() {
+        let manifest =
+            skyzen_manifest::Manifest::parse("", "Skyzen.toml", "/tmp/app").expect("empty");
+        let error = super::ensure_declared_secret(
+            manifest.data(),
+            &VarName::try_from("STRIPE_KEY".to_owned()).expect("a name"),
+        )
+        .expect_err("nothing is declared");
+        assert!(error.to_string().contains("[[secret]]"), "{error}");
     }
 }

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -11,7 +11,8 @@ mod native;
 use crate::{
     capabilities,
     cli::{Provider, SecretCommand},
-    environment, output,
+    environment::{self, ResolvedVariables, VariableKind},
+    output,
     project::{Project, WASM_TARGET},
 };
 use anyhow::{Context, Result};
@@ -120,12 +121,36 @@ pub trait ArtifactBuild: Debug + Send {
 }
 
 /// A file the CLI generates before running anything.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GeneratedFile {
     /// Where it goes.
     pub path: PathBuf,
     /// What goes in it.
-    pub contents: String,
+    pub contents: FileContents,
+}
+
+/// What a generated file holds, and therefore what `--dry-run` may print.
+///
+/// A generated `wrangler.toml` or `host.json` is configuration a user should be able to read
+/// before it is written; a `.dev.vars` is values. Making the distinction a type rather than a
+/// convention means a new generated file has to say which it is, and a printer cannot forget.
+#[derive(Debug)]
+pub enum FileContents {
+    /// Configuration, printed verbatim by `--dry-run`.
+    Public(String),
+    /// Values, never printed and written with owner-only permissions.
+    // Nothing in the binary builds one yet — the Cloudflare `.dev.vars` writer is the first that
+    // will. `expect` rather than `allow` so the marker removes itself: the compiler points at
+    // this line the moment it stops being true. Only outside `cfg(test)`, where the dry-run test
+    // already constructs one.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the first secret-valued generated file is `.dev.vars`"
+        )
+    )]
+    Secret(secrecy::SecretString),
 }
 
 /// How the supervised process and the build relate while `dev` is running.
@@ -516,38 +541,40 @@ fn check_manifest(
 /// project is diagnosed on is routinely not the one holding the production connection strings.
 /// `skyzen dev` is where an unset variable is an error, because that is where it would panic.
 fn report_native_wiring(manifest: &Manifest) {
-    let Some(native) = manifest.data().native.as_ref() else {
-        return;
-    };
-    if native.service.is_empty() && native.database.is_empty() {
-        return;
-    }
-
-    for (name, service) in &native.service {
-        output::ok(format!(
-            "native: service `{name}` is backed by `{}`",
-            service.backend().as_str()
-        ));
-    }
-    for (name, database) in &native.database {
-        output::ok(format!(
-            "native: database `{name}` is backed by `{}`",
-            database.backend().as_str()
-        ));
-    }
-
-    let dotenv = environment::load_dotenv_files(manifest.root_dir()).unwrap_or_else(|error| {
-        output::warn(format!("native: {error:#}"));
-        std::collections::BTreeMap::new()
-    });
-    for variable in environment::required_variables(manifest.data()) {
-        if dotenv.contains_key(&variable.name) || std::env::var_os(&variable.name).is_some() {
-            continue;
+    if let Some(native) = manifest.data().native.as_ref() {
+        for (name, service) in &native.service {
+            output::ok(format!(
+                "native: service `{name}` is backed by `{}`",
+                service.backend().as_str()
+            ));
         }
-        output::warn(format!(
-            "native: {} is set nowhere (declared by {}); `skyzen dev` will refuse to start",
-            variable.name, variable.declared_by
-        ));
+        for (name, database) in &native.database {
+            output::ok(format!(
+                "native: database `{name}` is backed by `{}`",
+                database.backend().as_str()
+            ));
+        }
+    }
+
+    let variables = environment::runtime_variables(manifest.data());
+    if variables.is_empty() {
+        return;
+    }
+    let loaded = environment::Environment::load(manifest.root_dir()).unwrap_or_else(|error| {
+        output::warn(format!("native: {error:#}"));
+        environment::Environment::default()
+    });
+    for variable in variables {
+        match loaded.get(variable.name.as_str()) {
+            Ok(Some(_)) => {}
+            Ok(None) => output::warn(format!(
+                "native: {} {} is set nowhere (declared by {}); `skyzen dev` will refuse to start",
+                variable.kind.label(),
+                variable.name,
+                variable.declared_by
+            )),
+            Err(error) => output::warn(format!("native: {} {error}", variable.name)),
+        }
     }
 }
 
@@ -595,16 +622,41 @@ fn check_cloudflare_manifest(manifest: &Manifest, environment: Option<&str>) -> 
     failures
 }
 
-/// Load the project's `.env` files and check every variable the manifest declares is available.
+/// The runtime variables one provider needs, resolved, plus the environment its child gets.
+#[derive(Debug, Default)]
+pub struct ChildEnvironment {
+    /// Every variable of the requested kinds, with the value found for it.
+    ///
+    /// A provider that delivers variables to a deployed function reads these; one that only runs
+    /// the application locally needs nothing beyond the resolution having succeeded.
+    // `expect` rather than `allow`: the AWS and Azure deploy sinks are what read it, and the
+    // compiler will point at this line once they do.
+    #[expect(dead_code, reason = "read by the per-provider delivery sinks")]
+    pub resolved: ResolvedVariables,
+    /// What to add to the child process's inherited environment.
+    pub child_env: Vec<(String, String)>,
+}
+
+/// Resolve the runtime variables of the given kinds, and say what a child process should be
+/// started with.
+///
+/// The child gets only the dotenv entries the CLI's own environment does not already hold, so a
+/// one-off `CACHE_URL=... skyzen dev` beats `.env` rather than the other way round.
 ///
 /// # Errors
 ///
 /// Fails when a dotenv file cannot be read, or when a declared variable is set nowhere.
-pub fn prepare_child_environment(manifest: &Manifest) -> Result<Vec<(String, String)>> {
-    let dotenv = environment::load_dotenv_files(manifest.root_dir())
+pub fn prepare_child_environment(
+    manifest: &Manifest,
+    kinds: &[VariableKind],
+) -> Result<ChildEnvironment> {
+    let loaded = environment::Environment::load(manifest.root_dir())
         .context("failed to load the project's .env files")?;
-    environment::ensure_available(&environment::required_variables(manifest.data()), &dotenv)?;
-    Ok(dotenv.into_iter().collect())
+    let resolved = loaded.resolve(&environment::runtime_variables_of(manifest.data(), kinds))?;
+    Ok(ChildEnvironment {
+        resolved,
+        child_env: loaded.child_overrides(),
+    })
 }
 
 #[cfg(test)]

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -7,6 +7,7 @@ pub mod aws;
 pub mod azure;
 pub mod cloudflare;
 mod native;
+pub mod secrets;
 
 use crate::{
     capabilities,
@@ -752,24 +753,45 @@ fn report_native_wiring(manifest: &Manifest) {
         }
     }
 
-    let variables = environment::runtime_variables(manifest.data());
+    report_runtime_variables(manifest, VariableKind::ALL, "native", "skyzen dev");
+}
+
+/// Report the runtime variables one provider is responsible for, and which of them have a value
+/// here.
+///
+/// A warning rather than a failure, and it counts none: `doctor` is not a run, and the machine a
+/// project is diagnosed on is routinely not the one holding the production connection strings. The
+/// command named in `refused_by` is where an unset variable *is* an error, because that is where
+/// it would either panic or ship a half-configured deployment.
+pub fn report_runtime_variables(
+    manifest: &Manifest,
+    kinds: &[VariableKind],
+    label: &str,
+    refused_by: &str,
+) {
+    let variables = environment::runtime_variables_of(manifest.data(), kinds);
     if variables.is_empty() {
         return;
     }
     let loaded = environment::Environment::load(manifest.root_dir()).unwrap_or_else(|error| {
-        output::warn(format!("native: {error:#}"));
+        output::warn(format!("{label}: {error:#}"));
         environment::Environment::default()
     });
     for variable in variables {
         match loaded.get(variable.name.as_str()) {
-            Ok(Some(_)) => {}
-            Ok(None) => output::warn(format!(
-                "native: {} {} is set nowhere (declared by {}); `skyzen dev` will refuse to start",
+            Ok(Some(_)) => output::ok(format!(
+                "{label}: {} {} is set (declared by {})",
                 variable.kind.label(),
                 variable.name,
                 variable.declared_by
             )),
-            Err(error) => output::warn(format!("native: {} {error}", variable.name)),
+            Ok(None) => output::warn(format!(
+                "{label}: {} {} is set nowhere (declared by {}); `{refused_by}` will refuse to run",
+                variable.kind.label(),
+                variable.name,
+                variable.declared_by
+            )),
+            Err(error) => output::warn(format!("{label}: {} {error}", variable.name)),
         }
     }
 }
@@ -824,11 +846,9 @@ pub struct ChildEnvironment {
     /// Every variable of the requested kinds, with the value found for it.
     ///
     /// A provider that delivers variables to a deployed function reads these; one that only runs
-    /// the application locally needs nothing beyond the resolution having succeeded.
-    // `expect` rather than `allow`: the AWS and Azure deploy sinks are what read it, and the
-    // compiler will point at this line once they do. The Cloudflare sinks resolve through
-    // `resolve_variables`, because what they deliver is not what their child process runs with.
-    #[expect(dead_code, reason = "read by the per-provider delivery sinks")]
+    /// the application locally needs nothing beyond the resolution having succeeded. The
+    /// Cloudflare sinks resolve through [`resolve_variables`] instead, because what they deliver
+    /// is not what their child process runs with.
     pub resolved: ResolvedVariables,
     /// What to add to the child process's inherited environment.
     pub child_env: Vec<(String, String)>,

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -16,11 +16,13 @@ use crate::{
     project::{Project, WASM_TARGET},
 };
 use anyhow::{Context, Result};
+use secrecy::{ExposeSecret as _, SecretString};
 use skyzen_manifest::Manifest;
 use std::{
     fmt::Debug,
+    io::Write as _,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
 };
 
 /// What the user asked the CLI to do, once `new`, `add` and `completions` — which need no
@@ -76,7 +78,7 @@ impl Action {
 }
 
 /// One external process to run.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CommandPlan {
     /// The program to launch.
     pub program: String,
@@ -84,10 +86,15 @@ pub struct CommandPlan {
     pub args: Vec<String>,
     /// The directory to launch it in.
     pub cwd: Option<PathBuf>,
+    /// What the process reads on its standard input.
+    pub stdin: CommandStdin,
 }
 
 impl CommandPlan {
     /// A copy-pasteable rendering, for progress output and `--dry-run`.
+    ///
+    /// The standard input is deliberately not part of it: a value delivered there is the one thing
+    /// about a command that must never reach a terminal or a log.
     pub fn display(&self) -> String {
         let command = if self.args.is_empty() {
             self.program.clone()
@@ -99,20 +106,118 @@ impl CommandPlan {
             None => command,
         }
     }
+
+    /// The same command, with `value` written to its standard input.
+    // `expect` rather than `allow` so the marker removes itself: the Cloudflare secret sinks are
+    // the first callers, and the compiler points here the moment they exist.
+    #[expect(dead_code, reason = "the first caller is `skyzen secret set`")]
+    #[must_use]
+    pub fn with_stdin(mut self, value: SecretString) -> Self {
+        self.stdin = CommandStdin::Secret(value);
+        self
+    }
 }
 
-/// The artifact build one provider performs before its commands run.
+/// What an external process reads on its standard input.
 ///
-/// Each provider's build is a different pipeline — wasm-bindgen glue for Cloudflare, a Linux
-/// cross-compile staged into a bundle for Azure — and only the provider knows what its own
-/// pipeline is, so the plan carries one of these rather than one provider's build plan standing in
-/// for all of them. A provider whose build is just a command (AWS runs `cargo lambda build`) uses
-/// a [`CommandPlan`] instead, where `--dry-run` can print it verbatim.
-pub trait ArtifactBuild: Debug + Send {
+/// The reason it is a field rather than a convention: a value handed to wrangler travels here and
+/// nowhere else, so [`CommandPlan::display`] can print every part of a command it *does* carry.
+#[derive(Debug, Default)]
+pub enum CommandStdin {
+    /// The CLI's own standard input, so a tool that prompts stays usable.
+    #[default]
+    Inherit,
+    /// A value written to the process, after which the pipe is closed.
+    #[expect(dead_code, reason = "the first caller is `skyzen secret set`")]
+    Secret(SecretString),
+}
+
+impl CommandStdin {
+    /// How the child's standard input is wired up.
+    fn stdio(&self) -> Stdio {
+        match self {
+            Self::Inherit => Stdio::inherit(),
+            Self::Secret(_) => Stdio::piped(),
+        }
+    }
+
+    /// Write the value to a spawned child, closing the pipe afterwards.
+    ///
+    /// On a thread of its own, because a value larger than the pipe buffer would otherwise
+    /// deadlock: the parent blocks writing while the child waits for input the parent is not
+    /// getting round to sending. The value is copied into the thread as another [`SecretString`],
+    /// so the copy is zeroized when the writer is done with it.
+    fn write_to(&self, child: &mut Child) -> Result<()> {
+        let Self::Secret(value) = self else {
+            return Ok(());
+        };
+        let mut pipe = child
+            .stdin
+            .take()
+            .context("the process was started without a standard input pipe")?;
+        let value = SecretString::from(value.expose_secret().to_owned());
+        std::thread::spawn(move || {
+            if let Err(error) = pipe.write_all(value.expose_secret().as_bytes()) {
+                output::warn(format!(
+                    "failed to write a value to the process's standard input: {error}"
+                ));
+            }
+        });
+        Ok(())
+    }
+}
+
+/// One piece of work in a provider's plan.
+#[derive(Debug)]
+pub enum Step {
+    /// An external process to run.
+    Command(CommandPlan),
+    /// Work the CLI performs itself.
+    #[expect(
+        dead_code,
+        reason = "the first planned task seeds a local Secrets Store entry"
+    )]
+    Task(Box<dyn Task>),
+}
+
+impl Step {
+    /// A one-line description, for progress output and `--dry-run`.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Command(command) => command.display(),
+            Self::Task(task) => task.describe(),
+        }
+    }
+
+    /// Perform it.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the process cannot be launched, when it exits non-zero, or when the task does.
+    pub fn run(&self, child_env: &[(String, String)]) -> Result<()> {
+        match self {
+            Self::Command(command) => run_command(command, child_env),
+            Self::Task(task) => {
+                output::step(task.describe());
+                task.run()
+            }
+        }
+    }
+}
+
+/// Work the CLI does itself rather than by launching a process.
+///
+/// An artifact build is one — wasm-bindgen glue for Cloudflare, a Linux cross-compile staged into
+/// a bundle for Azure — and so is anything whose next command depends on what the previous one
+/// answered, such as seeding a Secrets Store entry whose id is only known after listing the store.
+/// A step that is just a process uses a [`CommandPlan`] instead, where `--dry-run` prints it
+/// verbatim.
+pub trait Task: Debug + Send {
     /// A one-line description for progress output and `--dry-run`.
     fn describe(&self) -> String;
 
-    /// Produce the artifacts.
+    /// Do the work.
     ///
     /// # Errors
     ///
@@ -169,12 +274,15 @@ pub enum RunMode {
 /// What one provider decided to do.
 #[derive(Debug, Default)]
 pub struct ProviderPlan {
-    /// External processes to run, in order.
-    pub commands: Vec<CommandPlan>,
+    /// The work to perform after the build, in order.
+    pub steps: Vec<Step>,
     /// Files to write first.
     pub generated_files: Vec<GeneratedFile>,
     /// The artifact build to perform, when the action needs artifacts.
-    pub build: Option<Box<dyn ArtifactBuild>>,
+    ///
+    /// Separate from [`steps`](Self::steps) because it is the *supervised* build: `skyzen dev`
+    /// re-runs this one on every source change, and nothing else.
+    pub build: Option<Box<dyn Task>>,
     /// How to supervise the commands.
     pub run_mode: RunMode,
     /// Environment to hand the supervised process, never applied to the CLI's own environment.
@@ -186,6 +294,90 @@ pub struct ProviderPlan {
     /// `deploy --dry-run` maps onto `wrangler deploy --dry-run`, which validates the real bundle,
     /// so its plan runs for real and only the upload is skipped. Everything else prints instead.
     pub execute_despite_dry_run: bool,
+}
+
+impl ProviderPlan {
+    /// The steps a supervised run performs first, and the process it then supervises.
+    ///
+    /// The supervised process is the last step, and everything before it is a preamble that has to
+    /// have happened by the time it starts — seeding wrangler's local Secrets Store before
+    /// `wrangler dev` reads it, for one.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the plan ends in something other than a command, which would mean supervising
+    /// nothing while silently skipping the work that was planned.
+    pub fn supervised(&self) -> Result<(&[Step], &CommandPlan)> {
+        let (last, preamble) = self
+            .steps
+            .split_last()
+            .context("a supervised run needs a command to supervise")?;
+        let Step::Command(command) = last else {
+            anyhow::bail!(
+                "a supervised run must end in the process to supervise, not `{}`",
+                last.describe()
+            );
+        };
+        Ok((preamble, command))
+    }
+}
+
+/// Run every step in order, or report what they would have been.
+///
+/// # Errors
+///
+/// Fails on the first step that does, naming it.
+pub fn run_steps(steps: &[Step], simulate: bool, child_env: &[(String, String)]) -> Result<()> {
+    for step in steps {
+        if simulate {
+            output::dry_run(step.describe());
+            continue;
+        }
+        step.run(child_env)?;
+    }
+    Ok(())
+}
+
+/// Run one external command to completion.
+///
+/// # Errors
+///
+/// Fails when the program cannot be launched or exits non-zero.
+pub fn run_command(command: &CommandPlan, child_env: &[(String, String)]) -> Result<()> {
+    let display = command.display();
+    output::step(&display);
+    let mut child = spawn_command(command, child_env)?;
+    let status = child
+        .wait()
+        .with_context(|| format!("failed to wait for {}", command.program))?;
+    if !status.success() {
+        anyhow::bail!("command failed with status {status}: {display}");
+    }
+    Ok(())
+}
+
+/// Start one external command, handing it whatever its standard input carries.
+///
+/// # Errors
+///
+/// Fails when the program cannot be launched.
+pub fn spawn_command(command: &CommandPlan, child_env: &[(String, String)]) -> Result<Child> {
+    let mut process = Command::new(&command.program);
+    process
+        .args(&command.args)
+        .envs(child_env.iter().map(|(key, value)| (key, value)))
+        .stdin(command.stdin.stdio())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    if let Some(cwd) = &command.cwd {
+        process.current_dir(cwd);
+    }
+
+    let mut child = process
+        .spawn()
+        .with_context(|| format!("failed to launch {}", command.program))?;
+    command.stdin.write_to(&mut child)?;
+    Ok(child)
 }
 
 /// Build the plan for one action.
@@ -630,7 +822,8 @@ pub struct ChildEnvironment {
     /// A provider that delivers variables to a deployed function reads these; one that only runs
     /// the application locally needs nothing beyond the resolution having succeeded.
     // `expect` rather than `allow`: the AWS and Azure deploy sinks are what read it, and the
-    // compiler will point at this line once they do.
+    // compiler will point at this line once they do. The Cloudflare sinks resolve through
+    // `resolve_variables`, because what they deliver is not what their child process runs with.
     #[expect(dead_code, reason = "read by the per-provider delivery sinks")]
     pub resolved: ResolvedVariables,
     /// What to add to the child process's inherited environment.
@@ -661,7 +854,7 @@ pub fn prepare_child_environment(
 
 #[cfg(test)]
 mod tests {
-    use super::{Action, CommandPlan};
+    use super::{Action, CommandPlan, CommandStdin};
     use crate::cli::Provider;
     use std::path::PathBuf;
 
@@ -727,7 +920,7 @@ mod tests {
             false,
         )
         .expect("native dev needs no manifest");
-        assert!(plan.commands[0].display().contains("cargo run"));
+        assert!(plan.steps[0].describe().contains("cargo run"));
 
         // The Cloudflare path still fails, but with the message that says what to add.
         let error = super::prepare(
@@ -747,6 +940,7 @@ mod tests {
             program: "wrangler".to_owned(),
             args: vec!["dev".to_owned()],
             cwd: Some(PathBuf::from("/tmp/app")),
+            stdin: CommandStdin::Inherit,
         };
         assert_eq!(plan.display(), "(cd /tmp/app && wrangler dev)");
     }

--- a/cli/src/providers/native.rs
+++ b/cli/src/providers/native.rs
@@ -2,7 +2,9 @@
 
 use crate::{
     environment::VariableKind,
-    providers::{prepare_child_environment, Action, CommandPlan, ProviderPlan, RunMode},
+    providers::{
+        prepare_child_environment, Action, CommandPlan, CommandStdin, ProviderPlan, RunMode, Step,
+    },
 };
 use anyhow::Result;
 use skyzen_manifest::Manifest;
@@ -55,11 +57,12 @@ pub fn prepare(action: &Action, manifest: &Manifest) -> Result<ProviderPlan> {
     };
 
     Ok(ProviderPlan {
-        commands: vec![CommandPlan {
+        steps: vec![Step::Command(CommandPlan {
             program: "cargo".to_owned(),
             args,
             cwd: Some(root_dir.clone()),
-        }],
+            stdin: CommandStdin::Inherit,
+        })],
         generated_files: Vec::new(),
         build: None,
         run_mode,
@@ -92,16 +95,12 @@ mod tests {
         .expect("dev plan");
         assert_eq!(dev.run_mode, RunMode::Restart);
         // The separator is what makes the arguments reach the application, not cargo.
-        assert!(dev.commands[0]
-            .display()
-            .contains("cargo run -- --port 3000"));
+        assert!(dev.steps[0].describe().contains("cargo run -- --port 3000"));
         assert!(dev.watch_root.is_some());
 
         let build = prepare(&Action::Build { release: true }, &manifest).expect("build plan");
         assert_eq!(build.run_mode, RunMode::Once);
-        assert!(build.commands[0]
-            .display()
-            .contains("cargo build --release"));
+        assert!(build.steps[0].describe().contains("cargo build --release"));
         assert!(build.watch_root.is_none());
     }
 

--- a/cli/src/providers/native.rs
+++ b/cli/src/providers/native.rs
@@ -1,6 +1,9 @@
 //! The native provider: run the application as an ordinary binary.
 
-use crate::providers::{prepare_child_environment, Action, CommandPlan, ProviderPlan, RunMode};
+use crate::{
+    environment::VariableKind,
+    providers::{prepare_child_environment, Action, CommandPlan, ProviderPlan, RunMode},
+};
 use anyhow::Result;
 use skyzen_manifest::Manifest;
 
@@ -46,7 +49,7 @@ pub fn prepare(action: &Action, manifest: &Manifest) -> Result<ProviderPlan> {
     // runtime environment, and gating compilation on a connection string set only in production
     // would break every CI box.
     let child_env = if matches!(action, Action::Dev { .. }) {
-        prepare_child_environment(manifest)?
+        prepare_child_environment(manifest, VariableKind::ALL)?.child_env
     } else {
         Vec::new()
     };

--- a/cli/src/providers/secrets.rs
+++ b/cli/src/providers/secrets.rs
@@ -1,0 +1,151 @@
+//! What a provider hands a deployed function, and how it merges with what is already there.
+//!
+//! Lambda's function environment and a Function App's application settings are the same shape —
+//! one flat map of names to values, replaced wholesale by the call that writes it — so the read,
+//! merge and name-listing are here rather than twice. What differs is only the transport, which is
+//! each provider's own module.
+//!
+//! The values stay in [`SecretString`] from the moment they are read out of the environment until
+//! [`Delivery::merged_over`] builds the map that goes into the request body, which is the one
+//! place a value is exposed and the one place to look for a leak.
+
+use crate::environment::{self, ResolvedVariables};
+use secrecy::SecretString;
+use std::collections::BTreeMap;
+
+/// The variables one delivery sets on a deployed function.
+///
+/// Ordered by name, so a description and a request body list them the same way every run.
+#[derive(Debug, Default)]
+pub struct Delivery(BTreeMap<String, SecretString>);
+
+impl Delivery {
+    /// Every runtime variable the deployment resolved.
+    #[must_use]
+    pub fn from_resolved(resolved: &ResolvedVariables) -> Self {
+        Self(
+            resolved
+                .iter()
+                .map(|(name, value)| (name.to_string(), environment::duplicate(value)))
+                .collect(),
+        )
+    }
+
+    /// The same, with a plaintext table underneath it.
+    ///
+    /// A name the resolved variables also carry keeps its resolved value: `[aws.env]` is
+    /// documented as the *non-secret* table, so a name that is also a `[[secret]]` or a wiring
+    /// variable is one the deployment supplies a real value for, and shipping the manifest's copy
+    /// instead would deploy a placeholder.
+    #[must_use]
+    pub fn with_defaults(mut self, plaintext: &BTreeMap<String, String>) -> Self {
+        for (name, value) in plaintext {
+            self.0
+                .entry(name.clone())
+                .or_insert_with(|| SecretString::from(value.clone()));
+        }
+        self
+    }
+
+    /// One name and value, for `skyzen secret set`.
+    #[must_use]
+    pub fn one(name: &str, value: &SecretString) -> Self {
+        Self(BTreeMap::from([(
+            name.to_owned(),
+            environment::duplicate(value),
+        )]))
+    }
+
+    /// Whether there is nothing to deliver.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The names alone, which is all a description or a log line may carry.
+    #[must_use]
+    pub fn names(&self) -> String {
+        self.0
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// This delivery laid over what the deployment already has.
+    ///
+    /// A read-modify-write rather than a replace, because both platforms' write calls replace the
+    /// whole map: a variable another tool set — a Functions host setting, a value from the console
+    /// — would otherwise be deleted by a deploy that never mentioned it.
+    ///
+    /// The one place a delivered value is exposed: what comes back goes into the request body and
+    /// nowhere else.
+    #[must_use]
+    pub fn merged_over(
+        &self,
+        existing: impl IntoIterator<Item = (String, String)>,
+    ) -> BTreeMap<String, String> {
+        let mut merged: BTreeMap<String, String> = existing.into_iter().collect();
+        merged.extend(
+            self.0
+                .iter()
+                .map(|(name, value)| (name.clone(), environment::expose(value).to_owned())),
+        );
+        merged
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Delivery;
+    use secrecy::SecretString;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn a_delivery_keeps_what_is_already_there_and_wins_where_they_collide() {
+        let delivery = Delivery::one("STRIPE_KEY", &SecretString::from("sk_live_123"));
+        let merged = delivery.merged_over([
+            ("RUST_LOG".to_owned(), "info".to_owned()),
+            ("STRIPE_KEY".to_owned(), "stale".to_owned()),
+        ]);
+
+        // The Functions host's own settings, and anything set from a console, survive a deploy
+        // that never mentioned them.
+        assert_eq!(merged.get("RUST_LOG").map(String::as_str), Some("info"));
+        assert_eq!(
+            merged.get("STRIPE_KEY").map(String::as_str),
+            Some("sk_live_123")
+        );
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn a_resolved_value_beats_the_manifests_plaintext_copy() {
+        let resolved = crate::environment::from_dotenv("STRIPE_KEY=sk_live_123\n")
+            .resolve(&[crate::environment::RuntimeVariable {
+                name: skyzen_manifest::VarName::try_from("STRIPE_KEY".to_owned()).expect("a name"),
+                declared_by: "[[secret]] STRIPE_KEY".to_owned(),
+                kind: crate::environment::VariableKind::Secret,
+            }])
+            .expect("the dotenv entry supplies it");
+
+        let delivery = Delivery::from_resolved(&resolved).with_defaults(&BTreeMap::from([
+            ("RUST_LOG".to_owned(), "info".to_owned()),
+            ("STRIPE_KEY".to_owned(), "placeholder".to_owned()),
+        ]));
+        assert_eq!(delivery.names(), "RUST_LOG, STRIPE_KEY");
+
+        let merged = delivery.merged_over(BTreeMap::new());
+        assert_eq!(merged.get("RUST_LOG").map(String::as_str), Some("info"));
+        assert_eq!(
+            merged.get("STRIPE_KEY").map(String::as_str),
+            Some("sk_live_123")
+        );
+    }
+
+    #[test]
+    fn nothing_declared_is_nothing_to_deliver() {
+        assert!(Delivery::default().is_empty());
+        assert_eq!(Delivery::default().names(), "");
+    }
+}

--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -1,0 +1,27 @@
+//! The async runtime the CLI drives its own clients on.
+//!
+//! Nothing in the CLI is async: it is a program that runs a handful of requests and exits. The
+//! parts that talk to a cloud API or a database do so through crates that are — the AWS SDK, the
+//! ARM client, sqlx — so each of them borrows one current-thread runtime for the duration of the
+//! call and gives it back. A thread pool would be pure startup cost for a handful of round trips,
+//! and a runtime built per call site would be the same three lines written four times.
+
+use anyhow::{Context, Result};
+use std::future::Future;
+
+/// Run one future to completion on a current-thread runtime built for it.
+///
+/// `enable_all` is what gives the drivers underneath a reactor and a timer; without it a TCP
+/// connection or a waiter's sleep panics rather than failing.
+///
+/// # Errors
+///
+/// Fails when the runtime cannot be built, which on a healthy machine means the process is out of
+/// file descriptors.
+pub fn block_on<F: Future>(future: F) -> Result<F::Output> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to start the async runtime the CLI's clients need")?;
+    Ok(runtime.block_on(future))
+}

--- a/cli/src/scaffold/tests.rs
+++ b/cli/src/scaffold/tests.rs
@@ -478,7 +478,7 @@ fn the_env_example_lists_what_the_template_manifest_declares() {
     create_project(&request(&root, Template::Minimal)).expect("scaffold");
     let example = fs::read_to_string(root.join(".env.example")).expect(".env.example");
     assert!(
-        example.contains("declares no native environment variables"),
+        example.contains("declares no runtime environment variables"),
         "{example}"
     );
 }

--- a/cli/src/scaffold/tests.rs
+++ b/cli/src/scaffold/tests.rs
@@ -121,7 +121,7 @@ fn every_template_generates_the_files_a_project_needs() {
         );
 
         let gitignore = fs::read_to_string(root.join(".gitignore")).expect(".gitignore");
-        for secret_file in [".env", ".env.local", ".dev.vars"] {
+        for secret_file in [".env", ".env.local"] {
             assert!(
                 gitignore.lines().any(|line| line == secret_file),
                 "template `{label}` .gitignore must ignore {secret_file}"

--- a/cli/src/secret_files.rs
+++ b/cli/src/secret_files.rs
@@ -1,8 +1,11 @@
 //! Keep local secret files out of git.
 //!
-//! `.env`, `.env.local` and wrangler's `.dev.vars` hold credentials. Scaffolded `.gitignore`
-//! lists them; this module fails the CLI load when git is already tracking one (a 100% leak)
-//! and warns when a path is not ignored (`git add .` would stage it).
+//! `.env` and `.env.local` hold credentials. Scaffolded `.gitignore` lists them; this module
+//! fails the CLI load when git is already tracking one (a 100% leak) and warns when a path is not
+//! ignored (`git add .` would stage it).
+//!
+//! Not `.dev.vars`: it is generated into `.skyzen/gen/`, which is ignored whole, and nothing puts
+//! one in the project root any more.
 
 use anyhow::Result;
 use std::{
@@ -11,7 +14,7 @@ use std::{
 };
 
 /// Files that must not be committed.
-pub const SECRET_FILES: &[&str] = &[".env", ".env.local", ".dev.vars"];
+pub const SECRET_FILES: &[&str] = &[".env", ".env.local"];
 
 /// Inspect `root` for secret files git would commit.
 ///
@@ -107,11 +110,7 @@ mod tests {
     fn a_gitignored_env_file_is_ok() {
         let dir = tempfile::tempdir().expect("temp dir");
         git_init(dir.path());
-        fs::write(
-            dir.path().join(".gitignore"),
-            ".env\n.env.local\n.dev.vars\n",
-        )
-        .expect("gitignore");
+        fs::write(dir.path().join(".gitignore"), ".env\n.env.local\n").expect("gitignore");
         fs::write(dir.path().join(".env"), "TOKEN=aaaa\n").expect("write");
         let warnings = ensure(dir.path()).expect("ignored");
         assert!(warnings.is_empty(), "{warnings:?}");

--- a/cli/templates/api/Skyzen.toml.tmpl
+++ b/cli/templates/api/Skyzen.toml.tmpl
@@ -46,3 +46,10 @@ binding = "CACHE"
 [[cloudflare.d1_databases]]
 binding = "JOURNAL"
 database_name = "{{ ctx.worker_name }}-journal"
+
+# A secret is declared portably and resolved once at startup: the environment variable `STRIPE_KEY`
+# natively, a binding of the same name on Workers. `import_config!` generates `StripeKey`, a
+# newtype around `skyzen::Secret` a handler asks for by name. Uncomment it, then
+# `printf %s "$VALUE" | skyzen secret set STRIPE_KEY`.
+# [[secret]]
+# name = "STRIPE_KEY"

--- a/cli/templates/dev_vars.tmpl
+++ b/cli/templates/dev_vars.tmpl
@@ -1,0 +1,3 @@
+{% for entry in entries -%}
+{{ entry.name }}={{ entry.value }}
+{% endfor -%}

--- a/cli/templates/durable-realtime/Skyzen.toml.tmpl
+++ b/cli/templates/durable-realtime/Skyzen.toml.tmpl
@@ -12,3 +12,9 @@ class_name = "Room"
 tag = "v1"
 new_sqlite_classes = ["Room"]
 
+# A secret is declared portably and resolved once at startup: the environment variable `STRIPE_KEY`
+# natively, a binding of the same name on Workers. `import_config!` generates `StripeKey`, a
+# newtype around `skyzen::Secret` a handler asks for by name. Uncomment it, then
+# `printf %s "$VALUE" | skyzen secret set STRIPE_KEY`.
+# [[secret]]
+# name = "STRIPE_KEY"

--- a/cli/templates/env.example.tmpl
+++ b/cli/templates/env.example.tmpl
@@ -1,13 +1,15 @@
-# Environment variables this project's Skyzen.toml declares for native runs.
+# Environment variables this project's Skyzen.toml declares for a running application.
 #
 # Copy to `.env` and fill in. `skyzen dev` loads `.env` and then `.env.local`
 # into the process it starts, and refuses to start when one of these is unset.
+# A value already exported in your shell wins over both.
 {% for variable in variables %}
 # {{ variable.declared_by }}
 {{ variable.name }}=
 {%- endfor %}
 {%- if variables.is_empty() %}
-# This manifest declares no native environment variables yet. Add a
-# `[native.service.<name>]` or `[native.database.<name>]` section with a
-# `url_env` / `bucket_env` key and re-run `skyzen new` to regenerate this file.
+# This manifest declares no runtime environment variables yet. Add a
+# `[[secret]]` entry, or a `[native.service.<name>]` / `[native.database.<name>]`
+# section with a `url_env` / `bucket_env` key, and re-run `skyzen new` to
+# regenerate this file.
 {%- endif %}

--- a/cli/templates/gitignore.tmpl
+++ b/cli/templates/gitignore.tmpl
@@ -3,4 +3,3 @@
 /dist
 .env
 .env.local
-.dev.vars

--- a/cli/templates/minimal/Skyzen.toml.tmpl
+++ b/cli/templates/minimal/Skyzen.toml.tmpl
@@ -3,3 +3,10 @@ name = "{{ ctx.worker_name }}"
 main = "dist/worker.js"
 compatibility_date = "{{ ctx.compatibility_date }}"
 workers_dev = true
+
+# A secret is declared portably and resolved once at startup: the environment variable `STRIPE_KEY`
+# natively, a binding of the same name on Workers. `import_config!` generates `StripeKey`, a
+# newtype around `skyzen::Secret` a handler asks for by name. Uncomment it, then
+# `printf %s "$VALUE" | skyzen secret set STRIPE_KEY`.
+# [[secret]]
+# name = "STRIPE_KEY"

--- a/cli/templates/serverless-events/Skyzen.toml.tmpl
+++ b/cli/templates/serverless-events/Skyzen.toml.tmpl
@@ -14,3 +14,9 @@ queue = "jobs"
 [[cloudflare.queues.consumers]]
 queue = "jobs"
 
+# A secret is declared portably and resolved once at startup: the environment variable `STRIPE_KEY`
+# natively, a binding of the same name on Workers. `import_config!` generates `StripeKey`, a
+# newtype around `skyzen::Secret` a handler asks for by name. Uncomment it, then
+# `printf %s "$VALUE" | skyzen secret set STRIPE_KEY`.
+# [[secret]]
+# name = "STRIPE_KEY"

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -22,7 +22,7 @@ Cloudflare Workers service implementations for the Skyzen framework.
 | `CfD1` | `DbBackend` + raw D1 API | [D1](https://developers.cloudflare.com/d1/), with `execute_batch` as its atomic unit |
 | `CfCache` | raw Cache API | [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) |
 | `CfDurableDb`, `CfDurableKv`, `CfAlarm` | the `durable` backends | [Durable Objects storage](https://developers.cloudflare.com/durable-objects/api/storage-api/) |
-| `CfSecretStore` | — | [Secrets Store](https://developers.cloudflare.com/secrets-store/) bindings |
+| `CfSecret` | — | Classic Worker secrets and [Secrets Store](https://developers.cloudflare.com/secrets-store/) bindings, read as `skyzen::Secret` |
 | `CfService`, `CfAssets` | — | [Service bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/) and the static-assets binding |
 | `CfFetch` | — | Outbound `fetch` with Cloudflare's own request options |
 
@@ -31,6 +31,10 @@ The Worker events Cloudflare documents are covered too: `fetch` from `#[skyzen::
 `CfEmailMessage`, `TailTraceItem`), and the Durable Object `alarm` from `Route::on_alarm`.
 `CfProperties` (`skyzen::runtime`) carries the `request.cf` metadata, and `WorkerContext` carries
 `waitUntil`.
+
+A handler normally does not name `CfSecret`: `import_config!` generates a named type per
+`[[secret]]` manifest entry and calls the right reader for it, so the binding name is checked
+against the manifest rather than repeated as a string literal.
 
 ## Usage
 

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -34,7 +34,9 @@ The Worker events Cloudflare documents are covered too: `fetch` from `#[skyzen::
 
 A handler normally does not name `CfSecret`: `import_config!` generates a named type per
 `[[secret]]` manifest entry and calls the right reader for it, so the binding name is checked
-against the manifest rather than repeated as a string literal.
+against the manifest rather than repeated as a string literal. Declaring a secret, backing one with
+a Secrets Store entry and getting its value to the deployment are in
+[Secrets](https://github.com/zen-rs/skyzen/blob/main/docs/skyzen-toml-reference.md#secrets).
 
 ## Usage
 

--- a/cloudflare/src/lib.rs
+++ b/cloudflare/src/lib.rs
@@ -13,12 +13,16 @@
 //! - [`CfD1`] — Cloudflare D1 SQL database
 //! - [`CfService`] — Cloudflare service bindings (Worker-to-Worker over HTTP)
 //! - [`CfAssets`] — Cloudflare Static Assets binding
-//! - [`CfSecretStore`] — Cloudflare Secrets Store bindings
+//! - [`CfSecret`] — classic Worker secrets and Secrets Store bindings, read as [`skyzen::Secret`]
 //! - [`CfCache`] — Cloudflare Cache API
 //! - [`CfFetch`] — outbound `fetch` with Cloudflare's own request options
 //! - [`CfDurableDb`], [`CfDurableKv`], [`CfAlarm`] — Durable Object storage (`state.storage.sql`,
 //!   the key-value API, and alarms), plus [`CfDurableNamespace`] and [`CfDurableObjectStub`] for
 //!   addressing one
+//!
+//! [`CfSecret`] is the one type a handler does not normally name: `import_config!` generates a
+//! named type per `[[secret]]` manifest entry and calls the right reader for it, so the binding
+//! name is checked against the manifest instead of being repeated as a string literal.
 //!
 //! The Worker event payloads live here too — [`CfQueueBatch`], [`CfScheduledEvent`],
 //! [`CfEmailMessage`] and [`TailTraceItem`] — behind `#[skyzen::queue]`, `#[skyzen::scheduled]`,
@@ -136,10 +140,7 @@ pub use r2::{
     CfR2MultipartUpload, CfR2UploadedPart,
 };
 #[cfg(target_arch = "wasm32")]
-pub use secret::{
-    optional_string as optional_secret, required_string as required_secret, CfSecretError,
-    CfSecretStore,
-};
+pub use secret::{CfSecret, CfSecretError};
 #[cfg(target_arch = "wasm32")]
 pub use service::{CfAssets, CfService, CfServiceError};
 #[cfg(target_arch = "wasm32")]
@@ -226,7 +227,7 @@ const _: () = {
         assert_send(d1.batch(&[]));
         assert_send(service.fetch(&request));
         assert_send(service.fetch_json::<serde_json::Value>(&request));
-        assert_send(crate::CfSecretStore::get(
+        assert_send(crate::CfSecret::from_store(
             &wasm_bindgen::JsValue::NULL,
             "SECRET",
         ));

--- a/cloudflare/src/secret.rs
+++ b/cloudflare/src/secret.rs
@@ -1,25 +1,31 @@
-//! Typed readers for Cloudflare Workers secret and variable bindings.
+//! Readers for the two shapes a Cloudflare Workers secret binding can take.
 //!
 //! Cloudflare has two unrelated shapes here, and reading one with the other's API fails in a way
 //! that is hard to diagnose:
 //!
 //! - **`vars` and classic per-Worker secrets** are plain JS *strings* on the `env` object.
-//!   [`required_string`] and [`optional_string`] read those.
+//!   [`CfSecret::classic`] reads those.
 //! - **Secrets Store bindings** are *objects* whose value is fetched asynchronously via `.get()`,
-//!   so the string readers see a non-string and report [`CfSecretError::NotString`].
-//!   [`CfSecretStore`] reads those.
+//!   so the string reader sees a non-string and reports [`CfSecretError::NotString`].
+//!   [`CfSecret::from_store`] reads those.
+//!
+//! A handler normally reaches neither: `import_config!` generates one named
+//! [`skyzen::Secret`]-carrying type per `[[secret]]` entry and picks the right reader from the
+//! manifest, so the binding name is checked at compile time instead of being repeated as a string
+//! literal. These functions are what that generated code calls.
 //!
 //! `vars` are rendered into the generated `wrangler.toml` in plaintext and belong in source
-//! control only if their contents do; a real secret goes through `wrangler secret put` or the
-//! Secrets Store.
+//! control only if their contents do; a real secret is declared as `[[secret]]` and pushed with
+//! `skyzen secret push` or backed by the Secrets Store.
 
 use js_sys::Reflect;
+use skyzen::Secret;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use worker::send::IntoSendFuture;
 use worker_sys::SecretStoreSys;
 
-/// Errors raised when reading a Cloudflare Workers string binding.
+/// Errors raised when reading a Cloudflare Workers secret binding.
 #[derive(Debug, thiserror::Error)]
 pub enum CfSecretError {
     /// `Reflect::get` failed (typically: `env` is not the expected object).
@@ -36,8 +42,8 @@ pub enum CfSecretError {
     },
     /// The binding exists but isn't a string value.
     ///
-    /// A Secrets Store binding lands here when read with [`required_string`]: it is an object, not
-    /// a string. Read it with [`CfSecretStore`] instead.
+    /// A Secrets Store binding lands here when read with [`CfSecret::classic`]: it is an object,
+    /// not a string. Read it with [`CfSecret::from_store`] instead.
     #[error("Cloudflare Workers binding `{binding}` must be a string")]
     NotString {
         /// Binding name being read.
@@ -59,28 +65,58 @@ pub enum CfSecretError {
     },
 }
 
-/// A Cloudflare Secrets Store binding.
+/// The reader for a Cloudflare Workers secret binding.
 ///
-/// Unlike a classic secret, which the runtime materializes as a string on `env` before the Worker
-/// starts, a Secrets Store secret is fetched on demand — so reading one is `async` and can fail.
+/// Both constructors return a [`skyzen::Secret`], so a value read out of the Workers environment
+/// is redacted from the moment it exists.
 ///
 /// # Example
 ///
 /// ```ignore
-/// let api_key = CfSecretStore::get(&env, "STRIPE_KEY").await?;
+/// let classic = CfSecret::classic(&env, "JWT_SIGNING_KEY")?;
+/// let stored = CfSecret::from_store(&env, "STRIPE_KEY").await?;
 /// ```
 #[derive(Debug)]
-pub struct CfSecretStore;
+pub struct CfSecret;
 
-impl CfSecretStore {
+impl CfSecret {
+    /// Read a classic per-Worker secret (or a `vars` entry): a plain string on `env`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CfSecretError`] when the binding cannot be read, is missing, or is not a string —
+    /// the last being what a Secrets Store binding looks like here, which
+    /// [`CfSecret::from_store`] reads instead.
+    pub fn classic(env: &JsValue, binding: &str) -> Result<Secret, CfSecretError> {
+        let value =
+            Reflect::get(env, &JsValue::from_str(binding)).map_err(|_| CfSecretError::Reflect {
+                binding: binding.to_owned(),
+            })?;
+        if value.is_undefined() || value.is_null() {
+            return Err(CfSecretError::Missing {
+                binding: binding.to_owned(),
+            });
+        }
+        value
+            .as_string()
+            .map(Secret::new)
+            .ok_or_else(|| CfSecretError::NotString {
+                binding: binding.to_owned(),
+            })
+    }
+
     /// Read a secret out of a Secrets Store binding.
+    ///
+    /// Unlike a classic secret, which the runtime materializes as a string on `env` before the
+    /// Worker starts, a Secrets Store secret is fetched on demand — so reading one is `async` and
+    /// can fail.
     ///
     /// # Errors
     ///
     /// Returns [`CfSecretError`] when the binding is missing, is not a Secrets Store binding (the
-    /// common case being a classic secret, which [`required_string`] reads instead), when the
+    /// common case being a classic secret, which [`CfSecret::classic`] reads instead), when the
     /// store refuses the read, or when it hands back something that is not a string.
-    pub async fn get(env: &JsValue, binding: &str) -> Result<String, CfSecretError> {
+    pub async fn from_store(env: &JsValue, binding: &str) -> Result<Secret, CfSecretError> {
         let value =
             Reflect::get(env, &JsValue::from_str(binding)).map_err(|_| CfSecretError::Reflect {
                 binding: binding.to_owned(),
@@ -118,53 +154,11 @@ impl CfSecretStore {
                     message: format!("{error:?}"),
                 })?;
 
-        secret.as_string().ok_or_else(|| CfSecretError::NotString {
-            binding: binding.to_owned(),
-        })
+        secret
+            .as_string()
+            .map(Secret::new)
+            .ok_or_else(|| CfSecretError::NotString {
+                binding: binding.to_owned(),
+            })
     }
-}
-
-/// Read a required string binding. Returns an error when the binding is
-/// missing or non-string.
-///
-/// # Errors
-///
-/// Returns [`CfSecretError`] when the binding cannot be read, is missing,
-/// or is not a string.
-pub fn required_string(env: &JsValue, binding: &str) -> Result<String, CfSecretError> {
-    let value =
-        Reflect::get(env, &JsValue::from_str(binding)).map_err(|_| CfSecretError::Reflect {
-            binding: binding.to_owned(),
-        })?;
-    if value.is_undefined() || value.is_null() {
-        return Err(CfSecretError::Missing {
-            binding: binding.to_owned(),
-        });
-    }
-    value.as_string().ok_or_else(|| CfSecretError::NotString {
-        binding: binding.to_owned(),
-    })
-}
-
-/// Read an optional string binding. Returns `Ok(None)` when the binding is
-/// undefined or null. Returns `Err` only when the binding is present but not
-/// a string.
-///
-/// # Errors
-///
-/// Returns [`CfSecretError::NotString`] when the binding is present but not
-/// a string.
-pub fn optional_string(env: &JsValue, binding: &str) -> Result<Option<String>, CfSecretError> {
-    let Ok(value) = Reflect::get(env, &JsValue::from_str(binding)) else {
-        return Ok(None);
-    };
-    if value.is_undefined() || value.is_null() {
-        return Ok(None);
-    }
-    value
-        .as_string()
-        .map(Some)
-        .ok_or_else(|| CfSecretError::NotString {
-            binding: binding.to_owned(),
-        })
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ utoipa = { version = "5.4", optional = true, default-features = false, features 
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 tracing = { workspace = true, optional = true }
+secrecy = { version = "0.10", optional = true }
 
 [dev-dependencies]
 futures-lite = "2.6"
@@ -25,5 +26,5 @@ workspace = true
 
 [features]
 default = ["std"]
-std = ["dep:serde", "dep:serde_json", "dep:tracing"]
+std = ["dep:serde", "dep:serde_json", "dep:tracing", "dep:secrecy"]
 openapi = ["std", "dep:utoipa"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,6 +47,10 @@ pub use server::Server;
 mod net;
 #[cfg(feature = "std")]
 pub use net::{error_response, log_endpoint_error, panic_message, MissingRemoteAddr, PeerAddr};
+#[cfg(feature = "std")]
+mod secret;
+#[cfg(feature = "std")]
+pub use secret::Secret;
 #[cfg(feature = "openapi")]
 pub mod openapi;
 

--- a/core/src/secret.rs
+++ b/core/src/secret.rs
@@ -1,0 +1,78 @@
+//! The one runtime representation of a configured secret.
+//!
+//! A `[[secret]]` entry resolves into exactly this type on every target: an environment variable
+//! natively, a Worker secret or a Secrets Store binding on Cloudflare. Nothing else in the
+//! framework carries a secret value, so there is a single place where redaction is decided.
+
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::fmt;
+
+use secrecy::{ExposeSecret, SecretString};
+
+/// A configured secret value.
+///
+/// The value is readable only through [`Secret::expose`], which is what makes reading one visible
+/// in a diff. [`Debug`] prints `Secret(<redacted>)` and there is deliberately no [`Display`]: a
+/// secret that formats itself is a secret that reaches a log the first time someone interpolates
+/// a struct holding it.
+///
+/// ```
+/// use skyzen_core::Secret;
+///
+/// let key = Secret::new("sk_live_123");
+/// assert_eq!(key.expose(), "sk_live_123");
+/// assert_eq!(format!("{key:?}"), "Secret(<redacted>)");
+/// ```
+#[derive(Clone)]
+pub struct Secret(Arc<SecretString>);
+
+impl Secret {
+    /// Wrap a value read from the environment, a Worker binding or a secrets store.
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(Arc::new(SecretString::from(value.into())))
+    }
+
+    /// Read the value.
+    ///
+    /// This is the only way to reach it, so every use site names the exposure.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        self.0.expose_secret()
+    }
+}
+
+impl fmt::Debug for Secret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Secret(<redacted>)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Secret;
+    use alloc::format;
+
+    const fn assert_send_sync<T: Send + Sync>() {}
+    const _: () = assert_send_sync::<Secret>();
+
+    #[test]
+    fn debug_redacts_the_value() {
+        let secret = Secret::new("hunter2");
+        let rendered = format!("{secret:?}");
+        assert_eq!(rendered, "Secret(<redacted>)");
+        assert!(!rendered.contains("hunter2"));
+    }
+
+    #[test]
+    fn expose_is_the_only_way_to_read_it() {
+        assert_eq!(Secret::new("hunter2").expose(), "hunter2");
+    }
+
+    #[test]
+    fn a_clone_shares_the_value() {
+        let secret = Secret::new("hunter2");
+        assert_eq!(secret.clone().expose(), secret.expose());
+    }
+}

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -33,8 +33,9 @@ provider:
 - that `wrangler whoami` succeeds, so a deploy will not fail on authentication;
 - for AWS, what `[aws]` would deploy — the function name, the architecture, whether it gets a
   Function URL;
-- for Azure, that `[azure]` names an `app_name` to publish to, and that the Linux target it names
-  is installed.
+- for Azure, that `[azure]` names the Function App to publish to — `app_name`, `subscription_id`
+  and `resource_group` — and that the Linux target it names is installed;
+- for every selected provider, which of the runtime variables it delivers have a value here.
 
 Every check runs even after one fails, and the command exits non-zero if any did.
 
@@ -209,17 +210,13 @@ See [Environments](skyzen-toml-reference.md#environments) for the merge rules.
 
 ### CI
 
-`${NAME}` in `Skyzen.toml` is expanded from the process environment, then `.env` / `.env.local`,
-when the CLI reads the file. Drop a gitignored `.env` onto the runner (one file, not one `env:`
-line per key) or export the variables in the job. That is the environment of `skyzen deploy`, not
-the Worker after it starts.
-
-See [Deploy-time interpolation](skyzen-toml-reference.md#deploy-time-interpolation) for the syntax.
+Drop a gitignored `.env` onto the runner (one file, not one `env:` line per key) or export the
+variables in the job. That is the environment of `skyzen deploy`, not the Worker after it starts.
 `CLOUDFLARE_API_TOKEN` is wrangler's own credential and stays out of the file.
 
-The CLI refuses to load a checkout that has committed a known credential form in `Skyzen.toml`, or
-that is tracking `.env` / `.env.local` / `.dev.vars`. A secret-named key whose value is not a
-known token is a warning, not a hard failure.
+[Secrets](skyzen-toml-reference.md#secrets) has where a value is looked up, what each provider
+delivers, and what the CLI refuses to load; [Deploy-time
+interpolation](skyzen-toml-reference.md#deploy-time-interpolation) has the `${NAME}` syntax.
 
 ### Logs and Secrets
 
@@ -227,10 +224,13 @@ known token is a warning, not a hard failure.
 skyzen logs                                  # wrangler tail
 skyzen logs -- --format json                 # extra arguments pass straight through
 skyzen secret set API_KEY                    # value is read from stdin
-skyzen secret list
+skyzen secret push                           # deliver every declared [[secret]], no rebuild
+skyzen secret list                           # names only
 ```
 
-Secrets are the channel for anything sensitive; `[cloudflare.vars]` is plaintext and committed.
+All three work on Cloudflare, AWS and Azure: `--provider` picks which deployment they act on, and
+a name they are given must be declared as `[[secret]]`. Anything sensitive is a `[[secret]]`;
+`[cloudflare.vars]` is plaintext and committed.
 
 ### Durable Objects
 
@@ -321,8 +321,10 @@ url = true                       # create (and keep) a Function URL; the default
 RUST_LOG = "info"
 ```
 
-`[aws.env]` values are plaintext environment variables, visible to anyone who can read the
-function's configuration. Read anything sensitive from Secrets Manager or SSM at startup instead.
+`[aws.env]` values are plaintext environment variables, committed to the manifest and visible to
+anyone who can read the function's configuration. Declare anything sensitive as `[[secret]]`
+instead: the deploy delivers it to the same function environment without it ever being written
+down. See [Secrets](skyzen-toml-reference.md#secrets).
 
 ### Deploying
 
@@ -336,8 +338,12 @@ That runs, and `--dry-run` prints, exactly:
 ```sh
 cargo lambda build --target aarch64-unknown-linux-gnu --release --features lambda
 cargo lambda deploy --binary-name my-app --memory 512 --timeout 30 \
-  --env-var RUST_LOG=info --enable-function-url skyzen-api
+  --enable-function-url skyzen-api
 ```
+
+The upload is followed by one `UpdateFunctionConfiguration` call that sets the function's
+environment to `[aws.env]` plus every `[[secret]]` and native wiring variable, merged over what the
+function already has. No value reaches a command line: that is why `--env-var` is not passed.
 
 The target triple is named outright rather than left to `cargo lambda`'s default, so the
 architecture the manifest declares is the one that gets built. Setting `url = false` passes
@@ -404,6 +410,8 @@ serves is a startup error naming both; one that merely overlaps a parameterized 
 ```toml
 [azure]
 app_name = "skyzen-demo"                 # the Function App to publish to
+subscription_id = "00000000-0000-0000-0000-000000000000"   # the subscription it lives in
+resource_group = "skyzen-rg"             # the resource group it lives in
 target = "x86_64-unknown-linux-musl"     # a Function App runs Linux
 http_mode = "forward"                    # or "proxy", which streams responses
 
@@ -416,6 +424,12 @@ connection_env = "AzureWebJobsStorage"   # the app setting holding the connectio
 `http_mode = "forward"` buffers the response, which is fine for an API and wrong for server-sent
 events or any other stream: pick `"proxy"` (the host's `enableProxyingHttpRequest`) when the
 application streams.
+
+`subscription_id` and `resource_group` are required by `deploy` and by every `skyzen secret`
+action: a Function App's application settings *are* the custom handler's environment, and they are
+addressed by the resource's full ARM id. The publish is followed by a read-modify-write of those
+settings carrying every `[[secret]]` and native wiring variable, so the host's own settings survive
+it. See [Secrets](skyzen-toml-reference.md#secrets).
 
 ### Deploying
 

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -568,18 +568,28 @@ run_worker_first = false
 
 ### Secrets Store
 
+A secret is declared portably with `[[secret]]`; `[cloudflare.secret.<NAME>]` backs one with a
+Cloudflare Secrets Store entry instead of a classic Worker secret. The section's key is the
+`[[secret]]` name, which is also the binding the Worker resolves — so nothing in the application
+knows which of the two it got.
+
 ```toml
-[[cloudflare.secrets_store_secrets]]
-binding = "API_KEY"
+[[secret]]
+name = "API_KEY"
+
+[cloudflare.secret.API_KEY]
 store_id = "your-store-id"
 secret_name = "api-key"
 ```
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `binding` | string | **Required.** Binding name, as seen from `env` |
 | `store_id` | string | **Required.** The secrets store the secret lives in |
 | `secret_name` | string | **Required.** The secret's name within that store |
+
+A `[cloudflare.secret.<NAME>]` naming a secret no `[[secret]]` declares is a parse error, as is a
+`[[secret]]` whose name is also a `[cloudflare.vars]` or `[aws.env]` key — those tables are
+uploaded in plaintext.
 
 ### Handlers
 

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -397,6 +397,144 @@ binding = "DB"
 |-----|------|-------------|
 | `binding` | string | **Required.** Cloudflare D1 binding name |
 
+## Secrets
+
+A secret is a portable capability, declared once and resolved once at startup on every target:
+
+```toml
+[[secret]]
+name = "STRIPE_KEY"
+
+[[secret]]
+name = "JWT_SIGNING_KEY"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | string | **Required.** `[A-Za-z_][A-Za-z0-9_]*`. The environment variable natively, and the binding on Workers |
+
+The name is the identifier everywhere: the native process reads an environment variable of that
+name, and the Worker resolves a binding of that name. Nothing in the application knows which it
+got.
+
+### The Generated Type
+
+`import_config!` generates one newtype around `skyzen::Secret` per entry, with the name converted
+from `SCREAMING_SNAKE_CASE`: `STRIPE_KEY` generates `pub struct StripeKey(Secret)`. There is no
+bare `Secret` extractor to fall back on — the type names a value rather than a capability — so a
+handler always asks for the entry by name:
+
+```rust
+async fn charge(stripe: StripeKey) -> Result<&'static str> {
+    gateway(stripe.expose()).await?;   // `Deref` reaches `Secret::expose`
+    Ok("ok")
+}
+```
+
+`Secret` is readable only through `expose`, its `Debug` prints `Secret(<redacted>)`, and it has no
+`Display`, so a struct holding one cannot interpolate it into a log.
+
+`#[skyzen::main]` binds each type once at startup: `std::env::var` natively, `CfSecret::classic` or
+`CfSecret::from_store` on Workers. A name that is set nowhere is a startup panic naming the
+`[[secret]]` entry, not a failure on the first request that needed the value.
+
+The generated type is a `Middleware` that injects itself, which is how `#[skyzen::main]` binds it
+and how a test supplies its own value — the same as for a named service type:
+
+```rust
+let router = router.layer(StripeKey::new(Secret::new("sk_test_123")));
+```
+
+### Cloudflare Secrets Store
+
+`[cloudflare.secret.<NAME>]` backs one declared secret with a Cloudflare
+[Secrets Store](https://developers.cloudflare.com/secrets-store/) entry instead of a classic Worker
+secret. The section's key is the `[[secret]]` name, which is still the binding:
+
+```toml
+[[secret]]
+name = "STRIPE_KEY"
+
+[cloudflare.secret.STRIPE_KEY]
+store_id = "your-store-id"
+secret_name = "stripe-key"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `store_id` | string | **Required.** The store the entry lives in |
+| `secret_name` | string | **Required.** The entry's name within that store |
+
+A store-backed secret is **externally managed**. `skyzen deploy` and `skyzen secret push` neither
+need nor write its value, so a deployment whose store is already populated is complete without a
+local copy. `skyzen secret set <NAME>` is the only command that writes one.
+
+The backing belongs in the base `[cloudflare]` section. A Worker reads one kind of binding in every
+environment, so a backing declared only in a `[cloudflare.env.<name>]` overlay is a compile-time
+error rather than a wrong reader in that environment.
+
+A `[cloudflare.secret.<NAME>]` naming a secret no `[[secret]]` declares is a parse error, as is a
+`[[secret]]` whose name is also a `[cloudflare.vars]` or `[aws.env]` key — those tables are
+uploaded in plaintext.
+
+### Where a Value Comes From
+
+The CLI looks for a value in the **process environment** first, then in `.env.local`, then in
+`.env`. An exported variable wins over both files, and `.env.local` wins over `.env`.
+
+That one rule covers everything the CLI does with a value: `${NAME}` expansion when it reads
+`Skyzen.toml`, the environment `skyzen dev` gives the process it starts, the connection string
+`skyzen migrate` dials, what `skyzen doctor` reports, and what `deploy` and `secret push` deliver.
+
+`skyzen new` writes `.env.example` from the manifest — every `[[secret]]` first, then the native
+wiring variables — and gitignores `.env` and `.env.local`. The CLI refuses to load a checkout that
+tracks either of them.
+
+`#[skyzen::main]` reads none of this. It resolves a secret from the real process environment at
+startup, and it never expands `${NAME}`, so a value only CI holds cannot fail `cargo build`.
+
+### Delivery
+
+Two kinds of variable reach a running application: a `[[secret]]`, and the *wiring* variables a
+native backend reads (`url_env`, `bucket_env`, `connection_env`, `sas_url_env`, and the names a
+backend fixes itself). A Worker binds its services rather than dialling them, so it never wants a
+wiring variable; the Lambda and the Functions binaries *are* the native binary, so they want both.
+
+| Provider | `dev` | `deploy` | `secret set NAME` / `secret push` | `secret list` |
+|---|---|---|---|---|
+| native | secrets and wiring must resolve; the `.env` entries the shell does not already hold are added to the child's environment | — | refused: nothing remote to write to | refused |
+| cloudflare | every secret must resolve. Classic ones are written to `.skyzen/gen/.dev.vars` (`.dev.vars.<env>` under `--env`); store-backed ones are seeded into wrangler's *local* store, which starts out empty however full the account's is | `wrangler deploy`, then the classic secrets through `wrangler secret bulk`. Store-backed ones are neither needed nor written | `set`: `wrangler secret put`, or a write to the account's store for a store-backed name. `push`: the same `secret bulk` the deploy runs | `wrangler secret list` |
+| aws | — (run it as an ordinary server with `skyzen dev`) | `cargo lambda deploy`, then `UpdateFunctionConfiguration` with `[aws.env]` plus the secrets and wiring variables | the same call, without the build | the function environment's names |
+| azure | — (`func start` over a built bundle) | `func azure functionapp publish`, then the application settings — which *are* the custom handler's environment — set to the secrets and wiring variables | the same call, without the publish | the app settings' names |
+
+`deploy` delivers, and refuses before it uploads anything when a variable it has to deliver is set
+nowhere — listing every one of them, rather than shipping a deployment that panics at cold start.
+`secret push` is that same delivery without the build.
+
+Both cloud sinks are a read-modify-write, because the call that writes them replaces the whole map:
+a setting the Functions host or a console made survives a deploy that never mentioned it. A name
+that is both a delivered variable and an `[aws.env]` key keeps the delivered value — `[aws.env]` is
+the plaintext table, and shipping its copy over a real value would deploy a placeholder.
+
+`[azure]` needs `subscription_id` and `resource_group` before any of this works: application
+settings are addressed by the resource's full ARM id, which `app_name` alone does not determine.
+
+### Setting a Value, and What Is Never Printed
+
+`skyzen secret set NAME` reads the value from the CLI's own standard input, and `NAME` must be a
+declared `[[secret]]` — an undeclared name is refused, naming the ones that exist:
+
+```sh
+printf '%s' "$STRIPE_KEY" | skyzen secret set STRIPE_KEY
+skyzen secret push --provider aws          # deliver every declared value, no rebuild
+skyzen secret list --provider azure        # names only
+```
+
+No value is ever placed on a command line or printed. Values travel on a child process's standard
+input (every `wrangler` invocation) or inside a request body (Lambda, ARM). A file that carries
+values is created owner-only, and `--dry-run` reports it as `write <path> (secret values, not
+shown)` instead of its contents.
+
 ## Cloudflare Section
 
 ```toml
@@ -424,7 +562,7 @@ API_URL = "https://api.example.com"
 | `workers_dev` | bool | Enable `*.workers.dev` subdomain |
 | `route` | string | URL pattern for routing |
 | `zone_id` | string | Cloudflare zone ID |
-| `vars` | table | Plaintext environment variables. Use `skyzen secret set` for anything sensitive |
+| `vars` | table | Plaintext environment variables. Declare anything sensitive as `[[secret]]` — see [Secrets](#secrets) |
 
 > **Two different `service` keys.** `[cloudflare.service.<name>]` (a table, below) wires a **portable** `[[service]]` entry to a Cloudflare binding. `[[cloudflare.services]]` (an array, below) declares a wrangler **service binding** to another Worker. They are unrelated.
 
@@ -568,28 +706,9 @@ run_worker_first = false
 
 ### Secrets Store
 
-A secret is declared portably with `[[secret]]`; `[cloudflare.secret.<NAME>]` backs one with a
-Cloudflare Secrets Store entry instead of a classic Worker secret. The section's key is the
-`[[secret]]` name, which is also the binding the Worker resolves — so nothing in the application
-knows which of the two it got.
-
-```toml
-[[secret]]
-name = "API_KEY"
-
-[cloudflare.secret.API_KEY]
-store_id = "your-store-id"
-secret_name = "api-key"
-```
-
-| Key | Type | Description |
-|-----|------|-------------|
-| `store_id` | string | **Required.** The secrets store the secret lives in |
-| `secret_name` | string | **Required.** The secret's name within that store |
-
-A `[cloudflare.secret.<NAME>]` naming a secret no `[[secret]]` declares is a parse error, as is a
-`[[secret]]` whose name is also a `[cloudflare.vars]` or `[aws.env]` key — those tables are
-uploaded in plaintext.
+`[cloudflare.secret.<NAME>]` backs a declared `[[secret]]` with a Cloudflare Secrets Store entry
+instead of a classic Worker secret, keeping the same binding name. The keys, the externally
+managed rule and the delivery are in [Secrets](#secrets).
 
 ### Handlers
 
@@ -757,8 +876,8 @@ The generated `wrangler.toml` contains a complete `[env.<name>]` section for eac
 ## Deploy-time interpolation
 
 String values may contain `${NAME}` placeholders. `skyzen deploy`, `skyzen dev`, `skyzen provision`
-and the rest of the CLI expand them from the **process environment of the machine running the
-command**, then from `.env` / `.env.local`. Process environment wins, same as native wiring.
+and the rest of the CLI expand them when they read the file, from the sources and in the order
+[Secrets](#secrets) states.
 
 This is not the runtime environment of the deployed Worker or Lambda. `url_env = "CACHE_URL"` names
 a variable the application reads after it starts. `${CACHE_NAMESPACE_ID}` is replaced **before**
@@ -778,10 +897,9 @@ id = "${CACHE_NAMESPACE_ID}"
 API_URL = "${API_URL}"
 ```
 
-Put the values in `.env` (gitignored) or export them in the shell that runs the CLI. Skyzen does
-not require a per-key mapping in GitHub Actions: write `.env` onto the runner, or export the
-variables however the job already does. `CLOUDFLARE_API_TOKEN` is wrangler's own credential and
-stays out of the file.
+Skyzen does not require a per-key mapping in GitHub Actions: write `.env` onto the runner, or
+export the variables however the job already does. `CLOUDFLARE_API_TOKEN` is wrangler's own
+credential and stays out of the file.
 
 A documented credential form (GitHub PAT, PEM private key, URL with a password, …) stored as a
 literal fails the CLI load. A `vars` / `[aws.env]` key whose *name* looks like a secret but whose
@@ -799,7 +917,8 @@ Rules:
 - `#[skyzen::main]` does **not** expand placeholders. A missing GitHub secret must not fail `cargo build`. Do not wrap `url_env` / `binding` / service names in `${}` — those fields are consumed at compile time as literal names.
 
 Interpolating a secret into `[cloudflare.vars]` or `[aws.env]` still stores it as a plaintext
-platform variable. Worker secrets stay on `skyzen secret set`.
+platform variable. A real secret is declared as `[[secret]]` and delivered — see
+[Secrets](#secrets).
 
 ## Escape Hatch
 
@@ -835,6 +954,9 @@ type = "storage"
 [[database]]
 name = "main"
 type = "sql"
+
+[[secret]]
+name = "STRIPE_KEY"
 
 [native.service.cache]
 backend = "redis"
@@ -891,9 +1013,9 @@ The `skyzen` CLI generates provider-specific config files from `Skyzen.toml`:
 
 | Provider | Generated Config | `dev` Command | `deploy` Command |
 |----------|-----------------|---------------|-----------------|
-| Cloudflare | `.skyzen/gen/wrangler.toml`, `dist/worker.js`, `dist/worker_bg.js`, `dist/worker_bg.wasm` | `wrangler dev --local` | `wrangler deploy` |
-| AWS | none — the flags are derived from `[aws]` | — (run it as a server with `skyzen dev`) | `cargo lambda build` then `cargo lambda deploy` |
-| Azure | `.skyzen/gen/azure/{host.json, local.settings.json, <function>/function.json}` plus the staged binary | — (`func start` over a built bundle) | `func azure functionapp publish` |
+| Cloudflare | `.skyzen/gen/wrangler.toml`, `.skyzen/gen/.dev.vars`, `dist/worker.js`, `dist/worker_bg.js`, `dist/worker_bg.wasm` | `wrangler dev --local` | `wrangler deploy`, then `wrangler secret bulk` |
+| AWS | none — the flags are derived from `[aws]` | — (run it as a server with `skyzen dev`) | `cargo lambda build` then `cargo lambda deploy`, then the function environment |
+| Azure | `.skyzen/gen/azure/{host.json, local.settings.json, <function>/function.json}` plus the staged binary | — (`func start` over a built bundle) | `func azure functionapp publish`, then the app settings |
 
 The generated files are derived artifacts, rewritten on every run — edit `Skyzen.toml`, not them.
 

--- a/docs/skyzen-toml-reference.md
+++ b/docs/skyzen-toml-reference.md
@@ -688,6 +688,8 @@ does not create. See the [deployment guide](deployment-guide.md#queues).
 ```toml
 [azure]
 app_name = "skyzen-demo"                 # the Function App to publish to
+subscription_id = "00000000-0000-0000-0000-000000000000"   # the subscription it lives in
+resource_group = "skyzen-rg"             # the resource group it lives in
 target = "x86_64-unknown-linux-musl"     # a Function App runs Linux
 http_mode = "forward"                    # "forward" (default) or "proxy"
 
@@ -699,7 +701,9 @@ connection_env = "AzureWebJobsStorage"   # the app setting holding the connectio
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
-| `app_name` | string | none | Required by `deploy` and `logs`; nothing can infer it |
+| `app_name` | string | none | Required by `deploy`, `logs` and `secret`; nothing can infer it |
+| `subscription_id` | string | none | Required by `deploy` and `secret`: half the ARM id of the app settings the runtime variables are delivered to (`az account show --query id -o tsv`) |
+| `resource_group` | string | none | Required by `deploy` and `secret`: the other half of that ARM id |
 | `target` | string | the host's own target | A Linux triple; a macOS build is refused before publishing |
 | `http_mode` | `"forward"` \| `"proxy"` | `"forward"` | `proxy` streams responses; `forward` buffers them |
 | `queue_triggers` | array of tables | empty | One Functions queue trigger each |

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -8,7 +8,7 @@ use quote::{format_ident, quote};
 use skyzen_manifest::{
     AzureQueueTrigger, DatabaseEntry, DatabaseType, Manifest, NativeDatabaseSection,
     NativeQueueConsumer, NativeServiceSection, RdsEngine, ServiceEntry, ServiceType,
-    SkyzenManifest,
+    SkyzenManifest, VarName,
 };
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -231,6 +231,22 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
 /// namespaces declared, only `Cache` and `Sessions` are injected and a handler asking for a bare
 /// `Kv` gets its `KvNotConfigured` error (HTTP 500) rather than one namespace chosen arbitrarily.
 /// Name the binding you mean.
+///
+/// # Secrets
+///
+/// Every `[[secret]]` entry generates the same newtype around [`skyzen::Secret`], with its name
+/// converted from `SCREAMING_SNAKE_CASE`: `name = "STRIPE_KEY"` generates `pub struct
+/// StripeKey(Secret)`. There is no bare `Secret` to fall back on — the type names a value rather
+/// than a capability — so a handler always asks for the entry by name:
+///
+/// ```ignore
+/// async fn handler(stripe: StripeKey) -> Result<&'static str> {
+///     charge(stripe.expose()).await?;              // `Deref` reaches `Secret::expose`
+///     Ok("ok")
+/// }
+/// ```
+///
+/// [`skyzen::Secret`]: https://docs.rs/skyzen/latest/skyzen/struct.Secret.html
 #[proc_macro]
 pub fn import_config(input: TokenStream) -> TokenStream {
     if !input.is_empty() {
@@ -2351,11 +2367,30 @@ fn service_wrapper_path(service_type: ServiceType) -> proc_macro2::TokenStream {
 
 fn expand_import_config() -> syn::Result<proc_macro2::TokenStream> {
     let manifest = load_manifest()?.unwrap_or_default();
+    let generated_items = import_config_items(&manifest)?;
+    let manifest_tracking = manifest_tracking_tokens();
+
+    Ok(quote! {
+        #manifest_tracking
+
+        #[doc(hidden)]
+        pub mod __skyzen_config {
+            #(#generated_items)*
+        }
+
+        pub use __skyzen_config::*;
+    })
+}
+
+/// One generated newtype per `[[service]]`, `[[database]]` and `[[secret]]` entry.
+fn import_config_items(manifest: &SkyzenManifest) -> syn::Result<Vec<proc_macro2::TokenStream>> {
     let services = &manifest.service;
     let databases = &manifest.database;
-    let mut generated_items = Vec::with_capacity(services.len() + databases.len());
-    // Services and databases land in the same module, so one set catches a collision between
-    // kinds — a service named `main-db` and a database named `main` both normalize to `MainDb`.
+    let secrets = &manifest.secret;
+    let mut generated_items = Vec::with_capacity(services.len() + databases.len() + secrets.len());
+    // Services, databases and secrets land in the same module, so one set catches a collision
+    // between kinds — a service named `main-db` and a database named `main` both normalize to
+    // `MainDb`.
     let mut seen_idents = HashSet::new();
 
     for service in services {
@@ -2397,18 +2432,26 @@ fn expand_import_config() -> syn::Result<proc_macro2::TokenStream> {
         ));
     }
 
-    let manifest_tracking = manifest_tracking_tokens();
-
-    Ok(quote! {
-        #manifest_tracking
-
-        #[doc(hidden)]
-        pub mod __skyzen_config {
-            #(#generated_items)*
+    for secret in secrets {
+        let ident = secret_ident_from_name(&secret.name)?;
+        if !seen_idents.insert(ident.to_string()) {
+            return Err(Error::new(
+                proc_macro2::Span::call_site(),
+                format!("duplicate secret type name after normalization: `{ident}`"),
+            ));
         }
 
-        pub use __skyzen_config::*;
-    })
+        generated_items.push(named_binding_tokens(
+            &ident,
+            &quote! { ::skyzen::Secret },
+            &format!(
+                "secret `{}` not configured. Ensure Skyzen.toml secret wiring is installed.",
+                secret.name
+            ),
+        ));
+    }
+
+    Ok(generated_items)
 }
 
 /// Generate the named newtype for one `[[service]]` or `[[database]]` entry.
@@ -2525,23 +2568,37 @@ struct PortableWiring {
 }
 
 fn portable_injection_wrap_steps() -> syn::Result<PortableWiring> {
-    let empty = PortableWiring {
+    let Some(document) = load_manifest_document()? else {
+        return Ok(empty_portable_wiring());
+    };
+
+    portable_wiring(&document)
+}
+
+/// Nothing to bind: the endpoint is launched exactly as the entry function built it.
+fn empty_portable_wiring() -> PortableWiring {
+    PortableWiring {
         steps: Vec::new(),
         consumers: quote! { () },
-    };
+    }
+}
 
-    let Some(manifest) = load_manifest()? else {
-        return Ok(empty);
-    };
-
+/// The binding statements one resolved manifest expands to.
+///
+/// The whole document is taken rather than only its base data because a secret's *kind* of
+/// Cloudflare backing has to agree across every environment, which is a question only the
+/// overlays can answer.
+fn portable_wiring(document: &Manifest) -> syn::Result<PortableWiring> {
+    let manifest = document.data();
     let services = &manifest.service;
     let databases = &manifest.database;
-    if services.is_empty() && databases.is_empty() {
-        return Ok(empty);
+    let secrets = &manifest.secret;
+    if services.is_empty() && databases.is_empty() && secrets.is_empty() {
+        return Ok(empty_portable_wiring());
     }
     let default_database = default_database_index(databases)?;
 
-    let mut steps = Vec::with_capacity(services.len() + databases.len() + 1);
+    let mut steps = Vec::with_capacity(services.len() + databases.len() + secrets.len() + 1);
     let service_type_counts = service_type_counts(services);
     let mut service_bindings = HashMap::new();
 
@@ -2552,8 +2609,8 @@ fn portable_injection_wrap_steps() -> syn::Result<PortableWiring> {
     for service in services {
         let ident = service_ident_from_name(&service.name)?;
         let binding = service_binding_ident(&ident);
-        let native_init = generate_native_service_init(service, &manifest);
-        let cloudflare_init = generate_cloudflare_service_init(service, &manifest);
+        let native_init = generate_native_service_init(service, manifest);
+        let cloudflare_init = generate_cloudflare_service_init(service, manifest);
         // The bare `Kv`/`Storage`/`Queue` extractor names whichever service of that type is the
         // only one, so it is injected exactly when the type is unambiguous.
         let inject_bare = service_type_counts[&service.service_type] == 1;
@@ -2570,8 +2627,8 @@ fn portable_injection_wrap_steps() -> syn::Result<PortableWiring> {
     for (index, database) in databases.iter().enumerate() {
         let ident = database_ident_from_name(&database.name)?;
         let binding = service_binding_ident(&ident);
-        let native_init = generate_native_database_init(database, &manifest);
-        let cloudflare_init = generate_cloudflare_database_init(database, &manifest);
+        let native_init = generate_native_database_init(database, manifest);
+        let cloudflare_init = generate_cloudflare_database_init(database, manifest);
         let inject_bare = default_database == Some(index);
         steps.push(named_injection_tokens(
             &binding,
@@ -2582,7 +2639,23 @@ fn portable_injection_wrap_steps() -> syn::Result<PortableWiring> {
         ));
     }
 
-    let consumers = queue_consumer_tokens(&manifest, &service_bindings)?;
+    for secret in secrets {
+        let ident = secret_ident_from_name(&secret.name)?;
+        let binding = secret_binding_ident(&ident);
+        let native_init = generate_native_secret_init(&secret.name);
+        let cloudflare_init = generate_cloudflare_secret_init(document, &secret.name)?;
+        // There is no unambiguous bare secret: `Secret` names a value, not a capability, so a
+        // single `[[secret]]` is still reached through its own generated type.
+        steps.push(named_injection_tokens(
+            &binding,
+            &ident,
+            &native_init,
+            &cloudflare_init,
+            false,
+        ));
+    }
+
+    let consumers = queue_consumer_tokens(manifest, &service_bindings)?;
 
     Ok(PortableWiring { steps, consumers })
 }
@@ -2594,6 +2667,14 @@ fn portable_injection_wrap_steps() -> syn::Result<PortableWiring> {
 /// enqueued through the injected `Queue` would never reach the consumer polling "the same" queue.
 fn service_binding_ident(ident: &proc_macro2::Ident) -> proc_macro2::Ident {
     format_ident!("__skyzen_service_{}", ident.to_string().to_lowercase())
+}
+
+/// The local binding that holds one `[[secret]]` for the length of the factory.
+///
+/// Separate from [`service_binding_ident`] so that a service and a secret whose names normalize
+/// to the same lowercase text cannot name the same local.
+fn secret_binding_ident(ident: &proc_macro2::Ident) -> proc_macro2::Ident {
+    format_ident!("__skyzen_secret_{}", ident.to_string().to_lowercase())
 }
 
 /// Build the `QueueConsumers` value for every `[[native.queue_consumer]]` entry.
@@ -3316,6 +3397,79 @@ fn generate_cloudflare_database_init(
     }
 }
 
+/// Whether `[cloudflare.secret.<NAME>]` backs this secret with a Cloudflare Secrets Store.
+///
+/// Wiring is read from the base document, as it is for services, so a backing declared only in an
+/// overlay would generate the classic-secret reader for an environment wrangler binds through the
+/// store. One Worker cannot read a name two ways, so the disagreement is refused here rather than
+/// discovered on the first request in that environment.
+fn secret_is_store_backed(document: &Manifest, name: &VarName) -> syn::Result<bool> {
+    let backed_in = |environment: Option<&str>| {
+        document
+            .cloudflare(environment)
+            .ok()
+            .flatten()
+            .is_some_and(|cloudflare| cloudflare.secret.contains_key(name))
+    };
+
+    if backed_in(None) {
+        return Ok(true);
+    }
+
+    for environment in document.environment_names() {
+        if backed_in(Some(environment)) {
+            return Err(Error::new(
+                proc_macro2::Span::call_site(),
+                format!(
+                    "secret `{name}` is backed by a Cloudflare Secrets Store in environment \
+                     `{environment}` but not in the base manifest: declare \
+                     `[cloudflare.secret.{name}]` at the top level, since the Worker reads one \
+                     kind of binding in every environment"
+                ),
+            ));
+        }
+    }
+
+    Ok(false)
+}
+
+/// Read one `[[secret]]` from the process environment at startup.
+fn generate_native_secret_init(name: &VarName) -> proc_macro2::TokenStream {
+    let value = env_value_expr("secret", name.as_str(), name);
+    quote! { ::skyzen::Secret::new(#value) }
+}
+
+/// Read one `[[secret]]` from the Worker environment at factory time.
+fn generate_cloudflare_secret_init(
+    document: &Manifest,
+    name: &VarName,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let store_backed = secret_is_store_backed(document, name)?;
+    let name_lit = LitStr::new(name.as_str(), proc_macro2::Span::call_site());
+    let binding_kind = if store_backed {
+        "Secrets Store binding"
+    } else {
+        "secret binding"
+    };
+    let failure_message = LitStr::new(
+        &format!("portable secret `{name}` failed to resolve Cloudflare {binding_kind} `{name}`"),
+        proc_macro2::Span::call_site(),
+    );
+
+    Ok(if store_backed {
+        quote! {{
+            ::skyzen_cloudflare::CfSecret::from_store(&__skyzen_wasm_env, #name_lit)
+                .await
+                .unwrap_or_else(|error| panic!("{}: {error}", #failure_message))
+        }}
+    } else {
+        quote! {{
+            ::skyzen_cloudflare::CfSecret::classic(&__skyzen_wasm_env, #name_lit)
+                .unwrap_or_else(|error| panic!("{}: {error}", #failure_message))
+        }}
+    })
+}
+
 fn compile_error_block(message: &str) -> proc_macro2::TokenStream {
     let message = LitStr::new(message, proc_macro2::Span::call_site());
     quote! {{
@@ -3370,6 +3524,34 @@ fn database_ident_from_name(name: &str) -> syn::Result<proc_macro2::Ident> {
 
 fn service_ident_from_name(name: &str) -> syn::Result<proc_macro2::Ident> {
     pascal_ident_from_name(name, "", "service")
+}
+
+/// Turn a `[[secret]]` name into a type name: `STRIPE_KEY` becomes `StripeKey`.
+///
+/// A secret is named in `SCREAMING_SNAKE_CASE` because that is the name its value is read under
+/// natively, so the tail of every `_`-separated segment is lowered. [`pascal_ident_from_name`]
+/// deliberately does not do this — lowering there would rename the type generated for an existing
+/// `myCache` service — which is why secrets get their own conversion rather than a shared one.
+fn secret_ident_from_name(name: &VarName) -> syn::Result<proc_macro2::Ident> {
+    let name = name.as_str();
+    let mut normalized = String::with_capacity(name.len());
+
+    for segment in name.split('_').filter(|segment| !segment.is_empty()) {
+        // `VarName` is validated as ASCII, so the first byte is the first character.
+        let (first, rest) = segment.split_at(1);
+        normalized.push_str(&first.to_ascii_uppercase());
+        normalized.push_str(&rest.to_ascii_lowercase());
+    }
+
+    syn::parse_str::<proc_macro2::Ident>(&normalized).map_err(|_| {
+        Error::new(
+            proc_macro2::Span::call_site(),
+            format!(
+                "secret `{name}` normalizes to `{normalized}`, which is not a usable Rust type \
+                 name: rename the secret"
+            ),
+        )
+    })
 }
 
 fn default_database_index(databases: &[DatabaseEntry]) -> syn::Result<Option<usize>> {
@@ -4004,10 +4186,12 @@ mod tests {
 
     /// Parse a manifest through the same shared schema the macros use at compile time.
     fn manifest(source: &str) -> SkyzenManifest {
-        Manifest::parse(source, "Skyzen.toml", ".")
-            .expect("valid manifest")
-            .data()
-            .clone()
+        document(source).data().clone()
+    }
+
+    /// The same parse, keeping the `[cloudflare.env.<name>]` overlays `#[skyzen::main]` reads.
+    fn document(source: &str) -> Manifest {
+        Manifest::parse(source, "Skyzen.toml", ".").expect("valid manifest")
     }
 
     #[test]
@@ -4529,6 +4713,143 @@ binding = "DB"
             "_9lives"
         );
         assert!(service_ident_from_name("---").is_err());
+    }
+
+    #[test]
+    fn a_secret_name_becomes_a_pascal_case_type_name() {
+        use super::secret_ident_from_name;
+        use skyzen_manifest::VarName;
+
+        for (name, expected) in [
+            ("STRIPE_KEY", "StripeKey"),
+            ("JWT_SIGNING_KEY", "JwtSigningKey"),
+            ("API_KEY_V2", "ApiKeyV2"),
+            ("TOKEN", "Token"),
+        ] {
+            assert_eq!(
+                secret_ident_from_name(&VarName::from_static(name))
+                    .unwrap()
+                    .to_string(),
+                expected,
+                "{name}"
+            );
+        }
+
+        // A name that normalizes to a keyword, or to nothing at all, is refused rather than
+        // panicking inside `Ident::new` with no mention of the manifest entry that caused it.
+        assert!(secret_ident_from_name(&VarName::from_static("SELF")).is_err());
+        assert!(secret_ident_from_name(&VarName::from_static("_")).is_err());
+    }
+
+    #[test]
+    fn a_secret_generates_a_named_extractor_wrapping_the_redacting_type() {
+        use super::import_config_items;
+
+        let generated = import_config_items(&manifest("[[secret]]\nname = \"STRIPE_KEY\"\n"))
+            .expect("generated")
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+
+        assert!(
+            generated.contains("pub struct StripeKey (:: skyzen :: Secret)"),
+            "{generated}"
+        );
+        assert!(generated.contains("impl :: skyzen :: extract :: Extractor for StripeKey"));
+        assert!(generated.contains("impl :: skyzen :: middleware :: Middleware for StripeKey"));
+        assert!(generated.contains("pub StripeKeyNotConfigured"));
+    }
+
+    #[test]
+    fn a_secret_and_a_service_that_normalize_alike_collide_at_compile_time() {
+        use super::import_config_items;
+
+        // `stripe_key` and `STRIPE_KEY` both become `StripeKey`; two types of that name in one
+        // module is a much worse error than naming the clash here.
+        let manifest = manifest(
+            "[[service]]\nname = \"stripe_key\"\ntype = \"kv\"\n\n\
+             [[secret]]\nname = \"STRIPE_KEY\"\n",
+        );
+
+        let error = import_config_items(&manifest).expect_err("collision");
+        assert!(error.to_string().contains("StripeKey"), "{error}");
+    }
+
+    #[test]
+    fn a_secret_reads_its_env_var_natively_and_is_never_injected_bare() {
+        use super::portable_wiring;
+
+        let wiring =
+            portable_wiring(&document("[[secret]]\nname = \"STRIPE_KEY\"\n")).expect("wiring");
+        assert_eq!(wiring.steps.len(), 1);
+
+        let step = wiring.steps[0].to_string();
+        assert!(step.contains(":: skyzen :: Secret :: new"), "{step}");
+        assert!(step.contains("\"STRIPE_KEY\""), "{step}");
+        assert!(
+            step.contains("portable secret `STRIPE_KEY` missing native env var `STRIPE_KEY`"),
+            "{step}"
+        );
+        assert!(step.contains("StripeKey :: new"), "{step}");
+        // `Secret` names a value rather than a capability, so there is no bare wrapper to inject
+        // even when the manifest declares exactly one secret.
+        assert_eq!(step.matches("with_middleware").count(), 1, "{step}");
+    }
+
+    #[test]
+    fn a_store_backed_secret_awaits_the_store_and_a_classic_one_does_not() {
+        use super::generate_cloudflare_secret_init;
+        use skyzen_manifest::VarName;
+
+        let name = VarName::from_static("STRIPE_KEY");
+
+        let classic = generate_cloudflare_secret_init(
+            &document("[[secret]]\nname = \"STRIPE_KEY\"\n"),
+            &name,
+        )
+        .expect("classic")
+        .to_string();
+        assert!(classic.contains("CfSecret :: classic"), "{classic}");
+        assert!(!classic.contains("await"), "{classic}");
+
+        let backed = generate_cloudflare_secret_init(
+            &document(
+                "[[secret]]\nname = \"STRIPE_KEY\"\n\n\
+                 [cloudflare.secret.STRIPE_KEY]\n\
+                 store_id = \"0c2a3f\"\nsecret_name = \"stripe-key\"\n",
+            ),
+            &name,
+        )
+        .expect("store backed")
+        .to_string();
+        assert!(backed.contains("CfSecret :: from_store"), "{backed}");
+        assert!(backed.contains(". await"), "{backed}");
+        assert!(backed.contains("Secrets Store binding"), "{backed}");
+    }
+
+    #[test]
+    fn a_store_backing_declared_only_in_an_overlay_is_a_compile_error() {
+        use super::generate_cloudflare_secret_init;
+        use skyzen_manifest::VarName;
+
+        // The Worker is generated once, from the base document, so it would read `STRIPE_KEY` as a
+        // classic secret while wrangler binds it through the store in `staging`.
+        let error = generate_cloudflare_secret_init(
+            &document(
+                "[[secret]]\nname = \"STRIPE_KEY\"\n\n\
+                 [cloudflare.env.staging.secret.STRIPE_KEY]\n\
+                 store_id = \"0c2a3f\"\nsecret_name = \"stripe-key\"\n",
+            ),
+            &VarName::from_static("STRIPE_KEY"),
+        )
+        .expect_err("overlay-only backing");
+
+        let message = error.to_string();
+        assert!(message.contains("staging"), "{message}");
+        assert!(
+            message.contains("[cloudflare.secret.STRIPE_KEY]"),
+            "{message}"
+        );
     }
 
     #[test]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -2900,8 +2900,12 @@ fn native_database_wiring<'a>(
 ///
 /// Every native backend that takes a URL, a bucket or a connection string reads it this way, so
 /// the lookup and its failure message are written once here rather than in each arm.
-fn env_value_expr(kind: &str, entry: &str, variable: &str) -> proc_macro2::TokenStream {
-    let variable_lit = LitStr::new(variable, proc_macro2::Span::call_site());
+fn env_value_expr(
+    kind: &str,
+    entry: &str,
+    variable: &skyzen_manifest::VarName,
+) -> proc_macro2::TokenStream {
+    let variable_lit = LitStr::new(variable.as_str(), proc_macro2::Span::call_site());
     let missing_message = LitStr::new(
         &format!("portable {kind} `{entry}` missing native env var `{variable}`"),
         proc_macro2::Span::call_site(),
@@ -3091,7 +3095,10 @@ fn native_queue_tokens(
         NativeServiceSection::StorageQueue(storage_queue) => {
             // The signed URL *is* the credential, so the constructor is handed the variable's name
             // and reports it itself rather than being handed a value read here.
-            let variable = LitStr::new(&storage_queue.sas_url_env, proc_macro2::Span::call_site());
+            let variable = LitStr::new(
+                storage_queue.sas_url_env.as_str(),
+                proc_macro2::Span::call_site(),
+            );
             let failure = connect_failure_lit(
                 name,
                 &format!(

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -3,9 +3,9 @@
 The typed model of `Skyzen.toml`, shared by the [Skyzen](https://github.com/zen-rs/skyzen)
 procedural macros and the `skyzen` CLI.
 
-`Skyzen.toml` declares portable capabilities (`[[service]]`, `[[database]]`) once and wires them
-per target (`[native.*]`, `[cloudflare.*]`, `[aws]`, `[azure]`). Two very different consumers read
-it:
+`Skyzen.toml` declares portable capabilities (`[[service]]`, `[[database]]`, `[[secret]]`) once and
+wires them per target (`[native.*]`, `[cloudflare.*]`, `[aws]`, `[azure]`). Two very different
+consumers read it:
 
 - `#[skyzen::main]` reads it at compile time and generates the backend construction, the typed
   extractors, and the Azure queue triggers the runtime mounts.
@@ -29,6 +29,12 @@ let manifest = Manifest::load(std::path::Path::new("Skyzen.toml"))?;
 let cloudflare = manifest.cloudflare(Some("staging"))?;
 # Ok::<_, Box<dyn std::error::Error>>(())
 ```
+
+Every variable name the schema carries — a `[[secret]]` name, and every `url_env` /
+`bucket_env` / `connection_env` / `sas_url_env` wiring key — is a `VarName`, validated as
+`[A-Za-z_][A-Za-z0-9_]*` when the file is parsed. The two consumers would otherwise read different
+variables from the same key: the CLI expands `url_env = "${FOO}"` and the macro bakes it in
+literally, so the type refuses it outright.
 
 String values may contain `${NAME}` placeholders. The CLI expands them from the process
 environment and `.env` through `Manifest::load_with`. `Manifest::load` leaves them as written,

--- a/manifest/src/interpolate.rs
+++ b/manifest/src/interpolate.rs
@@ -8,8 +8,11 @@
 //! quotes or newlines cannot break the file. Keys are never expanded. A missing, unclosed, or
 //! invalid name fails the parse; there is no `${NAME:-default}`. `$$` writes a literal `$`.
 
+use crate::{
+    schema::VarName,
+    walk::{walk_strings, StringSite},
+};
 use std::borrow::Cow;
-use toml::Value;
 
 /// Looks up `${NAME}` during expansion. `Ok(None)` means the name is unset.
 pub type EnvLookup<'a> = &'a dyn Fn(&str) -> Result<Option<String>, InterpolateError>;
@@ -128,7 +131,7 @@ pub fn expand<'a>(
                     location: location.to_owned(),
                 });
             }
-            if !is_ident(name) {
+            if !VarName::is_valid(name) {
                 return Err(InterpolateError::InvalidName {
                     location: location.to_owned(),
                     name: name.to_owned(),
@@ -164,60 +167,12 @@ pub fn expand_table(
     table: &mut toml::Table,
     lookup: EnvLookup<'_>,
 ) -> Result<(), InterpolateError> {
-    expand_table_at(table, "", lookup)
-}
-
-fn expand_table_at(
-    table: &mut toml::Table,
-    parent: &str,
-    lookup: EnvLookup<'_>,
-) -> Result<(), InterpolateError> {
-    for (key, value) in table.iter_mut() {
-        let location = child_path(parent, key);
-        expand_value(value, &location, lookup)?;
-    }
-    Ok(())
-}
-
-fn expand_value(
-    value: &mut Value,
-    location: &str,
-    lookup: EnvLookup<'_>,
-) -> Result<(), InterpolateError> {
-    match value {
-        Value::String(text) => {
-            if let Cow::Owned(expanded) = expand(text, location, lookup)? {
-                *text = expanded;
-            }
-            Ok(())
+    walk_strings(table, &mut |site: StringSite<'_>| {
+        if let Cow::Owned(expanded) = expand(site.value, site.location, lookup)? {
+            *site.value = expanded;
         }
-        Value::Array(items) => {
-            for (index, item) in items.iter_mut().enumerate() {
-                let child = format!("{location}[{index}]");
-                expand_value(item, &child, lookup)?;
-            }
-            Ok(())
-        }
-        Value::Table(table) => expand_table_at(table, location, lookup),
-        Value::Integer(_) | Value::Float(_) | Value::Boolean(_) | Value::Datetime(_) => Ok(()),
-    }
-}
-
-fn child_path(parent: &str, key: &str) -> String {
-    if parent.is_empty() {
-        key.to_owned()
-    } else {
-        format!("{parent}.{key}")
-    }
-}
-
-fn is_ident(name: &str) -> bool {
-    let mut bytes = name.bytes();
-    match bytes.next() {
-        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
-        _ => return false,
-    }
-    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/manifest/src/interpolate.rs
+++ b/manifest/src/interpolate.rs
@@ -1,8 +1,9 @@
 //! Deploy-time `${NAME}` expansion in `Skyzen.toml` string values.
 //!
-//! The CLI expands placeholders from the process environment (and the project's `.env` files)
-//! when it reads the manifest. `#[skyzen::main]` does **not**: compile-time env is not the
-//! deploy runner, and a GitHub secret the compiler does not have must not fail `cargo build`.
+//! The CLI expands placeholders when it reads the manifest, from the sources and in the order
+//! `docs/skyzen-toml-reference.md#secrets` states. `#[skyzen::main]` does **not**: compile-time env
+//! is not the deploy runner, and a GitHub secret the compiler does not have must not fail
+//! `cargo build`.
 //!
 //! Expansion runs on the parsed TOML document, before the typed schema, so a value containing
 //! quotes or newlines cannot break the file. Keys are never expanded. A missing, unclosed, or

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -50,6 +50,7 @@ mod merge;
 pub mod migrations;
 mod schema;
 mod secrets;
+mod walk;
 
 pub use interpolate::{expand, expand_table, process_env, EnvLookup, InterpolateError};
 pub use merge::deep_merge;
@@ -58,18 +59,19 @@ pub use schema::{
     AwsSection, AzureHttpMode, AzureQueueTrigger, AzureSection, BlobWiring, CfAssets,
     CfAssetsNotFoundHandling, CfD1Database, CfDurableBinding, CfDurableMigration, CfDurableObjects,
     CfDurableRenamedClass, CfHandlers, CfKvNamespace, CfQueueConsumer, CfQueueProducer, CfQueues,
-    CfR2Bucket, CfSecretsStoreSecret, CfServiceBinding, CfTriggers, CloudflareDatabaseSection,
+    CfR2Bucket, CfServiceBinding, CfTriggers, CloudflareDatabaseSection, CloudflareSecretSection,
     CloudflareSection, CloudflareServiceSection, CosmosWiring, DatabaseEntry, DatabaseType,
-    DynamoDbWiring, LambdaArchitecture, MemoryWiring, NativeDatabaseBackend, NativeDatabaseSection,
-    NativeQueueConsumer, NativeSection, NativeServiceBackend, NativeServiceSection,
-    PartialRdsDataWiring, QueueTriggerError, RdsDataParts, RdsDataWiring, RdsEngine, RedisWiring,
-    S3Wiring, ServiceBusWiring, ServiceEntry, ServiceType, SkyzenManifest, SqlUrlWiring, SqsWiring,
-    StorageQueueWiring, WiringEnvVar, HTTP_FUNCTION_NAME,
+    DynamoDbWiring, InvalidVarName, LambdaArchitecture, MemoryWiring, NativeDatabaseBackend,
+    NativeDatabaseSection, NativeQueueConsumer, NativeSection, NativeServiceBackend,
+    NativeServiceSection, PartialRdsDataWiring, QueueTriggerError, RdsDataParts, RdsDataWiring,
+    RdsEngine, RedisWiring, S3Wiring, SecretEntry, ServiceBusWiring, ServiceEntry, ServiceType,
+    SkyzenManifest, SqlUrlWiring, SqsWiring, StorageQueueWiring, VarName, WiringEnvVar,
+    HTTP_FUNCTION_NAME, PLAINTEXT_VARIABLE_TABLES,
 };
 pub use secrets::{scan_table, SecretError, SecretFinding, SecretReport};
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -131,6 +133,41 @@ pub enum ManifestError {
         database: String,
         /// Which keys are named and which are missing.
         source: schema::PartialRdsDataWiring,
+    },
+    /// Two `[[secret]]` entries declare the same name.
+    #[error("{path}: `[[secret]]` declares `{name}` twice; one secret is one name")]
+    DuplicateSecret {
+        /// The manifest path.
+        path: PathBuf,
+        /// The name declared more than once.
+        name: String,
+    },
+    /// A `[cloudflare.secret.<NAME>]` section backs a secret nothing declares.
+    #[error(
+        "{path}: [{section}.secret.{name}] backs a secret the manifest does not declare; add \
+         `[[secret]]` with `name = \"{name}\"`, or remove the section"
+    )]
+    UnknownSecret {
+        /// The manifest path.
+        path: PathBuf,
+        /// The section the backing was written in — `cloudflare`, or `cloudflare.env.<name>`.
+        section: String,
+        /// The secret the section names.
+        name: String,
+    },
+    /// A `[[secret]]` name is also a plaintext variable key on some platform.
+    #[error(
+        "{path}: `{name}` is declared as `[[secret]]` and is also a key of [{table}]; the two \
+         would claim the same name on the deployed application, and [{table}] is uploaded in \
+         plaintext. Keep the `[[secret]]`, or rename one of them."
+    )]
+    SecretIsPlaintextVariable {
+        /// The manifest path.
+        path: PathBuf,
+        /// The name declared twice over.
+        name: String,
+        /// The plaintext table that also holds it.
+        table: String,
     },
     /// A `${NAME}` placeholder in a string value could not be expanded.
     #[error("{path}: {source}")]
@@ -270,7 +307,7 @@ impl Manifest {
         // `lookup = None` and skip the scan so `cargo build` does not fail on a token the
         // compiler never needed.
         let secret_warnings = if lookup.is_some() {
-            let report = secrets::scan_table(&document);
+            let report = secrets::scan_table(&mut document);
             if let Some(source) = secrets::blocking_error(&report) {
                 return Err(ManifestError::CommittedSecret {
                     path: path.clone(),
@@ -356,6 +393,8 @@ impl Manifest {
             environments.insert(name, section);
         }
 
+        check_secrets(&data, &environments, &path)?;
+
         Ok(Self {
             path,
             root_dir: root_dir.into(),
@@ -426,6 +465,88 @@ impl Manifest {
     }
 }
 
+/// Check `[[secret]]` against everything that would claim one of its names.
+///
+/// Three rules, checked once for both consumers: a name is declared at most once, every
+/// `[cloudflare.secret.<NAME>]` backs a declared secret, and a secret's name is not also a key of
+/// a plaintext variable table — where the value would be uploaded in the clear, under the name the
+/// application reads its secret from. Every resolved overlay is checked, not only the base, so an
+/// environment that adds the collision fails the parse the same way.
+fn check_secrets(
+    data: &SkyzenManifest,
+    environments: &BTreeMap<String, CloudflareSection>,
+    path: &Path,
+) -> Result<(), ManifestError> {
+    let mut declared: BTreeSet<&str> = BTreeSet::new();
+    for entry in &data.secret {
+        if !declared.insert(entry.name.as_str()) {
+            return Err(ManifestError::DuplicateSecret {
+                path: path.to_path_buf(),
+                name: entry.name.to_string(),
+            });
+        }
+    }
+
+    if let Some(aws) = &data.aws {
+        check_plaintext_table(aws.env.keys(), &declared, path, schema::AWS_ENV_TABLE)?;
+    }
+    if let Some(cloudflare) = &data.cloudflare {
+        check_cloudflare_secrets(cloudflare, &declared, path, "cloudflare")?;
+    }
+    for (name, section) in environments {
+        check_cloudflare_secrets(
+            section,
+            &declared,
+            path,
+            &format!("cloudflare.{ENVIRONMENTS_KEY}.{name}"),
+        )?;
+    }
+    Ok(())
+}
+
+/// Check one `[cloudflare]` section — the base, or a resolved overlay — against `declared`.
+fn check_cloudflare_secrets(
+    section: &CloudflareSection,
+    declared: &BTreeSet<&str>,
+    path: &Path,
+    label: &str,
+) -> Result<(), ManifestError> {
+    for name in section.secret.keys() {
+        if !declared.contains(name.as_str()) {
+            return Err(ManifestError::UnknownSecret {
+                path: path.to_path_buf(),
+                section: label.to_owned(),
+                name: name.to_string(),
+            });
+        }
+    }
+    check_plaintext_table(
+        section.vars.keys(),
+        declared,
+        path,
+        &format!("{label}.vars"),
+    )
+}
+
+/// Fail when a plaintext variable table holds a key a `[[secret]]` already declares.
+fn check_plaintext_table<'a>(
+    keys: impl Iterator<Item = &'a String>,
+    declared: &BTreeSet<&str>,
+    path: &Path,
+    table: &str,
+) -> Result<(), ManifestError> {
+    for key in keys {
+        if declared.contains(key.as_str()) {
+            return Err(ManifestError::SecretIsPlaintextVariable {
+                path: path.to_path_buf(),
+                name: key.clone(),
+                table: table.to_owned(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Remove `[cloudflare.env]` from `document` and return the overlays it held.
 fn take_environment_overlays(
     document: &mut toml::Table,
@@ -463,7 +584,7 @@ fn take_environment_overlays(
 mod tests {
     use super::{
         InterpolateError, Manifest, ManifestError, NativeDatabaseBackend, NativeDatabaseSection,
-        NativeServiceBackend, NativeServiceSection, RdsEngine, ServiceType,
+        NativeServiceBackend, NativeServiceSection, RdsEngine, ServiceType, VarName,
     };
     use std::time::Duration;
 
@@ -1253,10 +1374,143 @@ mod tests {
         )
         .expect("heuristic is a warning");
         assert_eq!(manifest.secret_warnings().len(), 1);
-        assert_eq!(
-            manifest.secret_warnings()[0].kind,
-            "plaintext value of a secret-named key"
+        assert!(
+            manifest.secret_warnings()[0]
+                .kind
+                .starts_with("plaintext value of a secret-named key"),
+            "{:?}",
+            manifest.secret_warnings()[0]
         );
+        // The fix the warning names is the portable one.
+        assert!(
+            manifest.secret_warnings()[0].kind.contains("[[secret]]"),
+            "{:?}",
+            manifest.secret_warnings()[0]
+        );
+    }
+
+    #[test]
+    fn a_secret_entry_declares_one_portable_name() {
+        let manifest = parse(
+            "[[secret]]\nname = \"STRIPE_KEY\"\n\n[[secret]]\nname = \"JWT_SIGNING_KEY\"\n\n\
+             [cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.secret.STRIPE_KEY]\nstore_id = \"0c2a3f\"\nsecret_name = \"stripe-key\"\n",
+        )
+        .expect("manifest parses");
+
+        let secrets = &manifest.data().secret;
+        assert_eq!(secrets.len(), 2);
+        assert_eq!(secrets[0].name, "STRIPE_KEY");
+        assert_eq!(secrets[1].name, "JWT_SIGNING_KEY");
+
+        let backing = &manifest
+            .cloudflare(None)
+            .expect("base")
+            .expect("cloudflare")
+            .secret[&secrets[0].name];
+        assert_eq!(backing.store_id, "0c2a3f");
+        assert_eq!(backing.secret_name, "stripe-key");
+    }
+
+    #[test]
+    fn two_secrets_cannot_share_a_name() {
+        let error = parse("[[secret]]\nname = \"API_KEY\"\n\n[[secret]]\nname = \"API_KEY\"\n")
+            .expect_err("one secret, one name");
+        assert!(
+            error.to_string().contains("twice") && error.to_string().contains("API_KEY"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn backing_a_secret_the_manifest_does_not_declare_is_rejected() {
+        let error = parse(
+            "[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.secret.STRIPE_KEY]\nstore_id = \"s\"\nsecret_name = \"stripe-key\"\n",
+        )
+        .expect_err("nothing declares STRIPE_KEY");
+        assert!(
+            error.to_string().contains("[cloudflare.secret.STRIPE_KEY]"),
+            "{error}"
+        );
+        assert!(error.to_string().contains("[[secret]]"), "{error}");
+    }
+
+    #[test]
+    fn an_overlay_backing_an_undeclared_secret_is_rejected_too() {
+        let error = parse(
+            "[[secret]]\nname = \"API_KEY\"\n\n\
+             [cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+             [cloudflare.env.staging.secret.OTHER_KEY]\nstore_id = \"s\"\nsecret_name = \"o\"\n",
+        )
+        .expect_err("the overlay backs a secret nothing declares");
+        assert!(
+            error
+                .to_string()
+                .contains("cloudflare.env.staging.secret.OTHER_KEY"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_secret_cannot_also_be_a_plaintext_variable() {
+        for (source, table) in [
+            (
+                "[[secret]]\nname = \"API_KEY\"\n\n[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+                 [cloudflare.vars]\nAPI_KEY = \"not-a-secret\"\n",
+                "cloudflare.vars",
+            ),
+            (
+                "[[secret]]\nname = \"API_KEY\"\n\n[aws.env]\nAPI_KEY = \"not-a-secret\"\n",
+                "aws.env",
+            ),
+            // Only the overlay collides: the base has no such var, and the parse still fails.
+            (
+                "[[secret]]\nname = \"API_KEY\"\n\n[cloudflare]\ncompatibility_date = \"2025-02-01\"\n\n\
+                 [cloudflare.env.staging.vars]\nAPI_KEY = \"not-a-secret\"\n",
+                "cloudflare.env.staging.vars",
+            ),
+        ] {
+            let error = parse(source).expect_err("one name, one kind of variable");
+            let rendered = error.to_string();
+            assert!(rendered.contains(table), "{table}: {rendered}");
+            assert!(rendered.contains("API_KEY"), "{table}: {rendered}");
+        }
+    }
+
+    #[test]
+    fn a_placeholder_cannot_name_a_variable() {
+        // The CLI expands `${FOO}`; `#[skyzen::main]` does not. A variable name that means two
+        // things to the two consumers is refused where it is written.
+        let wiring = database_wiring("backend = \"postgres\"\nurl_env = \"${FOO}\"\n")
+            .expect_err("a placeholder is not a variable name")
+            .to_string();
+        // A `backend`-tagged wiring is buffered by serde before the payload struct sees it, which
+        // costs the key's span: the error locates the wiring's table and quotes the value.
+        assert!(wiring.contains("native.database.main"), "{wiring}");
+        assert!(wiring.contains("${FOO}"), "{wiring}");
+        assert!(wiring.contains("placeholder"), "{wiring}");
+
+        // Everywhere the span survives, the field itself is named.
+        let secret = parse("[[secret]]\nname = \"${FOO}\"\n")
+            .expect_err("a placeholder is not a secret name")
+            .to_string();
+        assert!(secret.contains("secret.name"), "{secret}");
+    }
+
+    #[test]
+    fn a_variable_name_is_an_identifier_or_it_is_not_a_name() {
+        for rejected in ["FOO-BAR", "${X}", "1abc", "", "FOO BAR", "a.b"] {
+            let error = VarName::try_from(rejected.to_owned())
+                .expect_err("not an environment variable name");
+            assert!(error.to_string().contains(rejected), "{rejected}: {error}");
+        }
+        for accepted in ["FOO", "_private", "a1", "STRIPE_KEY"] {
+            let name = VarName::try_from(accepted.to_owned()).expect("an identifier");
+            assert_eq!(name, accepted);
+            assert_eq!(name.as_str(), accepted);
+            assert_eq!(name.to_string(), accepted);
+        }
     }
 
     #[test]

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -1510,7 +1510,11 @@ mod tests {
             assert_eq!(name, accepted);
             assert_eq!(name.as_str(), accepted);
             assert_eq!(name.to_string(), accepted);
+            // `FromStr` is how an argument parser reaches the same rule, so `skyzen secret set
+            // FOO-BAR` is rejected by the CLI rather than by the platform it is sent to.
+            assert_eq!(accepted.parse::<VarName>().expect("an identifier"), name);
         }
+        assert!("FOO-BAR".parse::<VarName>().is_err());
     }
 
     #[test]

--- a/manifest/src/schema.rs
+++ b/manifest/src/schema.rs
@@ -1397,6 +1397,16 @@ pub struct AzureSection {
     /// The Function App to publish to, as `func azure functionapp publish` names it.
     #[serde(default)]
     pub app_name: Option<String>,
+    /// The Azure subscription the Function App lives in.
+    ///
+    /// Required by `skyzen deploy` and by every `skyzen secret` action: the application settings a
+    /// deployment delivers its runtime variables through are addressed by the resource's full ARM
+    /// id, which the Function App's name alone does not determine.
+    #[serde(default)]
+    pub subscription_id: Option<String>,
+    /// The resource group the Function App lives in, the second half of that ARM id.
+    #[serde(default)]
+    pub resource_group: Option<String>,
     /// The Rust target triple to build the handler for.
     ///
     /// A Function App runs Linux, so a handler built on macOS or Windows cannot be published as

--- a/manifest/src/schema.rs
+++ b/manifest/src/schema.rs
@@ -19,6 +19,7 @@ use std::{
     ffi::OsStr,
     fmt::{Display, Formatter},
     num::{NonZeroU32, NonZeroUsize},
+    str::FromStr,
     time::Duration,
 };
 
@@ -107,6 +108,14 @@ impl TryFrom<String> for VarName {
         } else {
             Err(InvalidVarName { name })
         }
+    }
+}
+
+impl FromStr for VarName {
+    type Err = InvalidVarName;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        Self::try_from(name.to_owned())
     }
 }
 

--- a/manifest/src/schema.rs
+++ b/manifest/src/schema.rs
@@ -12,12 +12,152 @@
 //! rejected where it is written rather than ignored: `backend = "memory"` with a stray `url_env`
 //! is a parse error, and a required key is missing at parse time rather than at macro expansion.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
+    borrow::Cow,
     collections::BTreeMap,
+    ffi::OsStr,
+    fmt::{Display, Formatter},
     num::{NonZeroU32, NonZeroUsize},
     time::Duration,
 };
+
+/// The name of an environment variable, validated as `[A-Za-z_][A-Za-z0-9_]*`.
+///
+/// Every place the manifest names a variable — a `[[secret]]`, a wiring's `url_env` — holds one of
+/// these rather than a `String`, so the name a consumer reads is a name an operating system will
+/// accept. It is also what rejects `url_env = "${FOO}"`: deploy-time interpolation expands the
+/// *CLI's* view of the document, while `#[skyzen::main]` bakes in the text as written, so a
+/// placeholder in a variable name is two consumers disagreeing about what the variable is called.
+/// The rule catches it at parse time instead, naming the key.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[serde(try_from = "String")]
+pub struct VarName(Cow<'static, str>);
+
+impl VarName {
+    /// A name written as a literal, checked while the constant is evaluated.
+    ///
+    /// An invalid literal is a compile error rather than a startup panic:
+    ///
+    /// ```compile_fail
+    /// const BAD: skyzen_manifest::VarName = skyzen_manifest::VarName::from_static("bad-name");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// When `name` is not `[A-Za-z_][A-Za-z0-9_]*`. In a `const` or `static` — the only place this
+    /// constructor is meant to be used — that panic is a build failure.
+    #[must_use]
+    pub const fn from_static(name: &'static str) -> Self {
+        assert!(
+            Self::is_valid(name),
+            "an environment variable name must match [A-Za-z_][A-Za-z0-9_]*"
+        );
+        Self(Cow::Borrowed(name))
+    }
+
+    /// The name as written.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether `name` is a well-formed environment variable name.
+    ///
+    /// The one implementation of the rule: the schema validates names with it, the interpolator
+    /// validates `${NAME}` with it, and the secret scanner recognizes a placeholder with it.
+    pub(crate) const fn is_valid(name: &str) -> bool {
+        let bytes = name.as_bytes();
+        if bytes.is_empty() {
+            return false;
+        }
+        if !(bytes[0].is_ascii_alphabetic() || bytes[0] == b'_') {
+            return false;
+        }
+        let mut index = 1;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            if !(byte.is_ascii_alphanumeric() || byte == b'_') {
+                return false;
+            }
+            index += 1;
+        }
+        true
+    }
+}
+
+/// A string that is not a well-formed environment variable name.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "`{name}` is not an environment variable name: it must match [A-Za-z_][A-Za-z0-9_]*. A \
+     `${{NAME}}` placeholder cannot be used here — the compile-time reader does not expand it, so \
+     the variable the application reads and the one the CLI checks would be different."
+)]
+pub struct InvalidVarName {
+    /// The rejected text.
+    pub name: String,
+}
+
+impl TryFrom<String> for VarName {
+    type Error = InvalidVarName;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        if Self::is_valid(&name) {
+            Ok(Self(Cow::Owned(name)))
+        } else {
+            Err(InvalidVarName { name })
+        }
+    }
+}
+
+impl Display for VarName {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl AsRef<str> for VarName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<OsStr> for VarName {
+    fn as_ref(&self) -> &OsStr {
+        OsStr::new(self.as_str())
+    }
+}
+
+impl PartialEq<str> for VarName {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for VarName {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl Serialize for VarName {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+/// The manifest tables whose keys are **plaintext** platform variables, not secrets.
+///
+/// A key here is uploaded as written and is visible in the provider's console, which is why a
+/// `[[secret]]` may not also be one of them and why the secret scanner warns about a secret-named
+/// key in one. Written once so the schema rule and the scanner cannot disagree about the list.
+pub const PLAINTEXT_VARIABLE_TABLES: &[&str] = &[CLOUDFLARE_VARS_TABLE, AWS_ENV_TABLE];
+
+/// `[cloudflare.vars]`, as an overlay-free TOML path.
+pub const CLOUDFLARE_VARS_TABLE: &str = "cloudflare.vars";
+
+/// `[aws.env]`, as a TOML path.
+pub const AWS_ENV_TABLE: &str = "aws.env";
 
 /// A parsed `Skyzen.toml` document.
 ///
@@ -35,6 +175,9 @@ pub struct SkyzenManifest {
     /// `[[database]]` — logical portable SQL databases.
     #[serde(default)]
     pub database: Vec<DatabaseEntry>,
+    /// `[[secret]]` — values delivered to the deployed application at runtime.
+    #[serde(default)]
+    pub secret: Vec<SecretEntry>,
     /// `[native]` — how the portable capabilities are backed on native targets.
     #[serde(default)]
     pub native: Option<NativeSection>,
@@ -58,6 +201,19 @@ pub struct ServiceEntry {
     /// Which portable service trait this entry provides.
     #[serde(rename = "type")]
     pub service_type: ServiceType,
+}
+
+/// One `[[secret]]` entry — a value the deployment delivers to the running application.
+///
+/// One portable concept per target: the name is the environment variable a native, Lambda or
+/// Functions process reads, and the binding name a Worker resolves. `[cloudflare.secret.<NAME>]`
+/// backs one with a Secrets Store entry instead of a classic Worker secret; the name is the same
+/// either way, so nothing in the application knows which it got.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretEntry {
+    /// The secret's name, which is also the name the application reads it under.
+    pub name: VarName,
 }
 
 /// The portable service kinds a `[[service]]` entry can declare.
@@ -218,14 +374,14 @@ const fn default_retry_delay() -> Duration {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WiringEnvVar<'a> {
     /// The variable's name.
-    pub name: &'a str,
+    pub name: &'a VarName,
     /// The manifest key that named it, when the wiring chooses the name.
     pub key: Option<&'static str>,
 }
 
 impl<'a> WiringEnvVar<'a> {
     /// A variable the manifest names through `key`.
-    const fn declared(key: &'static str, name: &'a str) -> Self {
+    const fn declared(key: &'static str, name: &'a VarName) -> Self {
         Self {
             name,
             key: Some(key),
@@ -233,28 +389,28 @@ impl<'a> WiringEnvVar<'a> {
     }
 
     /// A variable the backend's constructor fixes the name of.
-    const fn fixed(name: &'static str) -> Self {
+    const fn fixed(name: &'static VarName) -> Self {
         Self { name, key: None }
     }
 }
 
 /// The account endpoint `CosmosKv::from_env` reads. Fixed by that constructor, which is the only
 /// public one that authenticates with an account key.
-const COSMOS_ENDPOINT_ENV: &str = "AZURE_COSMOS_ENDPOINT";
+static COSMOS_ENDPOINT_ENV: VarName = VarName::from_static("AZURE_COSMOS_ENDPOINT");
 
 /// The account key `CosmosKv::from_env` reads.
-const COSMOS_KEY_ENV: &str = "AZURE_COSMOS_KEY";
+static COSMOS_KEY_ENV: VarName = VarName::from_static("AZURE_COSMOS_KEY");
 
 /// The four variables `RdsDataDb::from_env` reads, in the order that constructor reads them.
 ///
 /// Read only by the wiring that names none of the four values itself; one that names all four is
 /// built through `RdsDataDb::from_parts` and reads nothing. Their names are fixed by the
 /// constructor, so a wiring can replace them wholesale but cannot rename them.
-const RDS_ENV_VARS: [&str; 4] = [
-    "RDS_RESOURCE_ARN",
-    "RDS_SECRET_ARN",
-    "RDS_DATABASE",
-    "RDS_ENGINE",
+static RDS_ENV_VARS: [VarName; 4] = [
+    VarName::from_static("RDS_RESOURCE_ARN"),
+    VarName::from_static("RDS_SECRET_ARN"),
+    VarName::from_static("RDS_DATABASE"),
+    VarName::from_static("RDS_ENGINE"),
 ];
 
 /// The manifest keys an [`RdsDataWiring`] names its four values with, in the order they are
@@ -336,8 +492,8 @@ impl NativeServiceSection {
                 vec![WiringEnvVar::declared("sas_url_env", &wiring.sas_url_env)]
             }
             Self::Cosmos(_) => vec![
-                WiringEnvVar::fixed(COSMOS_ENDPOINT_ENV),
-                WiringEnvVar::fixed(COSMOS_KEY_ENV),
+                WiringEnvVar::fixed(&COSMOS_ENDPOINT_ENV),
+                WiringEnvVar::fixed(&COSMOS_KEY_ENV),
             ],
             Self::DynamoDb(_) | Self::Memory(_) => Vec::new(),
         }
@@ -349,7 +505,7 @@ impl NativeServiceSection {
 #[serde(deny_unknown_fields)]
 pub struct RedisWiring {
     /// Environment variable holding the connection URL (`redis://host:port`).
-    pub url_env: String,
+    pub url_env: VarName,
 }
 
 /// `backend = "dynamodb"`.
@@ -389,7 +545,7 @@ pub struct CosmosWiring {
 #[serde(deny_unknown_fields)]
 pub struct S3Wiring {
     /// Environment variable holding the bucket name.
-    pub bucket_env: String,
+    pub bucket_env: VarName,
 }
 
 /// `backend = "blob"`.
@@ -400,12 +556,12 @@ pub struct BlobWiring {
     pub container: String,
     /// Environment variable holding the storage account connection string.
     #[serde(default = "default_azure_storage_connection_env")]
-    pub connection_env: String,
+    pub connection_env: VarName,
 }
 
 /// The variable `AzureBlob::from_env` reads, and this wiring's default.
-fn default_azure_storage_connection_env() -> String {
-    "AZURE_STORAGE_CONNECTION_STRING".to_owned()
+const fn default_azure_storage_connection_env() -> VarName {
+    VarName::from_static("AZURE_STORAGE_CONNECTION_STRING")
 }
 
 /// `backend = "sqs"`.
@@ -414,7 +570,7 @@ fn default_azure_storage_connection_env() -> String {
 pub struct SqsWiring {
     /// Environment variable holding the queue URL. It must name a standard queue: a FIFO queue
     /// needs a message group on every send, and is wired in code with `SqsQueue::fifo`.
-    pub url_env: String,
+    pub url_env: VarName,
 }
 
 /// `backend = "servicebus"`.
@@ -425,12 +581,12 @@ pub struct ServiceBusWiring {
     pub queue: String,
     /// Environment variable holding the namespace's connection string.
     #[serde(default = "default_servicebus_connection_env")]
-    pub connection_env: String,
+    pub connection_env: VarName,
 }
 
 /// The variable `ServiceBusQueue::from_env` reads, and this wiring's default.
-fn default_servicebus_connection_env() -> String {
-    "SERVICEBUS_CONNECTION_STRING".to_owned()
+const fn default_servicebus_connection_env() -> VarName {
+    VarName::from_static("SERVICEBUS_CONNECTION_STRING")
 }
 
 /// `backend = "storage-queue"`.
@@ -441,7 +597,7 @@ pub struct StorageQueueWiring {
     ///
     /// The whole URL is the credential, which is why it is read from the environment rather than
     /// split into a queue name and a secret.
-    pub sas_url_env: String,
+    pub sas_url_env: VarName,
 }
 
 pub use fieldless::MemoryWiring;
@@ -718,7 +874,7 @@ impl NativeDatabaseSection {
     /// answers — the variable an `azure-sql` wiring names is still reported by
     /// [`env_vars`](Self::env_vars), so `skyzen dev` and `.env.example` cover it like any other.
     #[must_use]
-    pub fn url_env(&self) -> Option<&str> {
+    pub const fn url_env(&self) -> Option<&VarName> {
         match self {
             Self::Postgres(wiring) | Self::Mysql(wiring) | Self::Sqlite(wiring) => {
                 Some(&wiring.url_env)
@@ -744,7 +900,7 @@ impl NativeDatabaseSection {
             // somehow did, naming the variables is the answer that fails loudly rather than
             // starting an application with half its configuration missing.
             Self::RdsData(wiring) if matches!(wiring.parts(), Ok(Some(_))) => Vec::new(),
-            Self::RdsData(_) => RDS_ENV_VARS.map(WiringEnvVar::fixed).to_vec(),
+            Self::RdsData(_) => RDS_ENV_VARS.iter().map(WiringEnvVar::fixed).collect(),
         }
     }
 }
@@ -763,7 +919,7 @@ pub struct SqlUrlWiring {
     /// A connection URL for `postgres`, `mysql` and `sqlite`; the ADO.NET connection string for
     /// `azure-sql`, where `AZURE_SQL_CONNECTION_STRING` — the name `AzureSqlConfig::from_env`
     /// reads — is the conventional choice.
-    pub url_env: String,
+    pub url_env: VarName,
 }
 
 /// The native backends a portable database can be wired to.
@@ -875,9 +1031,10 @@ pub struct CloudflareSection {
     /// `[cloudflare.assets]` — static assets served alongside the Worker.
     #[serde(default)]
     pub assets: Option<CfAssets>,
-    /// `[[cloudflare.secrets_store_secrets]]`.
+    /// `[cloudflare.secret.<NAME>]` — the `[[secret]]` entries backed by a Secrets Store entry
+    /// rather than by a classic Worker secret, keyed by the secret's name.
     #[serde(default)]
-    pub secrets_store_secrets: Vec<CfSecretsStoreSecret>,
+    pub secret: BTreeMap<VarName, CloudflareSecretSection>,
     /// `[cloudflare.raw]` — an escape hatch merged verbatim into the generated `wrangler.toml`.
     ///
     /// Anything wrangler accepts but Skyzen does not model goes here. The table is deep-merged
@@ -1382,14 +1539,17 @@ impl AzureSection {
     }
 }
 
-/// One `[[cloudflare.secrets_store_secrets]]` entry.
+/// `[cloudflare.secret.<NAME>]` — one `[[secret]]` backed by Cloudflare Secrets Store.
+///
+/// The map key is the `[[secret]]` name, which is also the binding the Worker resolves; a secret
+/// with no section here is a classic Worker secret, pushed by `skyzen secret push`. A Secrets
+/// Store entry is externally managed: the deployment binds it, and only `skyzen secret set` writes
+/// its value.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct CfSecretsStoreSecret {
-    /// Binding name, as seen from `env`.
-    pub binding: String,
+pub struct CloudflareSecretSection {
     /// The secrets store the secret lives in.
     pub store_id: String,
-    /// The secret's name within that store.
+    /// The secret's name within that store, which need not match the binding.
     pub secret_name: String,
 }

--- a/manifest/src/secrets.rs
+++ b/manifest/src/secrets.rs
@@ -7,7 +7,14 @@
 //! * **Heuristic** — a `vars` / `[aws.env]` key whose *name* looks like a secret, or a
 //!   JWT-shaped string. The CLI warns. `${NAME}` placeholders are neither.
 
-use std::fmt::{Display, Formatter};
+use crate::{
+    schema::{VarName, PLAINTEXT_VARIABLE_TABLES},
+    walk::{walk_strings, StringSite},
+};
+use std::{
+    convert::Infallible,
+    fmt::{Display, Formatter},
+};
 
 /// One string in the document that looks like a secret.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,52 +66,24 @@ pub struct SecretReport {
 }
 
 /// Walk every string **value** in `table`. Keys are not inspected for credential forms.
+///
+/// The table is taken by mutable reference because the walk is shared with `${NAME}` expansion,
+/// which rewrites what it visits; this pass only reads.
 #[must_use]
-pub fn scan_table(table: &toml::Table) -> SecretReport {
+pub fn scan_table(table: &mut toml::Table) -> SecretReport {
     let mut report = SecretReport::default();
-    scan_table_at(table, "", &mut report);
+    let visit = &mut |site: StringSite<'_>| -> Result<(), Infallible> {
+        classify(
+            site.location,
+            site.key,
+            site.parent,
+            site.value,
+            &mut report,
+        );
+        Ok(())
+    };
+    walk_strings(table, visit).unwrap_or_else(|never| match never {});
     report
-}
-
-fn scan_table_at(table: &toml::Table, parent: &str, report: &mut SecretReport) {
-    for (key, value) in table {
-        let location = child_path(parent, key);
-        match value {
-            toml::Value::String(text) => classify(&location, key, parent, text, report),
-            toml::Value::Array(items) => {
-                for (index, item) in items.iter().enumerate() {
-                    scan_value(&format!("{location}[{index}]"), key, parent, item, report);
-                }
-            }
-            toml::Value::Table(child) => scan_table_at(child, &location, report),
-            toml::Value::Integer(_)
-            | toml::Value::Float(_)
-            | toml::Value::Boolean(_)
-            | toml::Value::Datetime(_) => {}
-        }
-    }
-}
-
-fn scan_value(
-    location: &str,
-    key: &str,
-    parent: &str,
-    value: &toml::Value,
-    report: &mut SecretReport,
-) {
-    match value {
-        toml::Value::String(text) => classify(location, key, parent, text, report),
-        toml::Value::Array(items) => {
-            for (index, item) in items.iter().enumerate() {
-                scan_value(&format!("{location}[{index}]"), key, parent, item, report);
-            }
-        }
-        toml::Value::Table(child) => scan_table_at(child, location, report),
-        toml::Value::Integer(_)
-        | toml::Value::Float(_)
-        | toml::Value::Boolean(_)
-        | toml::Value::Datetime(_) => {}
-    }
 }
 
 fn classify(location: &str, key: &str, parent: &str, text: &str, report: &mut SecretReport) {
@@ -128,10 +107,17 @@ fn classify(location: &str, key: &str, parent: &str, text: &str, report: &mut Se
     if is_secret_key_table(parent) && is_secret_named_key(key) {
         report.warnings.push(SecretFinding {
             location: location.to_owned(),
-            kind: "plaintext value of a secret-named key",
+            kind: SECRET_NAMED_KEY,
         });
     }
 }
+
+/// The warning a plaintext value under a secret-named key produces.
+///
+/// Named because the scanner emits it and two tests assert on it; the fix it names is the one
+/// portable one, `[[secret]]`, rather than a per-provider table.
+const SECRET_NAMED_KEY: &str =
+    "plaintext value of a secret-named key; declare it as [[secret]] and run `skyzen secret push`";
 
 /// Documented forms that cannot reasonably be a resource id or a URL.
 fn block_kind(text: &str) -> Option<&'static str> {
@@ -287,9 +273,14 @@ fn url_has_password(text: &str) -> bool {
     }
 }
 
+/// A JWT anywhere in the value, matched token by token like the issuer prefixes above: a token
+/// pasted into a longer string ("Authorization: Bearer eyJ…") is the same leak as one on its own.
 fn looks_like_jwt(text: &str) -> bool {
-    let trimmed = text.trim();
-    let mut parts = trimmed.split('.');
+    text.split_whitespace().any(is_jwt_token)
+}
+
+fn is_jwt_token(token: &str) -> bool {
+    let mut parts = token.split('.');
     let Some(header) = parts.next() else {
         return false;
     };
@@ -307,20 +298,31 @@ fn is_placeholder(text: &str) -> bool {
     trimmed
         .strip_prefix("${")
         .and_then(|inner| inner.strip_suffix('}'))
-        .is_some_and(is_ident)
+        .is_some_and(VarName::is_valid)
 }
 
-fn is_ident(name: &str) -> bool {
-    let mut bytes = name.bytes();
-    match bytes.next() {
-        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
-        _ => return false,
-    }
-    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
-}
-
+/// Whether `parent` is one of the tables whose keys are plaintext platform variables.
+///
+/// Matched against the schema's own list, plus the Cloudflare environment overlay spelling of it:
+/// `[cloudflare.env.staging.vars]` is `[cloudflare.vars]` for one environment, and a secret
+/// committed there is committed just the same.
 fn is_secret_key_table(parent: &str) -> bool {
-    parent == "aws.env" || parent == "vars" || parent.strip_suffix(".vars").is_some()
+    PLAINTEXT_VARIABLE_TABLES
+        .iter()
+        .any(|table| parent == *table || is_cloudflare_overlay_of(parent, table))
+}
+
+/// Whether `parent` is `cloudflare.env.<name>.<rest>` for a `cloudflare.<rest>` table.
+fn is_cloudflare_overlay_of(parent: &str, table: &str) -> bool {
+    let Some(rest) = table.strip_prefix("cloudflare.") else {
+        return false;
+    };
+    let Some(overlay) = parent.strip_prefix("cloudflare.env.") else {
+        return false;
+    };
+    overlay
+        .split_once('.')
+        .is_some_and(|(name, tail)| !name.is_empty() && tail == rest)
 }
 
 const SECRET_KEY_NEEDLES: &[&str] = &[
@@ -343,14 +345,6 @@ fn is_secret_named_key(key: &str) -> bool {
         .any(|needle| upper.contains(needle))
 }
 
-fn child_path(parent: &str, key: &str) -> String {
-    if parent.is_empty() {
-        key.to_owned()
-    } else {
-        format!("{parent}.{key}")
-    }
-}
-
 /// Turn blocking findings into an error. `None` when there are none.
 #[must_use]
 pub fn blocking_error(report: &SecretReport) -> Option<SecretError> {
@@ -368,8 +362,8 @@ mod tests {
     use super::scan_table;
 
     fn scan(source: &str) -> super::SecretReport {
-        let table: toml::Table = toml::from_str(source).expect("toml");
-        scan_table(&table)
+        let mut table: toml::Table = toml::from_str(source).expect("toml");
+        scan_table(&mut table)
     }
 
     #[test]
@@ -393,10 +387,7 @@ mod tests {
         let report = scan("[cloudflare.vars]\nAPI_KEY = \"dev-only\"\n");
         assert_eq!(report.blocks, []);
         assert_eq!(report.warnings.len(), 1);
-        assert_eq!(
-            report.warnings[0].kind,
-            "plaintext value of a secret-named key"
-        );
+        assert_eq!(report.warnings[0].kind, super::SECRET_NAMED_KEY);
     }
 
     #[test]

--- a/manifest/src/secrets.rs
+++ b/manifest/src/secrets.rs
@@ -6,6 +6,9 @@
 //!   private key, a URL with a password). The CLI refuses to load the file.
 //! * **Heuristic** — a `vars` / `[aws.env]` key whose *name* looks like a secret, or a
 //!   JWT-shaped string. The CLI warns. `${NAME}` placeholders are neither.
+//!
+//! Both point at the same fix: declare the value as `[[secret]]`, which is described in
+//! `docs/skyzen-toml-reference.md#secrets`.
 
 use crate::{
     schema::{VarName, PLAINTEXT_VARIABLE_TABLES},

--- a/manifest/src/walk.rs
+++ b/manifest/src/walk.rs
@@ -1,0 +1,82 @@
+//! The one walk over a TOML document's string values.
+//!
+//! Two passes need it: deploy-time `${NAME}` expansion, which rewrites the value, and the secret
+//! scanner, which classifies it. They ran their own recursions once, and the TOML paths they
+//! reported — the thing a user is told to go and edit — drifted apart. One walker, one path.
+//!
+//! The walk visits string **values** only. Keys are never rewritten, and a table's own key reaches
+//! the visitor as [`StringSite::key`] so the scanner can ask which table a value sits in.
+
+use toml::Value;
+
+/// One string value in the document, with everything a visitor needs to locate and rewrite it.
+#[derive(Debug)]
+pub struct StringSite<'a> {
+    /// TOML path of the string, e.g. `cloudflare.kv_namespaces[0].id`.
+    pub location: &'a str,
+    /// The key this value is stored under. For an array item, the key of the array itself.
+    pub key: &'a str,
+    /// The path of the table holding the key, empty at the document root.
+    pub parent: &'a str,
+    /// The value, rewritable in place.
+    pub value: &'a mut String,
+}
+
+/// Visit every string value in `table`, depth first, in key order.
+///
+/// # Errors
+///
+/// Returns the first error `visit` produces, which stops the walk.
+pub fn walk_strings<E>(
+    table: &mut toml::Table,
+    visit: &mut impl FnMut(StringSite<'_>) -> Result<(), E>,
+) -> Result<(), E> {
+    walk_table(table, "", visit)
+}
+
+fn walk_table<E>(
+    table: &mut toml::Table,
+    parent: &str,
+    visit: &mut impl FnMut(StringSite<'_>) -> Result<(), E>,
+) -> Result<(), E> {
+    for (key, value) in table.iter_mut() {
+        let location = child_path(parent, key);
+        walk_value(value, &location, key, parent, visit)?;
+    }
+    Ok(())
+}
+
+fn walk_value<E>(
+    value: &mut Value,
+    location: &str,
+    key: &str,
+    parent: &str,
+    visit: &mut impl FnMut(StringSite<'_>) -> Result<(), E>,
+) -> Result<(), E> {
+    match value {
+        Value::String(text) => visit(StringSite {
+            location,
+            key,
+            parent,
+            value: text,
+        }),
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                let child = format!("{location}[{index}]");
+                walk_value(item, &child, key, parent, visit)?;
+            }
+            Ok(())
+        }
+        Value::Table(child) => walk_table(child, location, visit),
+        Value::Integer(_) | Value::Float(_) | Value::Boolean(_) | Value::Datetime(_) => Ok(()),
+    }
+}
+
+/// The TOML path of `key` inside the table at `parent`.
+fn child_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_owned()
+    } else {
+        format!("{parent}.{key}")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub use middleware::Middleware;
 pub use routing::{CreateRouteNode, Route};
 pub use skyzen_core::error::*;
 pub use skyzen_core::Server;
-pub use skyzen_core::{error_response, log_endpoint_error, ErrorChain, RequestBodyLimit};
+pub use skyzen_core::{error_response, log_endpoint_error, ErrorChain, RequestBodyLimit, Secret};
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
 pub use wasm_bindgen;


### PR DESCRIPTION
Fixes #40

## What

Secrets become one portable capability, `[[secret]] name = "NAME"`, wired like `[[service]]`, with one runtime type and one CLI delivery path per provider.

- **Manifest** (`skyzen-manifest`): `VarName` newtype (`[A-Za-z_][A-Za-z0-9_]*`, `const fn from_static` fails the build on a bad literal) for every `*_env` key and secret name, so `url_env = "${FOO}"` is a parse error instead of the CLI and the macro reading different variables. `[[secret]]` and `[cloudflare.secret.<NAME>]` (Secrets Store backing) replace `[[cloudflare.secrets_store_secrets]]`. One TOML walker behind the `${NAME}` expander and the committed-secret scanner. Cross-field rules: a backing names a declared secret, names are unique, a secret is never also a plaintext `[cloudflare.vars]` / `[aws.env]` key, checked for every overlay.
- **Runtime**: `skyzen::Secret` (`Arc<secrecy::SecretString>`, `expose()` only, `Debug` is `Secret(<redacted>)`). `import_config!` generates `StripeKey` per `STRIPE_KEY`; `#[skyzen::main]` resolves it once at startup (`std::env::var` natively, `CfSecret::classic` / `from_store` on Workers). A store backing declared only in an overlay is a compile error.
- **CLI**: one `Environment` (`.env`, `.env.local`, process env wins) replaces four hand-written precedence copies; `skyzen dev` now gives the child only the `.env` entries the shell does not already hold, so an exported variable wins as documented. Plans are ordered `Step`s (command with typed stdin, or in-process task). `skyzen secret set|push|list` works on Cloudflare (wrangler, value on stdin, `.skyzen/gen/.dev.vars` for dev, local Secrets Store seeding), AWS (`aws-sdk-lambda` `UpdateFunctionConfiguration`, read-modify-write) and Azure (ARM app settings, `az` bearer, read-modify-write; `[azure]` gains `subscription_id` / `resource_group`). `deploy` delivers the runtime variables each provider needs and refuses when one is missing. `--env-var` is gone from the Lambda command line; `--dry-run` prints `write <path> (secret values, not shown)` for value-bearing files.
- **Docs**: one canonical `## Secrets` section in the manifest reference; README, deployment guide, crate READMEs and AGENTS.md point at it. Root-level `.dev.vars` is no longer part of the story.

## Breaking changes

- `[[cloudflare.secrets_store_secrets]]` → `[[secret]]` + `[cloudflare.secret.<NAME>]`.
- `skyzen_cloudflare::{required_secret, optional_secret, CfSecretStore}` → `CfSecret::{classic, from_store}` returning `skyzen::Secret`.
- `[azure]` requires `subscription_id` and `resource_group` for `deploy` and `secret`.
- `skyzen_manifest` wiring fields (`url_env`, `bucket_env`, …) are `VarName`, not `String`.

## Verification

Per crate: `cargo test -p skyzen-manifest` (87 + 3 doc), `-p skyzen-core --all-features` (25 + 5 doc), `-p skyzen-macros` (68), `-p skyzen-cli` (176); `cargo clippy -p <crate> --all-targets -- -D warnings` for each; `cargo clippy -p skyzen-cloudflare --target wasm32-unknown-unknown -- -D warnings`; `cargo check -p skyzen --all-features`, `-p skyzen-example-queue-consumer`; `cargo machete`; `cargo fmt --all --check`. Generated tokens were compile-checked by temporarily adding a `[[secret]]` to the example crate.

Externals verified against upstream source: wrangler reads `.dev.vars` next to `--config`; `wrangler secret put` / `secrets-store secret create|update` read the value from stdin when it is not a TTY; current cargo-lambda attaches no `Environment` when no `--env-var` is passed.
