### PR TITLE
feat(openapi)!: serve Scalar as the default API docs UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ http = "1.4"
 # crate happening to switch it on.
 utoipa = { version = "5.4", default-features = false, features = ["macros"] }
 utoipa-redoc = "6.0"
+utoipa-scalar = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-tungstenite = { version = "0.33.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -835,10 +835,12 @@ async fn get_item(Path(id): Path<u64>) -> Result<Json<Item>> {
 
 fn router() -> Router {
     let routes = Route::new(("/items/{id}".get(get_item),));
-    let redoc = routes.openapi().redoc();     // interactive ReDoc page
-    Route::new((routes, "/docs".get(redoc))).build()
+    let docs = routes.openapi().scalar_route("/docs"); // interactive Scalar page
+    Route::new((routes, docs)).build()
 }
 ```
+
+`Route::enable_api_doc()` mounts the same Scalar UI at `/api-docs`. `.redoc()` / `.redoc_route()` remain available if you want Redoc instead.
 
 *Schema generation is gated to debug builds and native targets, so release binaries and edge wasm
 bundles stay small.*

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,7 @@ cargo run --example openapi
 Features:
 
 - Extended OpenAPI example with multiple annotated handlers.
-- Demonstrates `Route::openapi()` and `OpenApi::redoc_route("/docs")` to serve ReDoc documentation.
+- Demonstrates `Route::openapi()` and `OpenApi::scalar_route("/docs")` to serve Scalar documentation.
 - Shows typed request/response schemas with `#[skyzen::openapi]`, and `State<T>` shared across handlers.
 
 ```sh

--- a/examples/openapi.rs
+++ b/examples/openapi.rs
@@ -164,17 +164,17 @@ fn write_openapi_document(spec: &OpenApi) {
 
 #[skyzen::main]
 fn main() -> Router {
-    let redoc_endpoint = Route::new(("/hello".at(hello),)).openapi().redoc();
+    let scalar_endpoint = Route::new(("/hello".at(hello),)).openapi().scalar();
     let router = Route::new((
         "/hello".at(hello),
         "/projects/{project_id}/tasks".at(create_task),
-        // Serve interactive docs at GET /docs via utoipa-redoc.
-        "/docs".endpoint(Method::GET, redoc_endpoint),
+        // Serve interactive docs at GET /docs via Scalar.
+        "/docs".endpoint(Method::GET, scalar_endpoint),
     ))
     .build();
     let openapi = router.openapi();
     tracing::info!("OpenAPI enabled: {}", openapi.is_enabled());
-    tracing::info!("ReDoc endpoint mounted at GET /docs");
+    tracing::info!("Scalar endpoint mounted at GET /docs");
     log_openapi(&openapi);
     router
 }

--- a/examples/openapi_full.rs
+++ b/examples/openapi_full.rs
@@ -174,7 +174,7 @@ fn main() -> Router {
     ));
 
     let openapi = api_routes.openapi();
-    let docs = openapi.redoc_route("/docs");
+    let docs = openapi.scalar_route("/docs");
 
     Route::new((api_routes, docs)).middleware(store).build()
 }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -28,6 +28,7 @@ use utoipa::openapi::{
     Deprecated, OpenApi as UtoipaSpec, RefOr, Required,
 };
 use utoipa_redoc::Redoc;
+use utoipa_scalar::Scalar;
 
 /// `OpenAPI` schema reference type alias.
 pub type SchemaRef = RefOr<Schema>;
@@ -552,22 +553,38 @@ impl OpenApi {
         ))
     }
 
+    /// Convert the collected spec to a [`Scalar`](utoipa_scalar::Scalar) endpoint.
+    ///
+    /// This is the recommended interactive documentation UI.
     #[must_use]
-    /// Convert the collected spec to a [`Redoc`](utoipa_redoc::Redoc) endpoint.
-    pub fn redoc(&self) -> OpenApiRedocEndpoint {
-        if !self.is_enabled() {
-            return OpenApiRedocEndpoint::disabled();
-        }
-
-        let html = Redoc::new(self.to_utoipa_spec()).to_html();
-        OpenApiRedocEndpoint::enabled(html)
+    pub fn scalar(&self) -> OpenApiUiEndpoint {
+        self.ui_endpoint(|| Scalar::new(self.to_utoipa_spec()).to_html())
     }
 
-    /// Build a [`RouteNode`] that serves the generated `OpenAPI` document at the provided mount path.
+    /// Build a [`RouteNode`] that serves the generated `OpenAPI` document via Scalar at `mount_path`.
+    #[must_use]
+    pub fn scalar_route(&self, mount_path: impl Into<String>) -> RouteNode {
+        ui_route(self.scalar(), mount_path.into())
+    }
+
+    /// Convert the collected spec to a [`Redoc`](utoipa_redoc::Redoc) endpoint.
+    #[must_use]
+    pub fn redoc(&self) -> OpenApiUiEndpoint {
+        self.ui_endpoint(|| Redoc::new(self.to_utoipa_spec()).to_html())
+    }
+
+    /// Build a [`RouteNode`] that serves the generated `OpenAPI` document via Redoc at `mount_path`.
     #[must_use]
     pub fn redoc_route(&self, mount_path: impl Into<String>) -> RouteNode {
-        let endpoint = self.redoc();
-        redoc_route(endpoint, mount_path.into())
+        ui_route(self.redoc(), mount_path.into())
+    }
+
+    fn ui_endpoint(&self, html: impl FnOnce() -> String) -> OpenApiUiEndpoint {
+        if self.is_enabled() {
+            OpenApiUiEndpoint::enabled(html())
+        } else {
+            OpenApiUiEndpoint::disabled()
+        }
     }
 
     /// Convert collected operations to a fully hydrated [`utoipa::openapi::OpenApi`] document.
@@ -665,12 +682,12 @@ impl fmt::Debug for OpenApiOperation {
 }
 
 #[derive(Clone, Debug)]
-/// Endpoint that renders the `OpenAPI` document via Redoc.
-pub struct OpenApiRedocEndpoint {
+/// Endpoint that serves a pre-rendered `OpenAPI` documentation page.
+pub struct OpenApiUiEndpoint {
     html: Option<Arc<String>>,
 }
 
-impl OpenApiRedocEndpoint {
+impl OpenApiUiEndpoint {
     fn enabled(html: String) -> Self {
         Self {
             html: Some(Arc::new(html)),
@@ -684,10 +701,10 @@ impl OpenApiRedocEndpoint {
 
 http_error!(
     /// Error returned when OpenAPI support is disabled.
-    pub OpenApiRedocDisabledError, StatusCode::NOT_IMPLEMENTED, "OpenAPI support is disabled for this build");
+    pub OpenApiUiDisabledError, StatusCode::NOT_IMPLEMENTED, "OpenAPI support is disabled for this build");
 
-impl Endpoint for OpenApiRedocEndpoint {
-    type Error = OpenApiRedocDisabledError;
+impl Endpoint for OpenApiUiEndpoint {
+    type Error = OpenApiUiDisabledError;
     // The document is rendered at build time, so the future is ready on creation rather than an
     // `async` block with nothing to await.
     fn respond(
@@ -695,7 +712,7 @@ impl Endpoint for OpenApiRedocEndpoint {
         _request: &mut Request,
     ) -> impl Future<Output = Result<Response, Self::Error>> + Send {
         ready(self.html.as_ref().map_or_else(
-            || Err(OpenApiRedocDisabledError::new()),
+            || Err(OpenApiUiDisabledError::new()),
             |html| {
                 let mut response = Response::new(Body::from(html.as_bytes().to_vec()));
                 response.headers_mut().insert(
@@ -708,7 +725,7 @@ impl Endpoint for OpenApiRedocEndpoint {
     }
 }
 
-fn redoc_route(endpoint: OpenApiRedocEndpoint, mount_path: String) -> RouteNode {
+fn ui_route(endpoint: OpenApiUiEndpoint, mount_path: String) -> RouteNode {
     let wildcard_suffix = "/{*path}";
     let route = Route::new((
         RouteNode::new_endpoint(
@@ -730,12 +747,12 @@ fn redoc_route(endpoint: OpenApiRedocEndpoint, mount_path: String) -> RouteNode 
     RouteNode::new_route(mount_path, route)
 }
 
-/// Default mount path for the generated Redoc API documentation page.
+/// Default mount path for the generated API documentation page.
 pub const DEFAULT_API_DOCS_MOUNT: &str = "/api-docs";
 
-impl IntoRouteNode for OpenApiRedocEndpoint {
+impl IntoRouteNode for OpenApiUiEndpoint {
     fn into_route_node(self) -> RouteNode {
-        redoc_route(self, DEFAULT_API_DOCS_MOUNT.to_string())
+        ui_route(self, DEFAULT_API_DOCS_MOUNT.to_string())
     }
 }
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -445,12 +445,12 @@ impl Route {
         }
     }
 
-    /// Enable the Redoc API documentation endpoint at `/api-docs`.
+    /// Enable the Scalar API documentation endpoint at `/api-docs`.
     #[must_use]
     pub fn enable_api_doc(mut self) -> Self {
         let openapi = self.openapi();
         self.nodes
-            .push(openapi.redoc_route(openapi::DEFAULT_API_DOCS_MOUNT));
+            .push(openapi.scalar_route(openapi::DEFAULT_API_DOCS_MOUNT));
         self
     }
 }
@@ -508,13 +508,13 @@ impl RouteWithAlarm {
         router
     }
 
-    /// Enable the Redoc API documentation endpoint at `/api-docs`.
+    /// Enable the Scalar API documentation endpoint at `/api-docs`.
     #[must_use]
     pub fn enable_api_doc(mut self) -> Self {
         let openapi = self.route.openapi();
         self.route
             .nodes
-            .push(openapi.redoc_route(openapi::DEFAULT_API_DOCS_MOUNT));
+            .push(openapi.scalar_route(openapi::DEFAULT_API_DOCS_MOUNT));
         self
     }
 }

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -1311,6 +1311,31 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(content_type.contains("text/html"));
+        let body = response.into_body().into_string().await.unwrap();
+        assert!(
+            body.contains("@scalar/api-reference"),
+            "enable_api_doc should serve Scalar HTML"
+        );
+        assert!(body.contains("id=\"api-reference\""));
+    }
+
+    #[tokio::test]
+    async fn redoc_route_serves_redoc_html() {
+        async fn ping() -> Result<&'static str> {
+            Ok("pong")
+        }
+
+        let route = Route::new(("/ping".at(ping),));
+        let docs = route.openapi().redoc_route("/redoc");
+        let router = build(Route::new((route, docs))).unwrap();
+
+        let response = router.clone().go(get_request("/redoc")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().into_string().await.unwrap();
+        assert!(
+            body.contains("redoc"),
+            "redoc_route should serve Redoc HTML"
+        );
     }
 
     #[cfg(feature = "ws")]


### PR DESCRIPTION
Fixes #43

### Summary
- Add Scalar (`utoipa-scalar`) as the recommended OpenAPI UI.
- `Route::enable_api_doc()` now mounts Scalar at `/api-docs`.
- New APIs: `OpenApi::scalar()` and `OpenApi::scalar_route(path)`.
- Redoc remains opt-in via `redoc()` / `redoc_route()`.
- Shared `OpenApiUiEndpoint` replaces `OpenApiRedocEndpoint` (pre-1.0 break).
- Examples and README show Scalar.

Wasm/linkme is unchanged: schema collection stays native debug-only.
