### PR TITLE
fix(azure)!: speak the Service Bus REST API directly, dropping legacy azure_core

### DIFF
--- a/azure/Cargo.toml
+++ b/azure/Cargo.toml
@@ -20,11 +20,17 @@ tracing.workspace = true
 # Cosmos DB.
 azure_data_cosmos = { version = "0.37.1", features = ["key_auth"], optional = true }
 
-# Service Bus. The legacy client is the only published one; `azure_core` 0.21 is the HTTP stack it
-# already links, and the settlement calls this crate issues go out on that same client.
-azure_messaging_servicebus = { version = "0.21", optional = true }
-azure_core_legacy = { package = "azure_core", version = "0.21", optional = true }
-time = { version = "0.3", optional = true }
+# Service Bus speaks its REST API directly, on the same reqwest stack the blob backend uses. The
+# only published client, `azure_messaging_servicebus` 0.21, is built on legacy `azure_core` 0.21,
+# which logs the outgoing `authorization` header value at debug level (RUSTSEC-2026-0275) and drags
+# `http-types`, `async-std` and `rand 0.7` in behind it; there is no Service Bus client on
+# `azure_core` 1.0. Four requests — send, peek-lock, complete, unlock — are all this backend issues,
+# and `hmac`/`sha2` mint the shared access signature that authorizes each one.
+hmac = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+# `serde-well-known` is what writes `ScheduledEnqueueTimeUtc` as the RFC 2822 instant Service Bus
+# reads, byte for byte what the legacy client wrote.
+time = { version = "0.3", features = ["serde-well-known"], optional = true }
 url = { version = "2", optional = true }
 
 # Azure Storage queues, and the credential types Cosmos and the queues share.
@@ -83,10 +89,11 @@ blob = [
     "dep:bytes",
 ]
 servicebus = [
-    "dep:azure_messaging_servicebus",
-    "dep:azure_core_legacy",
-    "dep:time",
+    "dep:reqwest",
     "dep:url",
+    "dep:time",
+    "dep:hmac",
+    "dep:sha2",
 ]
 storage-queue = ["dep:azure_storage_queue", "dep:azure_core", "dep:async-io"]
 sql = [

--- a/azure/README.md
+++ b/azure/README.md
@@ -35,7 +35,7 @@ skyzen-azure = "0.1"
 |---------|---------|-------------|
 | `cosmos` | Yes | Cosmos DB `KeyValueStore` via `azure_data_cosmos` |
 | `blob` | Yes | Blob Storage `ObjectStorage` via Apache OpenDAL, plus the REST calls OpenDAL does not cover |
-| `servicebus` | Yes | Service Bus `MessageQueue` via `azure_messaging_servicebus` |
+| `servicebus` | Yes | Service Bus `MessageQueue`, speaking the Service Bus REST API on `reqwest` |
 | `storage-queue` | Yes | Azure Storage queue `MessageQueue` via `azure_storage_queue` |
 | `sql` | Yes | Azure SQL `DbBackend` via `tiberius` behind a `deadpool` pool |
 

--- a/azure/src/blob.rs
+++ b/azure/src/blob.rs
@@ -983,7 +983,7 @@ mod tests {
             .expect("an account key should sign");
 
         assert_eq!(request.method, http::Method::GET);
-        assert!(request.headers.is_empty());
+        assert!(request.headers.is_empty(), "{:?}", request.headers);
         assert!(request.url.contains("sig="), "{}", request.url);
     }
 }

--- a/azure/src/service_bus.rs
+++ b/azure/src/service_bus.rs
@@ -1,25 +1,33 @@
 //! Azure Service Bus implementation of [`MessageQueue`].
+//!
+//! The transport is the [Service Bus REST API] spoken directly on `reqwest`, rather than a client
+//! library: the only published Service Bus crate, `azure_messaging_servicebus` 0.21, is built on
+//! legacy `azure_core` 0.21, which logs the outgoing `authorization` header value at debug level
+//! (RUSTSEC-2026-0275) and drags `http-types`, `async-std` and `rand 0.7` in behind it. Four
+//! requests are all this backend ever issues — send, peek-lock, complete and unlock — so speaking
+//! them directly costs less than the client did.
+//!
+//! The wire format is the one the previous release put on the wire, read out of
+//! `azure_messaging_servicebus-0.21.0/src/service_bus/mod.rs`; each place that matters cites it.
+//!
+//! [Service Bus REST API]: https://learn.microsoft.com/rest/api/servicebus/service-bus-runtime-rest
 
-use core::time::Duration;
-use std::{collections::HashMap, sync::Arc};
+use core::{fmt, time::Duration};
 
-use azure_core_legacy::{
-    auth::Secret,
-    error::{Error as AzureError, ErrorKind},
-    headers::{HeaderName, Headers},
-    hmac::hmac_sha256,
-    new_http_client, HttpClient, Method, Request, StatusCode, Url,
-};
-use azure_messaging_servicebus::service_bus::{
-    PeekLockResponse, QueueClient, SendMessageOptions, SettableBrokerProperties,
-};
 use base64::Engine as _;
+use hmac::{Hmac, Mac as _};
+use reqwest::{
+    header::{HeaderMap, AUTHORIZATION, RETRY_AFTER},
+    Client, Method, Response, StatusCode,
+};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use skyzen_services::queue::{
     BatchSendFailure, MessageQueue, MessageReceipt, QueueError, QueueRetry, ReceiveOptions,
     ReceivedMessage, SendOptions,
 };
-use time::OffsetDateTime;
+use time::{OffsetDateTime, UtcOffset};
+use url::Url;
 
 use crate::status::{classify, retry_after, AzureStatus};
 
@@ -37,11 +45,28 @@ const HOST_SUFFIX: &str = ".servicebus.windows.net";
 /// The environment variable [`ServiceBusQueue::from_env`] reads its connection string from.
 const CONNECTION_STRING_ENV: &str = "SERVICEBUS_CONNECTION_STRING";
 
-/// How long the SAS token minted for one settlement request stays valid.
+/// The response header carrying a delivered message's `BrokerProperties`.
 ///
-/// The token authorizes a single `DELETE` or `PUT` that is issued immediately; a short life keeps
-/// a leaked token useless rather than granting queue access for an hour.
-const SETTLE_TOKEN_TTL: Duration = Duration::from_secs(300);
+/// Sent on a request, the same header carries the properties a send sets.
+const BROKER_PROPERTIES_HEADER: &str = "brokerproperties";
+
+/// The header Azure services name their own error code in.
+const ERROR_CODE_HEADER: &str = "x-ms-error-code";
+
+/// The body of a request that has none, which is what puts `Content-Length: 0` on the wire.
+///
+/// The REST reference's own peek-lock example sends that header, and
+/// `azure_messaging_servicebus-0.21.0/src/service_bus/mod.rs` set it explicitly "to avoid
+/// truncation errors" — so a bodyless request here declares its length rather than leaving it to
+/// the transport.
+const EMPTY_BODY: &str = "";
+
+/// How long the SAS token minted for one request stays valid.
+///
+/// Every token this backend mints authorizes a single request that is issued immediately, so the
+/// life is the same short one for all four: a leaked token is useless within five minutes rather
+/// than granting queue access for the hour the legacy client's own tokens lasted.
+const TOKEN_TTL: time::Duration = time::Duration::seconds(300);
 
 /// An Azure Service Bus-backed message queue.
 ///
@@ -71,19 +96,17 @@ const SETTLE_TOKEN_TTL: Duration = Duration::from_secs(300);
 /// fail, the rest are still delivered and [`QueueError::PartialBatch`] names exactly which entries
 /// were rejected.
 ///
-/// Cloning is cheap — the client and its HTTP stack are behind `Arc`.
+/// Cloning is cheap — the HTTP client is a handle onto a shared connection pool.
 #[derive(Debug, Clone)]
 pub struct ServiceBusQueue {
-    /// The SDK client, which owns sending and peek-lock receiving.
-    client: QueueClient,
-    /// The HTTP stack the client uses, shared so settlement rides the same connection pool.
-    http_client: Arc<dyn HttpClient>,
-    /// `https://{namespace}.servicebus.windows.net/{queue}`, the root of every settlement URL.
+    /// The HTTP client every request rides on.
+    http: Client,
+    /// `https://{namespace}.servicebus.windows.net/{queue}`, the root of every request URL.
     queue_url: Url,
-    /// The shared-access policy name that signs settlement requests.
+    /// The shared-access policy name that signs requests.
     policy_name: String,
-    /// The signing key, base64-encoded the way [`hmac_sha256`] expects to receive it.
-    signing_key: Secret,
+    /// The key those signatures are keyed with.
+    signing_key: SigningKey,
 }
 
 impl ServiceBusQueue {
@@ -95,35 +118,20 @@ impl ServiceBusQueue {
     /// # Errors
     ///
     /// [`QueueError::Backend`] when the namespace or queue name could not appear in a Service Bus
-    /// URL, which the legacy SDK would otherwise interpolate unencoded.
+    /// URL, or when the HTTP client could not be built.
     pub fn new(
         namespace: &str,
         queue: &str,
         policy_name: impl Into<String>,
         signing_key: &str,
     ) -> Result<Self, QueueError> {
-        let queue_url = queue_url(namespace, queue)?;
-        let http_client = new_http_client();
-        let policy_name = policy_name.into();
-
-        let client = QueueClient::new(
-            Arc::clone(&http_client),
-            namespace,
-            queue,
-            policy_name.clone(),
-            signing_key.to_owned(),
-        )
-        .map_err(backend_error)?;
-
         Ok(Self {
-            client,
-            http_client,
-            queue_url,
-            policy_name,
-            // `hmac_sha256` base64-decodes the key it is handed, and a Service Bus key signs with
-            // its own characters as the key bytes — so it is encoded once here to survive that
-            // decode. This is what the SDK's own client does with the key it is given.
-            signing_key: Secret::new(azure_core_legacy::base64::encode(signing_key)),
+            http: Client::builder().build().map_err(|error| {
+                QueueError::backend_with("failed to build an HTTPS client for Service Bus", error)
+            })?,
+            queue_url: queue_url(namespace, queue)?,
+            policy_name: policy_name.into(),
+            signing_key: SigningKey(signing_key.to_owned()),
         })
     }
 
@@ -138,7 +146,7 @@ impl ServiceBusQueue {
     /// [`QueueError::Backend`] when the connection string is malformed, names a namespace outside
     /// the public cloud, or names a different entity than `queue`;
     /// [`QueueError::Unsupported`] when it authenticates with a pre-minted signature rather than a
-    /// key, which this client cannot re-sign settlement requests with.
+    /// key, which this client cannot sign its own requests with.
     pub fn from_connection_string(
         connection_string: &str,
         queue: &str,
@@ -179,86 +187,32 @@ impl ServiceBusQueue {
         Self::from_connection_string(&connection_string, queue)
     }
 
-    /// Send one already-encoded message, reporting the SDK's own error.
-    async fn send_message(&self, message: &[u8], options: SendOptions) -> Result<(), AzureError> {
-        let encoded = encode_message(message);
-        let scheduled = options.delay.map(scheduled_enqueue_time).transpose()?;
-
-        let send_options = SendMessageOptions {
-            content_type: None,
-            broker_properties: scheduled.map(|scheduled_enqueue_time_utc| {
-                SettableBrokerProperties {
-                    scheduled_enqueue_time_utc: Some(scheduled_enqueue_time_utc),
-                    ..SettableBrokerProperties::default()
-                }
-            }),
-            custom_properties: encoded.base64.then(|| {
-                HashMap::from([(
-                    CONTENT_ENCODING_PROPERTY.to_owned(),
-                    BASE64_ENCODING.to_owned(),
-                )])
-            }),
-        };
-
-        self.client
-            .send_message(&encoded.body, Some(send_options))
-            .await
-    }
-
-    /// Build a settlement request against `receipt`'s lock, signed for [`SETTLE_TOKEN_TTL`].
-    ///
-    /// The URL is the one the Service Bus REST API documents for settling a peek-locked message,
-    /// `…/{queue}/messages/{messageId|sequenceNumber}/{lockToken}`: `DELETE` completes it, `PUT`
-    /// unlocks it. The SDK reaches it only through the response object a receive returns, which
-    /// cannot outlive the call, so a receipt that a caller may settle minutes later has to name it
-    /// directly.
-    ///
-    /// The sequence number is what names the message here, which is what the service puts in the
-    /// `Location` header of the peek-lock it answered: it is a number the broker assigned, while a
-    /// message id is whatever the sender chose to set.
-    fn settle_request(
-        &self,
-        method: Method,
-        receipt: &ServiceBusReceipt,
-    ) -> Result<Request, QueueError> {
+    /// The URL of `segments` under this queue, with every segment encoded by the URL parser.
+    fn message_url(&self, segments: &[&str]) -> Result<Url, ServiceBusError> {
         let mut url = self.queue_url.clone();
         url.path_segments_mut()
-            .map_err(|()| QueueError::backend("the Service Bus queue URL cannot carry a path"))?
-            .extend([
-                "messages",
-                &receipt.sequence_number.to_string(),
-                &receipt.lock_token,
-            ]);
-
-        let mut request = Request::new(url.clone(), method);
-        request.insert_header(
-            azure_core_legacy::headers::AUTHORIZATION,
-            self.sas_token(&url)?,
-        );
-        request.insert_header(azure_core_legacy::headers::CONTENT_LENGTH, "0");
-        request.set_body(azure_core_legacy::EMPTY_BODY);
-        Ok(request)
+            .map_err(|()| ServiceBusError::local("the Service Bus queue URL cannot carry a path"))?
+            .extend(segments);
+        Ok(url)
     }
 
     /// Mint a shared-access-signature token authorizing one request against `url`.
     ///
     /// The token is the documented Service Bus SAS: an HMAC-SHA256 over the percent-encoded
-    /// resource URI and the expiry instant, keyed with the policy's key.
-    fn sas_token(&self, url: &Url) -> Result<String, QueueError> {
+    /// resource URI and the expiry instant, keyed with the policy's key. It is valid for
+    /// [`TOKEN_TTL`].
+    fn sas_token(&self, url: &Url) -> Result<String, ServiceBusError> {
         let resource: String =
             url::form_urlencoded::byte_serialize(url.as_str().as_bytes()).collect();
         let expiry = OffsetDateTime::now_utc()
-            .checked_add(
-                time::Duration::try_from(SETTLE_TOKEN_TTL)
-                    .map_err(|error| QueueError::backend_with("SAS token lifetime", error))?,
-            )
-            .ok_or_else(|| QueueError::backend("the SAS token expiry overflowed the calendar"))?
+            .checked_add(TOKEN_TTL)
+            .ok_or_else(|| ServiceBusError::local("the SAS token expiry overflowed the calendar"))?
             .unix_timestamp();
 
-        let signature = hmac_sha256(&format!("{resource}\n{expiry}"), &self.signing_key)
-            .map_err(backend_error)?;
-        let signature: String =
-            url::form_urlencoded::byte_serialize(signature.as_bytes()).collect();
+        let signature: String = url::form_urlencoded::byte_serialize(
+            sign(&self.signing_key, &resource, expiry).as_bytes(),
+        )
+        .collect();
 
         Ok(format!(
             "SharedAccessSignature sr={resource}&sig={signature}&se={expiry}&skn={}",
@@ -266,23 +220,168 @@ impl ServiceBusQueue {
         ))
     }
 
-    /// Issue a settlement request and read the outcome off its status.
-    async fn settle(&self, method: Method, receipt: &MessageReceipt) -> Result<(), QueueError> {
-        let receipt = ServiceBusReceipt::decode(receipt)?;
-        let request = self.settle_request(method, &receipt)?;
+    /// Build the request one send goes out as.
+    ///
+    /// `POST {queue}/messages`, the body carrying the encoded text. A delay becomes the
+    /// `BrokerProperties` header and a base64 body its `skyzen-content-encoding` custom property —
+    /// the two headers `azure_messaging_servicebus-0.21.0/src/service_bus/mod.rs` put on this
+    /// request through `SendMessageOptions`.
+    ///
+    /// Nothing else, and in particular **no `Content-Type`**: the legacy client sent none, because
+    /// this backend never set `SendMessageOptions::content_type`, and a content type declared here
+    /// would arrive as the message's own `ContentType` for every consumer — describing a JSON or
+    /// text body as whatever this client happened to name. `skyzen-content-encoding` is this
+    /// backend's whole encoding contract.
+    fn send_request(
+        &self,
+        encoded: EncodedMessage,
+        options: &SendOptions,
+    ) -> Result<reqwest::Request, ServiceBusError> {
+        let url = self.message_url(&["messages"])?;
+
+        let mut request = self
+            .http
+            .post(url.clone())
+            .header(AUTHORIZATION, self.sas_token(&url)?)
+            .body(encoded.body);
+
+        if let Some(delay) = options.delay {
+            request = request.header(
+                BROKER_PROPERTIES_HEADER,
+                SendBrokerProperties::scheduled_at(scheduled_enqueue_time(delay)?).encode()?,
+            );
+        }
+
+        if encoded.base64 {
+            request = request.header(CONTENT_ENCODING_PROPERTY, property_value(BASE64_ENCODING)?);
+        }
+
+        request.build().map_err(|error| {
+            ServiceBusError::local_with("failed to build a Service Bus send request", error)
+        })
+    }
+
+    /// Send one message, reporting what the service said about it.
+    async fn send_message(
+        &self,
+        message: &[u8],
+        options: SendOptions,
+    ) -> Result<(), ServiceBusError> {
+        let request = self.send_request(encode_message(message), &options)?;
 
         let response = self
-            .http_client
-            .execute_request(&request)
+            .http
+            .execute(request)
             .await
-            .map_err(backend_error)?;
+            .map_err(|error| ServiceBusError::transport("send", error))?;
 
-        let retry_after_header = response
-            .headers()
-            .get_optional_string(&azure_core_legacy::headers::RETRY_AFTER);
-
-        settled(response.status(), retry_after_header.as_deref())
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(ServiceBusError::answered("send", response).await)
+        }
     }
+
+    /// Lease one message, waiting up to `wait` for one to arrive.
+    ///
+    /// `POST {queue}/messages/head?timeout=<secs>`, which the service answers with `201` and the
+    /// message, or with `204` when the wait elapsed first.
+    async fn peek_lock(&self, wait: Duration) -> Result<Option<ReceivedMessage>, QueueError> {
+        let mut url = self
+            .message_url(&["messages", "head"])
+            .map_err(queue_error)?;
+        url.query_pairs_mut()
+            .append_pair("timeout", &wait.as_secs().to_string());
+
+        let response = self
+            .http
+            .post(url.clone())
+            .header(AUTHORIZATION, self.sas_token(&url).map_err(queue_error)?)
+            .body(EMPTY_BODY)
+            .send()
+            .await
+            .map_err(|error| queue_error(ServiceBusError::transport("peek-lock", error)))?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+
+        if !peeked(status, header_text(&headers, RETRY_AFTER.as_str()))? {
+            return Ok(None);
+        }
+
+        let properties = broker_properties(&headers)?;
+        let encoding = content_encoding(&headers)?;
+        let body = response.bytes().await.map_err(|error| {
+            QueueError::backend_with("failed to read a Service Bus message body", error)
+        })?;
+        let body = core::str::from_utf8(&body).map_err(|error| {
+            QueueError::backend_with("Service Bus delivered a body that is not text", error)
+        })?;
+
+        received_message(&properties, encoding.as_deref(), body).map(Some)
+    }
+
+    /// Settle a leased message and read the outcome off the status.
+    ///
+    /// The URL is the one the Service Bus REST API documents for settling a peek-locked message,
+    /// `…/{queue}/messages/{messageId|sequenceNumber}/{lockToken}`: `DELETE` completes it, `PUT`
+    /// unlocks it.
+    ///
+    /// The sequence number is what names the message here, which is what the service puts in the
+    /// `Location` header of the peek-lock it answered: it is a number the broker assigned, while a
+    /// message id is whatever the sender chose to set.
+    async fn settle(&self, method: Method, receipt: &MessageReceipt) -> Result<(), QueueError> {
+        let receipt = ServiceBusReceipt::decode(receipt)?;
+        let url = self
+            .message_url(&[
+                "messages",
+                &receipt.sequence_number.to_string(),
+                &receipt.lock_token,
+            ])
+            .map_err(queue_error)?;
+
+        let response = self
+            .http
+            .request(method, url.clone())
+            .header(AUTHORIZATION, self.sas_token(&url).map_err(queue_error)?)
+            .body(EMPTY_BODY)
+            .send()
+            .await
+            .map_err(|error| queue_error(ServiceBusError::transport("settle", error)))?;
+
+        let status = response.status();
+        settled(
+            status,
+            header_text(response.headers(), RETRY_AFTER.as_str()),
+        )
+    }
+}
+
+/// The shared-access key requests are signed with.
+///
+/// A newtype rather than a bare `String` so that no `Debug` of anything holding it can print it:
+/// a client that logged its own credentials is what this backend exists to stop shipping.
+#[derive(Clone)]
+struct SigningKey(String);
+
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SigningKey(<redacted>)")
+    }
+}
+
+/// The `sig` of a SAS token: the base64 HMAC-SHA256 of `"{resource}\n{expiry}"`.
+///
+/// The key is the policy key's own characters taken as bytes. The legacy client reached the same
+/// bytes the long way around — `QueueClient::new` base64-*encoded* the key
+/// (`azure_messaging_servicebus-0.21.0/src/service_bus/queue_client.rs`) purely so that
+/// `azure_core`'s `hmac_sha256` could base64-*decode* it again
+/// (`azure_core-0.21.0/src/hmac.rs`) — so the signature is byte-identical.
+fn sign(key: &SigningKey, resource: &str, expiry: i64) -> String {
+    let mut hmac = Hmac::<Sha256>::new_from_slice(key.0.as_bytes())
+        .expect("HMAC-SHA256 accepts a key of any length");
+    hmac.update(format!("{resource}\n{expiry}").as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(hmac.finalize().into_bytes())
 }
 
 /// The URL of a queue in a namespace, with every segment encoded by the URL parser.
@@ -322,7 +421,7 @@ const fn is_namespace_char(c: char) -> bool {
 ///
 /// Service Bus entity names are letters, digits, periods, hyphens, underscores and slashes (which
 /// separate the segments of a hierarchical name). Nothing here needs percent-encoding, which is
-/// what makes it safe for the legacy SDK to interpolate the name straight into its URLs.
+/// what makes an entity name safe to sign as part of a resource URI.
 const fn is_entity_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '/')
 }
@@ -371,8 +470,8 @@ impl ConnectionString {
             } else if name.eq_ignore_ascii_case("SharedAccessSignature") {
                 return Err(QueueError::Unsupported(
                     "a connection string that carries a pre-minted SharedAccessSignature cannot \
-                     sign the settlement requests `ack` and `nack` issue; use a connection string \
-                     with a SharedAccessKey",
+                     sign the requests this backend issues; use a connection string with a \
+                     SharedAccessKey",
                 ));
             }
         }
@@ -396,9 +495,9 @@ impl ConnectionString {
 
 /// The bare namespace name inside `sb://my-namespace.servicebus.windows.net/`.
 ///
-/// A host outside `.servicebus.windows.net` is refused rather than accepted and then ignored: the
-/// legacy SDK builds every request URL against the public-cloud host, so a sovereign-cloud endpoint
-/// would silently address the wrong namespace.
+/// A host outside `.servicebus.windows.net` is refused rather than accepted and then ignored: every
+/// request URL is built against the public-cloud host, so a sovereign-cloud endpoint would silently
+/// address the wrong namespace.
 fn namespace_from_endpoint(endpoint: &str) -> Result<String, QueueError> {
     let url = Url::parse(endpoint).map_err(|error| {
         QueueError::backend_with(
@@ -419,7 +518,7 @@ fn namespace_from_endpoint(endpoint: &str) -> Result<String, QueueError> {
         .ok_or_else(|| {
             QueueError::backend(format!(
                 "the connection string's Endpoint {endpoint:?} is outside {HOST_SUFFIX}; \
-                 the Service Bus client this backend uses addresses the public cloud only"
+                 the Service Bus REST API this backend speaks addresses the public cloud only"
             ))
         })
 }
@@ -472,16 +571,57 @@ fn decode_message(body: &str, encoding: Option<&str>) -> Result<Vec<u8>, QueueEr
     }
 }
 
-/// The `skyzen-content-encoding` property, read off a delivered message's custom properties.
-///
-/// The SDK surfaces custom properties only as "anything that can be built from the response
-/// headers", which is what this is.
-struct ContentEncodingProperty(Option<String>);
+/// One header's value as text, when the response carries it and it is text at all.
+fn header_text<'headers>(headers: &'headers HeaderMap, name: &str) -> Option<&'headers str> {
+    headers.get(name).and_then(|value| value.to_str().ok())
+}
 
-impl From<Headers> for ContentEncodingProperty {
-    fn from(headers: Headers) -> Self {
-        Self(headers.get_optional_string(&HeaderName::from_static(CONTENT_ENCODING_PROPERTY)))
-    }
+/// A custom message property's value, as Service Bus encodes one.
+///
+/// The REST API carries a custom property as its own header holding a JSON value, and hands it back
+/// the same way: the `Peek-Lock Message` reference answers a message whose properties were sent as
+/// `Priority: High` with `Priority: "High"`. So a string property goes out quoted and comes back
+/// quoted, which is what [`content_encoding`] reads.
+fn property_value(value: &str) -> Result<String, ServiceBusError> {
+    serde_json::to_string(value).map_err(|error| {
+        ServiceBusError::local_with(
+            format!("failed to encode the {CONTENT_ENCODING_PROPERTY} message property"),
+            error,
+        )
+    })
+}
+
+/// The `BrokerProperties` of a delivered message, which is what makes it settleable.
+fn broker_properties(headers: &HeaderMap) -> Result<BrokerProperties, QueueError> {
+    let header = header_text(headers, BROKER_PROPERTIES_HEADER).ok_or_else(|| {
+        QueueError::backend(
+            "Service Bus delivered a message with no BrokerProperties, which can never be settled",
+        )
+    })?;
+
+    serde_json::from_str(header).map_err(|error| {
+        QueueError::backend_with(
+            "Service Bus delivered BrokerProperties this backend could not read",
+            error,
+        )
+    })
+}
+
+/// The `skyzen-content-encoding` property of a delivered message, when it carries one.
+fn content_encoding(headers: &HeaderMap) -> Result<Option<String>, QueueError> {
+    header_text(headers, CONTENT_ENCODING_PROPERTY)
+        .map(|value| {
+            serde_json::from_str(value).map_err(|error| {
+                QueueError::backend_with(
+                    format!(
+                        "the {CONTENT_ENCODING_PROPERTY} property of a delivered message is \
+                         {value:?}, which is not the JSON string Service Bus encodes a property as"
+                    ),
+                    error,
+                )
+            })
+        })
+        .transpose()
 }
 
 /// The lease this backend hands back, and takes back to settle a message.
@@ -514,67 +654,109 @@ impl ServiceBusReceipt {
     }
 }
 
-/// The instant `delay` from now, for Service Bus' `ScheduledEnqueueTimeUtc` broker property.
-fn scheduled_enqueue_time(delay: Duration) -> Result<OffsetDateTime, AzureError> {
-    let delay = time::Duration::try_from(delay).map_err(|error| {
-        AzureError::full(
-            ErrorKind::DataConversion,
-            error,
-            "the requested delivery delay does not fit a Service Bus schedule",
-        )
-    })?;
-
-    OffsetDateTime::now_utc().checked_add(delay).ok_or_else(|| {
-        AzureError::message(
-            ErrorKind::DataConversion,
-            "the requested delivery delay overflowed the calendar",
-        )
-    })
+/// The broker properties of a delivered message, as far as this backend reads them.
+///
+/// Deliberately **not** `deny_unknown_fields`: the broker sends `State`, `TimeToLive`,
+/// `EnqueuedTimeUtc` and whatever else the message carried, and a property this backend has no use
+/// for must not fail a delivery.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct BrokerProperties {
+    /// How many times this message has been delivered, this delivery included.
+    delivery_count: i64,
+    /// The lock this delivery holds, which a settlement names.
+    lock_token: String,
+    /// The message id the sender set.
+    message_id: String,
+    /// The number the broker assigned this message, which a settlement names.
+    sequence_number: i64,
 }
 
-/// Turn one peek-lock response into a leased message.
-fn received_message(response: &PeekLockResponse) -> Result<ReceivedMessage, QueueError> {
-    let broker_properties = response.broker_properties().ok_or_else(|| {
-        QueueError::backend(
-            "Service Bus delivered a message with no BrokerProperties, which can never be settled",
+/// The broker properties a send sets.
+///
+/// One property, and the wire form is the one
+/// `azure_messaging_servicebus-0.21.0/src/service_bus/mod.rs` produced: its
+/// `SettableBrokerProperties` is `PascalCase` with `skip_serializing_if = "Option::is_none"`, so a
+/// send that scheduled nothing else put exactly `{"ScheduledEnqueueTimeUtc":…}` on the wire, and
+/// that field is written with `time::serde::rfc2822` — `Wed, 02 Jul 2014 01:32:27 +0000`, not RFC
+/// 3339 and not the `GMT` spelling the service's own responses use.
+#[derive(Debug, Serialize)]
+struct SendBrokerProperties {
+    /// The instant the message becomes visible in the queue.
+    #[serde(rename = "ScheduledEnqueueTimeUtc", with = "time::serde::rfc2822")]
+    scheduled_enqueue_time_utc: OffsetDateTime,
+}
+
+impl SendBrokerProperties {
+    /// The properties scheduling a message for `instant`.
+    const fn scheduled_at(instant: OffsetDateTime) -> Self {
+        Self {
+            scheduled_enqueue_time_utc: instant,
+        }
+    }
+
+    /// The `BrokerProperties` header value these properties travel as.
+    fn encode(&self) -> Result<String, ServiceBusError> {
+        serde_json::to_string(self).map_err(|error| {
+            ServiceBusError::local_with("failed to encode a scheduled delivery time", error)
+        })
+    }
+}
+
+/// The instant `delay` from now, for Service Bus' `ScheduledEnqueueTimeUtc` broker property.
+///
+/// The offset is pinned to UTC: the property names a UTC instant, and RFC 2822 renders whatever
+/// offset the value carries.
+fn scheduled_enqueue_time(delay: Duration) -> Result<OffsetDateTime, ServiceBusError> {
+    let delay = time::Duration::try_from(delay).map_err(|error| {
+        ServiceBusError::local_with(
+            "the requested delivery delay does not fit a Service Bus schedule",
+            error,
         )
     })?;
 
-    let ContentEncodingProperty(encoding) = match response.custom_properties() {
-        Ok(property) => property,
-        Err(never) => match never {},
-    };
+    OffsetDateTime::now_utc()
+        .checked_add(delay)
+        .map(|instant| instant.to_offset(UtcOffset::UTC))
+        .ok_or_else(|| {
+            ServiceBusError::local("the requested delivery delay overflowed the calendar")
+        })
+}
 
+/// Turn one leased delivery into a message.
+fn received_message(
+    properties: &BrokerProperties,
+    encoding: Option<&str>,
+    body: &str,
+) -> Result<ReceivedMessage, QueueError> {
     let receipt = ServiceBusReceipt {
-        sequence_number: broker_properties.sequence_number,
-        lock_token: broker_properties.lock_token.clone(),
+        sequence_number: properties.sequence_number,
+        lock_token: properties.lock_token.clone(),
     };
 
     Ok(ReceivedMessage {
-        id: Some(broker_properties.message_id.clone()),
-        body: decode_message(&response.body(), encoding.as_deref())?,
+        id: Some(properties.message_id.clone()),
+        body: decode_message(body, encoding)?,
         receipt: receipt.encode()?,
-        attempts: Some(
-            u32::try_from(broker_properties.delivery_count).map_err(|error| {
-                QueueError::backend_with(
-                    format!(
-                        "Service Bus reported a DeliveryCount of {}, which is not a count",
-                        broker_properties.delivery_count
-                    ),
-                    error,
-                )
-            })?,
-        ),
+        attempts: Some(u32::try_from(properties.delivery_count).map_err(|error| {
+            QueueError::backend_with(
+                format!(
+                    "Service Bus reported a DeliveryCount of {}, which is not a count",
+                    properties.delivery_count
+                ),
+                error,
+            )
+        })?),
     })
 }
 
 /// Whether a peek-lock answered with a message, and refuse anything but a message or an empty queue.
-fn peeked(status: StatusCode) -> Result<bool, QueueError> {
+fn peeked(status: StatusCode, retry_after_header: Option<&str>) -> Result<bool, QueueError> {
     match status {
-        StatusCode::Ok | StatusCode::Created => Ok(true),
+        StatusCode::OK | StatusCode::CREATED => Ok(true),
         // Service Bus answers a peek-lock that waited out its timeout with an empty 204.
-        StatusCode::NoContent => Ok(false),
-        status => Err(status_error(status, "peek-lock", None)),
+        StatusCode::NO_CONTENT => Ok(false),
+        status => Err(status_error(status, "peek-lock", retry_after_header)),
     }
 }
 
@@ -587,7 +769,7 @@ fn settled(status: StatusCode, retry_after_header: Option<&str>) -> Result<(), Q
         return Ok(());
     }
 
-    match classify(u16::from(status)) {
+    match classify(status.as_u16()) {
         // The lock this receipt named is gone: it lapsed and the message went back to the queue, or
         // it was settled already. That is the message state changing underneath the call, not a
         // backend failure.
@@ -602,7 +784,7 @@ fn status_error(
     operation: &str,
     retry_after_header: Option<&str>,
 ) -> QueueError {
-    match classify(u16::from(status)) {
+    match classify(status.as_u16()) {
         AzureStatus::Throttled => QueueError::Throttled {
             retry_after: retry_after_header.and_then(retry_after),
         },
@@ -610,25 +792,123 @@ fn status_error(
         AzureStatus::Conflict => QueueError::Conflict,
         _ => QueueError::backend(format!(
             "Service Bus answered a {operation} request with {}",
-            u16::from(status)
+            status.as_u16()
         )),
     }
 }
 
-/// The HTTP status an SDK error carries, when it failed against the service at all.
-fn http_status(error: &AzureError) -> Option<StatusCode> {
-    match error.kind() {
-        ErrorKind::HttpResponse { status, .. } => Some(*status),
-        _ => None,
+/// A Service Bus request that failed.
+///
+/// It carries what the service said — the status, its own error code when it sent one, and the
+/// `Retry-After` of a throttled answer — because [`queue_error`] and [`batch_failure_code`] read
+/// exactly that. It never carries the `Authorization` header or the signing key, which is the
+/// whole point of not logging a request.
+#[derive(Debug)]
+struct ServiceBusError {
+    /// What the service answered, when the request reached it at all.
+    answer: Option<ServiceAnswer>,
+    /// What went wrong, in words.
+    message: String,
+    /// The failure underneath, when there was one.
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+/// The part of a failing answer this backend reads.
+#[derive(Debug)]
+struct ServiceAnswer {
+    /// The status the service answered with.
+    status: StatusCode,
+    /// The service's own error code, from `x-ms-error-code`.
+    code: Option<String>,
+    /// The delay a throttled answer asked for.
+    retry_after: Option<Duration>,
+}
+
+impl ServiceBusError {
+    /// A failure of this client's own, before or after the wire.
+    fn local(message: impl Into<String>) -> Self {
+        Self {
+            answer: None,
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// A failure of this client's own, keeping the error underneath it.
+    fn local_with(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            answer: None,
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// A request that never got an answer: a refused connection, a TLS failure, a timeout.
+    fn transport(operation: &str, source: reqwest::Error) -> Self {
+        Self {
+            answer: None,
+            message: format!("the {operation} request to Service Bus failed"),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// A request the service refused, read out of its answer.
+    async fn answered(operation: &str, response: Response) -> Self {
+        let status = response.status();
+        let code = header_text(response.headers(), ERROR_CODE_HEADER).map(ToOwned::to_owned);
+        let retry_after =
+            header_text(response.headers(), RETRY_AFTER.as_str()).and_then(retry_after);
+
+        // Service Bus explains a refusal in the body — an XML `<Error><Code>…</Code>` document —
+        // and a body this backend cannot read is no reason to lose the status.
+        let body = response.bytes().await.map_or_else(
+            |_| String::new(),
+            |body| String::from_utf8_lossy(&body).trim().to_owned(),
+        );
+
+        Self {
+            answer: Some(ServiceAnswer {
+                status,
+                code,
+                retry_after,
+            }),
+            message: if body.is_empty() {
+                format!("Service Bus answered a {operation} request with {status}")
+            } else {
+                format!("Service Bus answered a {operation} request with {status}: {body}")
+            },
+            source: None,
+        }
     }
 }
 
-/// Map an SDK error onto the portable taxonomy, keeping its source chain.
-fn sdk_error(error: AzureError) -> QueueError {
-    match http_status(&error).map(|status| classify(u16::from(status))) {
-        Some(AzureStatus::Throttled) => QueueError::Throttled { retry_after: None },
-        Some(AzureStatus::Unauthorized) => QueueError::Unauthorized,
-        Some(AzureStatus::Conflict) => QueueError::Conflict,
+impl fmt::Display for ServiceBusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ServiceBusError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| &**source as &(dyn std::error::Error + 'static))
+    }
+}
+
+/// Map a failed request onto the portable taxonomy, keeping its source chain.
+fn queue_error(error: ServiceBusError) -> QueueError {
+    match error
+        .answer
+        .as_ref()
+        .map(|answer| (classify(answer.status.as_u16()), answer.retry_after))
+    {
+        Some((AzureStatus::Throttled, retry_after)) => QueueError::Throttled { retry_after },
+        Some((AzureStatus::Unauthorized, _)) => QueueError::Unauthorized,
+        Some((AzureStatus::Conflict, _)) => QueueError::Conflict,
         _ => backend_error(error),
     }
 }
@@ -636,15 +916,18 @@ fn sdk_error(error: AzureError) -> QueueError {
 /// The service's own code for a rejected batch entry.
 ///
 /// Service Bus has no batch send, so there is no per-entry code to quote: the closest thing the
-/// service says about one rejected message is the status (and error code, when it sends one) of
-/// that message's own request.
-fn batch_failure_code(error: &AzureError) -> String {
-    match error.kind() {
-        ErrorKind::HttpResponse { status, error_code } => error_code
-            .clone()
-            .unwrap_or_else(|| u16::from(*status).to_string()),
-        kind => format!("{kind:?}"),
-    }
+/// service says about one rejected message is the error code (when it sends one) or the status of
+/// that message's own request. A request that never reached the service has neither.
+fn batch_failure_code(error: &ServiceBusError) -> String {
+    error.answer.as_ref().map_or_else(
+        || "Transport".to_owned(),
+        |answer| {
+            answer
+                .code
+                .clone()
+                .unwrap_or_else(|| answer.status.as_u16().to_string())
+        },
+    )
 }
 
 /// Map any error with a source chain onto [`QueueError::Backend`].
@@ -656,7 +939,7 @@ impl MessageQueue for ServiceBusQueue {
     async fn send(&self, message: &[u8]) -> Result<(), QueueError> {
         self.send_message(message, SendOptions::new())
             .await
-            .map_err(sdk_error)
+            .map_err(queue_error)
     }
 
     /// Send one message, scheduling it when [`SendOptions::delay`] asks for one.
@@ -664,7 +947,9 @@ impl MessageQueue for ServiceBusQueue {
     /// A delay becomes Service Bus' `ScheduledEnqueueTimeUtc` broker property, so the message sits
     /// in the queue invisible until that instant.
     async fn send_with(&self, message: &[u8], options: SendOptions) -> Result<(), QueueError> {
-        self.send_message(message, options).await.map_err(sdk_error)
+        self.send_message(message, options)
+            .await
+            .map_err(queue_error)
     }
 
     /// Send messages sequentially: the Service Bus REST API has no batch send.
@@ -725,27 +1010,21 @@ impl MessageQueue for ServiceBusQueue {
             ));
         }
 
-        if options.wait.is_none() {
+        let Some(wait) = options.wait else {
             return Err(QueueError::Unsupported(
                 "Service Bus peek-lock has no documented non-blocking receive form, so this \
                  backend cannot answer a `wait` of `None` immediately; pass an explicit wait, \
                  e.g. `ReceiveOptions::new().with_wait(Duration::from_secs(30))`",
             ));
-        }
+        };
 
         let mut messages = Vec::with_capacity(options.max_messages);
         for _ in 0..options.max_messages {
-            let response = self
-                .client
-                .peek_lock_message2(options.wait)
-                .await
-                .map_err(sdk_error)?;
-
-            if !peeked(*response.status())? {
+            let Some(message) = self.peek_lock(wait).await? else {
                 break;
-            }
+            };
 
-            messages.push(received_message(&response)?);
+            messages.push(message);
         }
 
         Ok(messages)
@@ -753,7 +1032,7 @@ impl MessageQueue for ServiceBusQueue {
 
     /// Complete a leased message, which deletes it from the queue.
     async fn ack(&self, receipt: &MessageReceipt) -> Result<(), QueueError> {
-        self.settle(Method::Delete, receipt).await
+        self.settle(Method::DELETE, receipt).await
     }
 
     /// Abandon a leased message, which returns it to the queue for immediate redelivery.
@@ -768,28 +1047,53 @@ impl MessageQueue for ServiceBusQueue {
             ));
         }
 
-        self.settle(Method::Put, receipt).await
+        self.settle(Method::PUT, receipt).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        batch_failure_code, decode_message, encode_message, peeked, queue_url, settled,
-        ConnectionString, ServiceBusQueue, ServiceBusReceipt,
-    };
-    use azure_core_legacy::{
-        error::{Error as AzureError, ErrorKind},
-        StatusCode,
+        batch_failure_code, content_encoding, decode_message, encode_message, peeked,
+        property_value, queue_url, received_message, settled, sign, BrokerProperties,
+        ConnectionString, SendBrokerProperties, ServiceAnswer, ServiceBusError, ServiceBusQueue,
+        ServiceBusReceipt, SigningKey, BROKER_PROPERTIES_HEADER, CONTENT_ENCODING_PROPERTY,
     };
     use base64::Engine as _;
     use core::time::Duration;
-    use skyzen_services::queue::{
-        MessageQueue, MessageReceipt, QueueError, QueueRetry, ReceiveOptions,
+    use reqwest::{
+        header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
+        StatusCode,
     };
+    use skyzen_services::queue::{
+        MessageQueue, MessageReceipt, QueueError, QueueRetry, ReceiveOptions, SendOptions,
+    };
+    use time::OffsetDateTime;
 
     const CONNECTION_STRING: &str = "Endpoint=sb://skyzen-test.servicebus.windows.net/;\
          SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c2t5emVuLXRlc3Qta2V5";
+
+    /// The `BrokerProperties` header of the `Peek-Lock Message` reference's own example answer.
+    const EXAMPLE_BROKER_PROPERTIES: &str = concat!(
+        r#"{"DeliveryCount":1,"EnqueuedSequenceNumber":0,"#,
+        r#""EnqueuedTimeUtc":"Wed, 02 Jul 2014 01:32:27 GMT","Label":"M1","#,
+        r#""LockToken":"7da9cfd5-40d5-4bb1-8d64-ec5a52e1c547","#,
+        r#""LockedUntilUtc":"Wed, 02 Jul 2014 01:33:27 GMT","#,
+        r#""MessageId":"31907572164743c38741631acd554d6f","SequenceNumber":2,"#,
+        r#""State":"Active","TimeToLive":10}"#,
+    );
+
+    fn queue() -> ServiceBusQueue {
+        ServiceBusQueue::from_connection_string(CONNECTION_STRING, "jobs").expect("should build")
+    }
+
+    fn headers(pairs: &[(&'static str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            headers.insert(*name, HeaderValue::from_str(value).expect("a header value"));
+        }
+        headers
+    }
 
     #[test]
     fn json_passes_through_unchanged() {
@@ -852,6 +1156,140 @@ mod tests {
     #[test]
     fn a_body_tagged_base64_that_is_not_base64_is_refused() {
         assert!(decode_message("not base64!", Some("base64")).is_err());
+    }
+
+    #[test]
+    fn a_custom_property_travels_as_a_json_string_in_both_directions() {
+        // What the REST API documents: a property is a JSON value in its own header, and the
+        // service hands a string property back quoted.
+        let value = property_value("base64").expect("should encode");
+        assert_eq!(value, "\"base64\"");
+
+        let read = content_encoding(&headers(&[(CONTENT_ENCODING_PROPERTY, &value)]))
+            .expect("should read");
+        assert_eq!(read.as_deref(), Some("base64"));
+
+        assert!(content_encoding(&HeaderMap::new())
+            .expect("no property is not a failure")
+            .is_none());
+    }
+
+    #[test]
+    fn a_custom_property_that_is_not_a_json_string_is_refused() {
+        let error = content_encoding(&headers(&[(CONTENT_ENCODING_PROPERTY, "base64")]))
+            .expect_err("an unquoted property should be refused");
+        assert!(error.to_string().contains(CONTENT_ENCODING_PROPERTY));
+    }
+
+    #[test]
+    fn a_scheduled_send_writes_the_broker_property_the_service_reads() {
+        let instant = OffsetDateTime::from_unix_timestamp(1_404_264_747).expect("a valid instant");
+        let properties = SendBrokerProperties::scheduled_at(instant).encode();
+
+        // RFC 2822, which is what the legacy client's `time::serde::rfc2822` wrote.
+        assert_eq!(
+            properties.expect("should encode"),
+            r#"{"ScheduledEnqueueTimeUtc":"Wed, 02 Jul 2014 01:32:27 +0000"}"#
+        );
+    }
+
+    #[test]
+    fn a_send_names_the_queue_and_declares_no_content_type() {
+        let queue = queue();
+        let request = queue
+            .send_request(encode_message(br#"{"kind":"email"}"#), &SendOptions::new())
+            .expect("should build a send request");
+
+        assert_eq!(
+            request.url().as_str(),
+            "https://skyzen-test.servicebus.windows.net/jobs/messages"
+        );
+        assert!(request.headers().contains_key(AUTHORIZATION));
+        // A content type declared here would arrive as the message's own `ContentType`, describing
+        // a JSON body as whatever this client named. The previous release sent none either.
+        assert!(
+            request.headers().get(CONTENT_TYPE).is_none(),
+            "{:?}",
+            request.headers()
+        );
+        // Text is not base64, so nothing tags it.
+        assert!(request.headers().get(CONTENT_ENCODING_PROPERTY).is_none());
+        assert!(request.headers().get(BROKER_PROPERTIES_HEADER).is_none());
+    }
+
+    #[test]
+    fn a_binary_or_delayed_send_carries_its_property_and_nothing_more() {
+        let queue = queue();
+
+        let binary = queue
+            .send_request(encode_message(&[0xFF, 0xFE]), &SendOptions::new())
+            .expect("should build a send request");
+        assert_eq!(
+            binary.headers().get(CONTENT_ENCODING_PROPERTY).unwrap(),
+            "\"base64\""
+        );
+        assert!(binary.headers().get(CONTENT_TYPE).is_none());
+
+        let delayed = queue
+            .send_request(
+                encode_message(b"later"),
+                &SendOptions::new().with_delay(Duration::from_secs(60)),
+            )
+            .expect("should build a send request");
+        let scheduled = delayed
+            .headers()
+            .get(BROKER_PROPERTIES_HEADER)
+            .expect("a delayed send schedules the message")
+            .to_str()
+            .expect("the header is text");
+        assert!(
+            scheduled.starts_with(r#"{"ScheduledEnqueueTimeUtc":"#),
+            "{scheduled}"
+        );
+        assert!(delayed.headers().get(CONTENT_TYPE).is_none());
+    }
+
+    #[test]
+    fn the_brokers_own_properties_are_read_and_the_rest_ignored() {
+        let properties: BrokerProperties =
+            serde_json::from_str(EXAMPLE_BROKER_PROPERTIES).expect("should parse");
+
+        assert_eq!(properties.sequence_number, 2);
+        assert_eq!(
+            properties.lock_token,
+            "7da9cfd5-40d5-4bb1-8d64-ec5a52e1c547"
+        );
+        assert_eq!(properties.message_id, "31907572164743c38741631acd554d6f");
+        assert_eq!(properties.delivery_count, 1);
+    }
+
+    #[test]
+    fn a_delivery_becomes_a_message_carrying_its_lease() {
+        let properties: BrokerProperties =
+            serde_json::from_str(EXAMPLE_BROKER_PROPERTIES).expect("should parse");
+        let message =
+            received_message(&properties, None, "This is a message.").expect("should convert");
+
+        assert_eq!(
+            message.id.as_deref(),
+            Some("31907572164743c38741631acd554d6f")
+        );
+        assert_eq!(message.body, b"This is a message.".to_vec());
+        assert_eq!(message.attempts, Some(1));
+        assert_eq!(
+            ServiceBusReceipt::decode(&message.receipt).unwrap(),
+            ServiceBusReceipt {
+                sequence_number: 2,
+                lock_token: "7da9cfd5-40d5-4bb1-8d64-ec5a52e1c547".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_delivery_with_no_broker_properties_can_never_be_settled() {
+        let error = super::broker_properties(&HeaderMap::new())
+            .expect_err("a message with no lock is not settleable");
+        assert!(error.to_string().contains("BrokerProperties"));
     }
 
     #[test]
@@ -934,7 +1372,7 @@ mod tests {
     }
 
     #[test]
-    fn a_pre_minted_signature_is_refused_because_settlement_cannot_be_signed() {
+    fn a_pre_minted_signature_is_refused_because_requests_cannot_be_signed() {
         let error = ConnectionString::parse(
             "Endpoint=sb://skyzen-test.servicebus.windows.net/;\
              SharedAccessSignature=SharedAccessSignature sr=x&sig=y&se=1&skn=z",
@@ -962,30 +1400,21 @@ mod tests {
 
     #[test]
     fn the_settlement_url_names_the_message_and_its_lock() {
-        let queue = ServiceBusQueue::from_connection_string(CONNECTION_STRING, "jobs")
-            .expect("should build");
-        let receipt = ServiceBusReceipt {
-            sequence_number: 2,
-            lock_token: "7da9cfd5-40d5-4bb1-8d64-ec5a52e1c547".to_owned(),
-        };
-
-        let request = queue
-            .settle_request(azure_core_legacy::Method::Delete, &receipt)
-            .expect("should build a settle request");
+        let url = queue()
+            .message_url(&["messages", "2", "7da9cfd5-40d5-4bb1-8d64-ec5a52e1c547"])
+            .expect("should build a settle URL");
 
         // The shape the service itself hands back in the `Location` header of a peek-lock.
         assert_eq!(
-            request.url().as_str(),
+            url.as_str(),
             "https://skyzen-test.servicebus.windows.net/jobs/messages/2/\
              7da9cfd5-40d5-4bb1-8d64-ec5a52e1c547"
         );
-        assert_eq!(*request.method(), azure_core_legacy::Method::Delete);
     }
 
     #[test]
-    fn the_settlement_token_carries_the_resource_expiry_and_policy() {
-        let queue = ServiceBusQueue::from_connection_string(CONNECTION_STRING, "jobs")
-            .expect("should build");
+    fn the_token_carries_the_resource_expiry_and_policy() {
+        let queue = queue();
         let url = queue.queue_url.clone();
 
         let token = queue.sas_token(&url).expect("should sign");
@@ -999,34 +1428,61 @@ mod tests {
     }
 
     #[test]
+    fn the_signature_is_the_hmac_of_the_resource_and_the_expiry() {
+        // A fixed vector: HMAC-SHA256 of "sb://skyzen-test\n1700000000" keyed with the key's own
+        // characters, base64-encoded — the same bytes the legacy client signed with, which took
+        // the same key the long way round through a base64 encode and decode.
+        assert_eq!(
+            sign(
+                &SigningKey("c2t5emVuLXRlc3Qta2V5".to_owned()),
+                "sb://skyzen-test",
+                1_700_000_000,
+            ),
+            "6M1ScjAp5xMJiipz4Wiky9uTD0EvTe5MTsPwL89uVbE="
+        );
+    }
+
+    #[test]
+    fn neither_the_key_nor_a_token_can_be_printed_by_accident() {
+        let debug = format!("{:?}", queue());
+
+        assert!(!debug.contains("c2t5emVuLXRlc3Qta2V5"), "{debug}");
+        assert!(!debug.contains("SharedAccessSignature"), "{debug}");
+        assert_eq!(
+            format!("{:?}", SigningKey("c2t5emVuLXRlc3Qta2V5".to_owned())),
+            "SigningKey(<redacted>)"
+        );
+    }
+
+    #[test]
     fn an_empty_peek_lock_ends_the_receive_and_a_failure_is_classified() {
-        assert!(peeked(StatusCode::Created).unwrap());
-        assert!(!peeked(StatusCode::NoContent).unwrap());
+        assert!(peeked(StatusCode::CREATED, None).unwrap());
+        assert!(!peeked(StatusCode::NO_CONTENT, None).unwrap());
         assert!(matches!(
-            peeked(StatusCode::TooManyRequests),
+            peeked(StatusCode::TOO_MANY_REQUESTS, None),
             Err(QueueError::Throttled { .. })
         ));
         assert!(matches!(
-            peeked(StatusCode::Unauthorized),
+            peeked(StatusCode::UNAUTHORIZED, None),
             Err(QueueError::Unauthorized)
         ));
     }
 
     #[test]
     fn a_lapsed_lease_settles_as_a_conflict() {
-        assert!(settled(StatusCode::Ok, None).is_ok());
+        assert!(settled(StatusCode::OK, None).is_ok());
         assert!(matches!(
-            settled(StatusCode::NotFound, None),
+            settled(StatusCode::NOT_FOUND, None),
             Err(QueueError::Conflict)
         ));
         // A queue that does not exist is not a lease that lapsed: it stays a backend error naming
         // the status, so a misconfiguration is not retried forever as a lost race.
         assert!(matches!(
-            settled(StatusCode::Gone, None),
+            settled(StatusCode::GONE, None),
             Err(QueueError::Backend { .. })
         ));
         assert!(matches!(
-            settled(StatusCode::TooManyRequests, Some("7")),
+            settled(StatusCode::TOO_MANY_REQUESTS, Some("7")),
             Err(QueueError::Throttled {
                 retry_after: Some(delay)
             }) if delay == Duration::from_secs(7)
@@ -1035,28 +1491,76 @@ mod tests {
 
     #[test]
     fn a_batch_failure_quotes_the_services_own_code() {
-        let error = AzureError::message(
-            ErrorKind::http_response(
-                StatusCode::Forbidden,
-                Some("AuthorizationFailed".to_owned()),
-            ),
-            "rejected",
-        );
-        assert_eq!(batch_failure_code(&error), "AuthorizationFailed");
+        let answered = |status, code: Option<&str>| ServiceBusError {
+            answer: Some(ServiceAnswer {
+                status,
+                code: code.map(ToOwned::to_owned),
+                retry_after: None,
+            }),
+            message: "rejected".to_owned(),
+            source: None,
+        };
 
-        let error = AzureError::message(
-            ErrorKind::http_response(StatusCode::TooManyRequests, None),
-            "rejected",
+        assert_eq!(
+            batch_failure_code(&answered(
+                StatusCode::FORBIDDEN,
+                Some("AuthorizationFailed")
+            )),
+            "AuthorizationFailed"
         );
-        assert_eq!(batch_failure_code(&error), "429");
+        assert_eq!(
+            batch_failure_code(&answered(StatusCode::TOO_MANY_REQUESTS, None)),
+            "429"
+        );
+        // A request that never reached the service has no code and no status of its own.
+        assert_eq!(
+            batch_failure_code(&ServiceBusError::local("the connection was refused")),
+            "Transport"
+        );
+    }
+
+    #[test]
+    fn a_refusal_is_classified_the_way_the_status_reads() {
+        let refused = |status, retry_after| ServiceBusError {
+            answer: Some(ServiceAnswer {
+                status,
+                code: None,
+                retry_after,
+            }),
+            message: "refused".to_owned(),
+            source: None,
+        };
+
+        assert!(matches!(
+            super::queue_error(refused(
+                StatusCode::TOO_MANY_REQUESTS,
+                Some(Duration::from_secs(3))
+            )),
+            QueueError::Throttled {
+                retry_after: Some(delay)
+            } if delay == Duration::from_secs(3)
+        ));
+        assert!(matches!(
+            super::queue_error(refused(StatusCode::UNAUTHORIZED, None)),
+            QueueError::Unauthorized
+        ));
+        assert!(matches!(
+            super::queue_error(refused(StatusCode::CONFLICT, None)),
+            QueueError::Conflict
+        ));
+        assert!(matches!(
+            super::queue_error(refused(StatusCode::INTERNAL_SERVER_ERROR, None)),
+            QueueError::Backend { .. }
+        ));
+        assert!(matches!(
+            super::queue_error(ServiceBusError::local("the connection was refused")),
+            QueueError::Backend { .. }
+        ));
     }
 
     #[tokio::test]
     async fn a_delayed_retry_is_refused_rather_than_silently_immediate() {
-        let queue = ServiceBusQueue::from_connection_string(CONNECTION_STRING, "jobs")
-            .expect("should build");
-
-        let error = queue
+        let error = queue()
             .nack(
                 &MessageReceipt::new("{}"),
                 QueueRetry::new().with_delay_seconds(30),
@@ -1068,10 +1572,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_per_delivery_visibility_timeout_is_refused() {
-        let queue = ServiceBusQueue::from_connection_string(CONNECTION_STRING, "jobs")
-            .expect("should build");
-
-        let error = queue
+        let error = queue()
             .receive(
                 ReceiveOptions::new()
                     .with_wait(Duration::from_secs(30))
@@ -1084,12 +1585,9 @@ mod tests {
 
     #[tokio::test]
     async fn a_receive_without_a_wait_is_refused_and_names_the_wait_to_pass() {
-        let queue = ServiceBusQueue::from_connection_string(CONNECTION_STRING, "jobs")
-            .expect("should build");
-
         // The default options carry no wait, and Service Bus has no immediate receive to answer
         // them with — so the call says so instead of blocking for the service's own default.
-        let error = queue
+        let error = queue()
             .receive(ReceiveOptions::new())
             .await
             .expect_err("a receive with no wait should be refused");


### PR DESCRIPTION
Fixes #42

## What

`ServiceBusQueue` now speaks the Service Bus REST API directly on the `reqwest 0.13` rustls client the crate already uses for Blob Storage, and `skyzen-azure` no longer depends on `azure_messaging_servicebus 0.21` or legacy `azure_core 0.21`. There is no published Service Bus client on the `azure_core` 1.0 line (0.21.0 is still the latest), and the legacy stack logs the `authorization` header at debug/trace level (RUSTSEC-2026-0275).

- Send is `POST …/messages`, peek-lock is `POST …/messages/head?timeout=`, settlement is the `DELETE`/`PUT …/messages/{sequenceNumber}/{lockToken}` the backend already hand-rolled. The SAS token is signed with `hmac` + `sha2` over the policy key's raw bytes, which is byte-identical to what the legacy helper computed after its base64 round trip (known-answer test included). The key lives in a newtype whose `Debug` is redacted; a test asserts neither the key nor a signature reaches a `Debug` line.
- Wire format matched against the vendored 0.21 sources: `BrokerProperties` scheduling stays RFC 2822 (`+0000`), the `brokerproperties` header name, the peek-lock timeout query, no `Content-Type` on send. One deliberate correction: custom properties are now JSON-encoded strings as the REST reference specifies. The legacy path sent the value raw and read it raw, so a binary payload went out tagged `base64` and came back `"base64"`, which the decoder refused; binary payloads round-trip for the first time.
- Errors carry status, `x-ms-error-code` and `Retry-After` only, so `Throttled` / `Unauthorized` / `Conflict` / `PartialBatch` classification is unchanged.
- Public API (`new`, `from_connection_string`, `from_env`, the `MessageQueue` impl) is unchanged.

Also: one pre-existing `clippy::assert_is_empty` hit in `azure/src/blob.rs` tests, fixed so the crate's `-D warnings` gate passes on nightly.

## Verification

`cargo test -p skyzen-azure` (117 passed), `cargo clippy -p skyzen-azure --all-targets --all-features -- -D warnings`, `cargo check -p skyzen-azure --no-default-features --features servicebus` and `--features blob,servicebus`, `cargo machete`, `cargo fmt --all --check`. `cargo tree -i azure_core@0.21.0`, `-i http-types` and `-i rand@0.7.3` no longer match any package. `cargo audit` reports zero vulnerabilities; the remaining informational warnings (`async-std` via `sqlx-core`, `instant`, a yanked `chacha20`) are unrelated to this crate.
