### PR TITLE
feat(openapi)!: serve the same document on every target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,23 @@ remain Cloudflare-only, because nothing else has those events.
   the `.env` precedence rule and the per-provider delivery table, is
   `docs/skyzen-toml-reference.md#secrets`.
 
+### 5c. OpenAPI
+- The document is target-independent. `#[skyzen::openapi]` collects a `HandlerSpec` per handler and
+  `describe_handler` resolves it by `type_name` when the route is built — on a server, in Lambda, in
+  Azure Functions and inside a Worker alike, in release as in debug.
+- **The `openapi` cargo feature is the only switch**, and the decision is made in `skyzen-macros`,
+  not in the expansion. Macro output lands in the *application's* crate, where
+  `cfg(feature = "openapi")` would ask about the application's features; so `skyzen/openapi` enables
+  `skyzen-macros/openapi` and `expand_openapi_fn` checks `cfg!(feature = "openapi")` at expansion
+  time. Feature off ⇒ nothing is emitted at all. This replaced `debug_assertions`, which used to
+  stand in for a switch that was not readable and left release builds with an empty document.
+- **`src/openapi/registry.rs` is the only file that asks what target it is.** Native registers into a
+  `linkme` distributed slice — linker-section data, nothing before `main`, free at runtime. wasm32
+  has no such linker support, so it uses `inventory`: one life-before-main constructor per handler,
+  pushing onto a list at isolate start. The cost difference is the entire reason for two backends,
+  and `__register_handler_spec!` hides the shape difference from the macro. Do not spread either
+  crate's name beyond that file, and do not adopt `inventory` natively.
+
 ### 6. Error Handling & Log Security
 - `#[skyzen::error]` generates `Display`, `Error`, and `HttpError` implementations with status code attributes.
 - **4xx errors** return formatted JSON messages to clients.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ futures-lite = "2.6"
 serial_test = "3.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# The wasm half of the OpenAPI handler registry; see `src/openapi/registry.rs` for why
+# native uses `linkme` and only wasm pays for `inventory`.
+inventory = "0.3"
 wasm-bindgen = { version = "0.2.110", features = ["spans"] }
 wasm-bindgen-futures = "0.4.60"
 js-sys = "0.3.87"
@@ -169,7 +172,7 @@ optional = true
 
 [features]
 default = ["json", "form", "query", "multipart", "sse", "rt", "openapi", "ws", "static-files", "runtime-async-std-native-tls"]
-openapi = ["skyzen-core/openapi"]
+openapi = ["skyzen-core/openapi", "skyzen-macros/openapi"]
 auth = []
 jwt = ["auth", "dep:jsonwebtoken"]
 json = ["http-kit/json"]

--- a/README.md
+++ b/README.md
@@ -842,8 +842,16 @@ fn router() -> Router {
 
 `Route::enable_api_doc()` mounts the same Scalar UI at `/api-docs`. `.redoc()` / `.redoc_route()` remain available if you want Redoc instead.
 
-*Schema generation is gated to debug builds and native targets, so release binaries and edge wasm
-bundles stay small.*
+The document is the same on every target — a native server, Lambda, Azure Functions and a
+Cloudflare Worker all serve what `#[skyzen::openapi]` collected, in release as in debug. The
+`openapi` cargo feature is the only switch, and it is on by default; a bundle that has no use for a
+schema turns it off with `skyzen = { version = "0.2", default-features = false, features = [...] }`
+and pays for nothing — no specs, no schema functions, no registration.
+
+*How the metadata is collected differs by target, and only in cost. Natively it is linker-section
+data, so nothing runs before `main`. WebAssembly has no such linker support, so there it rides one
+life-before-main constructor per documented handler — a few pointer pushes at isolate start, paid
+only on the edge. See `src/openapi/registry.rs`.*
 
 ---
 

--- a/cli/templates/api/src/app.rs.tmpl
+++ b/cli/templates/api/src/app.rs.tmpl
@@ -23,6 +23,12 @@ async fn health() -> &'static str {
     "OK"
 }
 
+/// Greet a caller by name, remembering whether they have been greeted before.
+///
+/// `#[skyzen::openapi]` reads this doc comment, the extractor types and the responder type, and
+/// registers the operation the `/api-docs` page below renders. It costs nothing at runtime on a
+/// server and works the same inside a Worker isolate.
+///
 /// Skyzen.toml declares `[[service]] name = "cache"` and `[[database]] name = "journal"`, so
 /// `#[skyzen::main]` generates a `Cache` extractor around the portable `Kv`, a `JournalDb`
 /// extractor around the portable `Db`, and injects both into every request.
@@ -30,6 +36,7 @@ async fn health() -> &'static str {
 /// This handler is the whole point of the framework: it runs unchanged against the in-process mock
 /// and SQLite during `skyzen dev`, and against a Cloudflare KV namespace and a D1 database after
 /// `skyzen deploy`. Changing backends is a Skyzen.toml edit, never a code edit.
+#[skyzen::openapi]
 async fn greet(cache: Cache, journal: JournalDb, params: Params) -> Result<Json<Greeting>> {
     let name = params.get("name")?.to_owned();
     // `Cache` derefs to `Kv`, so every `Kv` method is reachable through it.
@@ -64,5 +71,8 @@ pub fn router() -> Router {
         "/health".at(health),
         "/greet".route(("/{name}".at(greet),)),
     ))
+    // Serves the interactive Scalar reference at `/api-docs`, built from whatever
+    // `#[skyzen::openapi]` documented. `skyzen openapi` opens the same document without a server.
+    .enable_api_doc()
     .build()
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,6 +21,17 @@ quote = "1"
 skyzen-manifest.workspace = true
 syn = { version = "2", features = ["full"] }
 
+[features]
+# Whether `#[skyzen::openapi]` emits handler metadata at all.
+#
+# The metadata has to be gated where the decision is actually visible. Macro output expands in
+# the *downstream* crate, so a `#[cfg(feature = "openapi")]` in the expansion would ask about the
+# application's features, not skyzen's. Asking here instead — at expansion time, in this crate's
+# own compilation — is the only place the answer is right, so `skyzen/openapi` turns this on and
+# a `default-features = false` build emits no specs, no schema functions and no registrations on
+# any target.
+openapi = []
+
 [dev-dependencies]
 
 [lints]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -772,37 +772,40 @@ fn expand_openapi_fn(mut function: ItemFn) -> syn::Result<TokenStream> {
         fn_ident.to_string().to_uppercase()
     );
 
-    // All generated items are gated on `debug_assertions` + native targets only. The condition
-    // must not mention any cargo feature: these `cfg`s are evaluated against the *user's* crate
-    // features, and downstream crates have no feature named `openapi`. The referenced
-    // `::skyzen::openapi` symbols exist whenever skyzen itself is compiled for a native debug
-    // build, independent of skyzen's `openapi` feature.
+    // Whether to emit any of this is decided *here*, in this crate's own compilation, because
+    // this is the only place the question can be answered correctly. The expansion lands in the
+    // user's crate, so a `#[cfg(feature = "openapi")]` inside it would ask about the application's
+    // features rather than skyzen's — which is why this used to ride on `debug_assertions` as a
+    // stand-in switch, and why a release build had no document. `skyzen/openapi` turns on this
+    // crate's own `openapi` feature instead, so the real switch is finally readable.
+    if !cfg!(feature = "openapi") {
+        return Ok(quote! { #function }.into());
+    }
+
+    // Nothing below mentions a target: `__register_handler_spec!` owns that split, so a handler
+    // documents itself identically whether it is compiled for a server or for an isolate.
     Ok(quote! {
         #function
 
-        #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
         const _: fn() = || {
             #(#assertions)*
         };
 
-        #(
-            #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-            #schema_collector_defs
-        )*
+        #(#schema_collector_defs)*
 
-        #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-        #[::skyzen::openapi::linkme::distributed_slice(::skyzen::openapi::HANDLER_SPECS)]
-        #[linkme(crate = ::skyzen::openapi::linkme)]
-        static #spec_ident: ::skyzen::openapi::HandlerSpec = ::skyzen::openapi::HandlerSpec {
-            type_name: #type_name_literal,
-            operation_name: #operation_name_literal,
-            docs: #doc_tokens,
-            deprecated: #deprecated,
-            parameters: #schema_array,
-            parameter_names: #parameter_names_array,
-            response: #response_schema_fn,
-            schemas: #schema_collectors,
-        };
+        ::skyzen::__register_handler_spec!(
+            #spec_ident,
+            ::skyzen::openapi::HandlerSpec {
+                type_name: #type_name_literal,
+                operation_name: #operation_name_literal,
+                docs: #doc_tokens,
+                deprecated: #deprecated,
+                parameters: #schema_array,
+                parameter_names: #parameter_names_array,
+                response: #response_schema_fn,
+                schemas: #schema_collectors,
+            }
+        );
     }
     .into())
 }

--- a/macros/src/sql.rs
+++ b/macros/src/sql.rs
@@ -307,7 +307,7 @@ mod tests {
     fn doubled_braces_are_literal_text() {
         let (sql, captures) = split("SELECT '{{\"kind\":\"email\"}}'::jsonb");
         assert_eq!(sql, "SELECT '{\"kind\":\"email\"}'::jsonb");
-        assert!(captures.is_empty());
+        assert_eq!(captures, Vec::<String>::new());
     }
 
     #[test]

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -513,17 +513,24 @@ impl OpenApi {
     }
 
     /// Inspect the registered operations.
+    ///
+    /// Empty without the `openapi` feature, which is the only thing that varies: the signature is
+    /// the same in every build, so calling code never has to be written twice.
     #[must_use]
-    #[cfg(feature = "openapi")]
+    // Deliberately not `const` in the feature-off arm. It could be, but then the two arms would
+    // differ in a way a caller can observe, and one signature everywhere is worth more than a
+    // `const fn` returning an empty slice.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn operations(&self) -> &[OpenApiOperation] {
-        &self.operations
-    }
+        #[cfg(feature = "openapi")]
+        {
+            &self.operations
+        }
 
-    /// Inspect the registered operations.
-    #[must_use]
-    #[cfg(not(feature = "openapi"))]
-    pub const fn operations(&self) -> &[OpenApiOperation] {
-        &[]
+        #[cfg(not(feature = "openapi"))]
+        {
+            &[]
+        }
     }
 
     /// Indicates whether `OpenAPI` instrumentation is active.

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -105,15 +105,7 @@ impl fmt::Debug for ResponseSchema {
 /// Function type that collects `OpenAPI` schemas into a definitions map.
 pub type SchemaCollector = fn(&mut BTreeMap<String, SchemaRef>);
 
-// Re-exported for macro-generated registrations without requiring downstream crates to depend on
-// `linkme` directly.
-//
-// NOTE: this and the `HANDLER_SPECS`/`HandlerSpec` items below are deliberately *not* gated on
-// the `openapi` feature: `#[skyzen::openapi]`-generated code in downstream crates references them
-// under `cfg(all(debug_assertions, not(target_arch = "wasm32")))` — a condition that cannot
-// depend on skyzen's features, because it is evaluated against the downstream crate.
-#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-pub use linkme;
+pub mod registry;
 
 mod builtins;
 pub use builtins::IgnoreOpenApi;
@@ -210,13 +202,6 @@ where
     }
 }
 
-#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-/// Distributed registry containing handler specifications discovered via `#[skyzen::openapi]`.
-#[linkme::distributed_slice]
-#[linkme(crate = ::skyzen::openapi::linkme)]
-pub static HANDLER_SPECS: [HandlerSpec] = [..];
-
-#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 #[derive(Debug, Clone, Copy)]
 /// Metadata captured for every handler annotated with `#[skyzen::openapi]`.
 pub struct HandlerSpec {
@@ -238,11 +223,9 @@ pub struct HandlerSpec {
     pub schemas: &'static [SchemaCollector],
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 fn find_handler_spec(type_name: &str) -> Option<&'static HandlerSpec> {
-    HANDLER_SPECS
-        .iter()
-        .find(|spec| spec.type_name == type_name)
+    registry::iter().find(|spec| spec.type_name == type_name)
 }
 
 #[cfg(feature = "openapi")]
@@ -372,7 +355,7 @@ where
     }
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 fn collect_schemas(collectors: &[SchemaCollector], defs: &mut BTreeMap<String, SchemaRef>) {
     for collector in collectors {
         collector(defs);
@@ -382,19 +365,19 @@ fn collect_schemas(collectors: &[SchemaCollector], defs: &mut BTreeMap<String, S
 /// Handler metadata attached to each endpoint.
 #[derive(Clone, Copy, Debug)]
 pub struct RouteHandlerDoc {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     type_name: &'static str,
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     spec: Option<&'static HandlerSpec>,
 }
 
 impl RouteHandlerDoc {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     const fn new(type_name: &'static str, spec: Option<&'static HandlerSpec>) -> Self {
         Self { type_name, spec }
     }
 
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     const fn new() -> Self {
         Self {}
     }
@@ -404,21 +387,21 @@ impl RouteHandlerDoc {
 #[must_use]
 #[allow(clippy::missing_const_for_fn)]
 pub fn describe_handler<H: 'static>() -> RouteHandlerDoc {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     {
         let type_name = std::any::type_name::<H>();
         let spec = find_handler_spec(type_name);
         RouteHandlerDoc::new(type_name, spec)
     }
 
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     {
         let _ = ::core::marker::PhantomData::<H>;
         RouteHandlerDoc::new()
     }
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 #[derive(Debug, Clone)]
 /// Route metadata stored when `OpenAPI` instrumentation is enabled.
 pub struct RouteOpenApiEntry {
@@ -430,7 +413,7 @@ pub struct RouteOpenApiEntry {
     pub handler: RouteHandlerDoc,
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 impl RouteOpenApiEntry {
     #[must_use]
     /// Construct a new entry describing a route + handler pair.
@@ -446,9 +429,9 @@ impl RouteOpenApiEntry {
 /// Minimal `OpenAPI` representation for Skyzen routers.
 #[derive(Clone, Default)]
 pub struct OpenApi {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     operations: Vec<OpenApiOperation>,
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     schemas: Vec<(String, SchemaRef)>,
 }
 
@@ -463,7 +446,7 @@ impl Debug for OpenApi {
 
 impl OpenApi {
     /// Build an [`OpenApi`] instance from the collected route metadata.
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     #[must_use]
     pub(crate) fn from_entries(entries: &[RouteOpenApiEntry]) -> Self {
         let mut schema_defs = BTreeMap::new();
@@ -522,7 +505,7 @@ impl OpenApi {
     }
 
     /// Build an empty `OpenAPI` definition when `OpenAPI` support is disabled.
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     #[must_use]
     #[allow(dead_code)]
     pub(crate) const fn from_entries(_: &[()]) -> Self {
@@ -531,14 +514,14 @@ impl OpenApi {
 
     /// Inspect the registered operations.
     #[must_use]
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     pub fn operations(&self) -> &[OpenApiOperation] {
         &self.operations
     }
 
     /// Inspect the registered operations.
     #[must_use]
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     pub const fn operations(&self) -> &[OpenApiOperation] {
         &[]
     }
@@ -546,11 +529,7 @@ impl OpenApi {
     /// Indicates whether `OpenAPI` instrumentation is active.
     #[must_use]
     pub const fn is_enabled(&self) -> bool {
-        cfg!(all(
-            debug_assertions,
-            feature = "openapi",
-            not(target_arch = "wasm32")
-        ))
+        cfg!(feature = "openapi")
     }
 
     /// Convert the collected spec to a [`Scalar`](utoipa_scalar::Scalar) endpoint.
@@ -618,7 +597,7 @@ impl OpenApi {
             .build()
     }
 
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     fn build_components(&self) -> utoipa::openapi::schema::Components {
         self.schemas
             .iter()
@@ -629,7 +608,7 @@ impl OpenApi {
             .build()
     }
 
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     #[allow(clippy::unused_self)]
     fn build_components(&self) -> utoipa::openapi::schema::Components {
         ComponentsBuilder::new().build()

--- a/src/openapi/registry.rs
+++ b/src/openapi/registry.rs
@@ -15,57 +15,82 @@
 //!   absorbs a handful of pointer pushes, and the alternative on the edge is having no document at
 //!   all.
 //!
-//! Both halves expose the same two things — [`iter`] and
-//! [`__register_handler_spec!`](crate::__register_handler_spec) — so nothing else in the workspace,
-//! the `#[skyzen::openapi]` expansion included, has to know which one it is talking to.
+//! **The public surface is identical on every target**: [`iter`], and
+//! [`__register_handler_spec!`](crate::__register_handler_spec) with one invocation shape. Which
+//! backend answers is a private matter of this file — the `#[skyzen::openapi]` expansion, the rest
+//! of the crate and an application's own code all name the same items whatever they compile for.
 
 use super::HandlerSpec;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub use linkme;
-
-#[cfg(target_arch = "wasm32")]
-pub use inventory;
-
-/// The linker-collected registry every native `#[skyzen::openapi]` handler registers into.
-#[cfg(not(target_arch = "wasm32"))]
-#[linkme::distributed_slice]
-#[linkme(crate = ::skyzen::openapi::registry::linkme)]
-pub static HANDLER_SPECS: [HandlerSpec] = [..];
-
-#[cfg(target_arch = "wasm32")]
-inventory::collect!(HandlerSpec);
 
 /// Every handler specification this binary registered, in no particular order.
 pub fn iter() -> impl Iterator<Item = &'static HandlerSpec> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        HANDLER_SPECS.iter()
+        backend::HANDLER_SPECS.iter()
     }
 
     #[cfg(target_arch = "wasm32")]
     {
-        inventory::iter::<HandlerSpec>()
+        backend::inventory::iter::<HandlerSpec>()
     }
 }
 
-/// Register one handler's specification with whichever registry this target uses.
+/// The chosen backend's plumbing.
+///
+/// Public because [`__register_handler_spec!`](crate::__register_handler_spec) expands in the
+/// application's crate and has to name it from there, and hidden because naming it from anywhere
+/// else is a mistake: these are the items that genuinely differ by target, and keeping them behind
+/// one door is what lets everything above be the same everywhere.
+#[doc(hidden)]
+pub mod backend {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use linkme;
+
+    #[cfg(target_arch = "wasm32")]
+    pub use inventory;
+
+    /// The linker section every native `#[skyzen::openapi]` handler's specification lands in.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[linkme::distributed_slice]
+    #[linkme(crate = ::skyzen::openapi::registry::backend::linkme)]
+    pub static HANDLER_SPECS: [super::HandlerSpec] = [..];
+
+    #[cfg(target_arch = "wasm32")]
+    inventory::collect!(super::HandlerSpec);
+}
+
+/// Register one handler's specification with the registry.
 ///
 /// Called only from the `#[skyzen::openapi]` expansion, which builds the [`HandlerSpec`] and knows
-/// nothing about how it is stored — the two backends differ in the *shape* of a registration (a
-/// named `static` for `linkme`, an expression for `inventory`), and that difference stops here.
+/// nothing about how it is stored.
+///
+/// Defined twice, once per target, rather than once emitting `#[cfg]`-guarded code: the two
+/// backends want genuinely different item shapes — a named `static` carrying attributes for
+/// `linkme`, a bare expression for `inventory` — and choosing here means the *caller* sees one
+/// macro with one invocation shape, and the code it expands to carries no `#[cfg]` of its own.
+#[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __register_handler_spec {
     ($ident:ident, $spec:expr) => {
-        #[cfg(not(target_arch = "wasm32"))]
-        #[$crate::openapi::registry::linkme::distributed_slice(
-            $crate::openapi::registry::HANDLER_SPECS
+        #[$crate::openapi::registry::backend::linkme::distributed_slice(
+            $crate::openapi::registry::backend::HANDLER_SPECS
         )]
-        #[linkme(crate = $crate::openapi::registry::linkme)]
+        #[linkme(crate = $crate::openapi::registry::backend::linkme)]
         static $ident: $crate::openapi::HandlerSpec = $spec;
+    };
+}
 
-        #[cfg(target_arch = "wasm32")]
-        $crate::openapi::registry::inventory::submit! { $spec }
+/// Register one handler's specification with the registry.
+///
+/// See the native definition above; this is the same macro for the target whose registry is
+/// `inventory`, and takes the same arguments. The identifier is unused here — `inventory` names
+/// its own shim — and is accepted so that one invocation compiles for both.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_handler_spec {
+    ($ident:ident, $spec:expr) => {
+        $crate::openapi::registry::backend::inventory::submit! { $spec }
     };
 }

--- a/src/openapi/registry.rs
+++ b/src/openapi/registry.rs
@@ -1,0 +1,71 @@
+//! Where every `#[skyzen::openapi]` handler's metadata is collected, and the only place in the
+//! crate that asks what target it is building for.
+//!
+//! Two backends, chosen by target, because they do not cost the same:
+//!
+//! - **Native uses [`linkme`], and pays nothing.** A [`HandlerSpec`] is a `static` placed in a
+//!   dedicated linker section; the linker lays the section out, no code runs before `main`, and
+//!   reading the registry is reading a slice. Registration is free at runtime and the specs of
+//!   handlers nothing routes are still just data the linker already had to place.
+//! - **wasm32 uses [`inventory`], and pays for it.** `linkme` has no WebAssembly backend — its
+//!   supported-platform table is Linux, macOS, Windows, FreeBSD, OpenBSD and illumos — so the edge
+//!   has to fall back on life-before-main constructors, one per documented handler, each pushing
+//!   onto a linked list when the module initializes. That is real startup work and real code size,
+//!   which is why it is confined here rather than adopted everywhere: an isolate's cold start
+//!   absorbs a handful of pointer pushes, and the alternative on the edge is having no document at
+//!   all.
+//!
+//! Both halves expose the same two things — [`iter`] and
+//! [`__register_handler_spec!`](crate::__register_handler_spec) — so nothing else in the workspace,
+//! the `#[skyzen::openapi]` expansion included, has to know which one it is talking to.
+
+use super::HandlerSpec;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use linkme;
+
+#[cfg(target_arch = "wasm32")]
+pub use inventory;
+
+/// The linker-collected registry every native `#[skyzen::openapi]` handler registers into.
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice]
+#[linkme(crate = ::skyzen::openapi::registry::linkme)]
+pub static HANDLER_SPECS: [HandlerSpec] = [..];
+
+#[cfg(target_arch = "wasm32")]
+inventory::collect!(HandlerSpec);
+
+/// Every handler specification this binary registered, in no particular order.
+pub fn iter() -> impl Iterator<Item = &'static HandlerSpec> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        HANDLER_SPECS.iter()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        inventory::iter::<HandlerSpec>()
+    }
+}
+
+/// Register one handler's specification with whichever registry this target uses.
+///
+/// Called only from the `#[skyzen::openapi]` expansion, which builds the [`HandlerSpec`] and knows
+/// nothing about how it is stored — the two backends differ in the *shape* of a registration (a
+/// named `static` for `linkme`, an expression for `inventory`), and that difference stops here.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_handler_spec {
+    ($ident:ident, $spec:expr) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        #[$crate::openapi::registry::linkme::distributed_slice(
+            $crate::openapi::registry::HANDLER_SPECS
+        )]
+        #[linkme(crate = $crate::openapi::registry::linkme)]
+        static $ident: $crate::openapi::HandlerSpec = $spec;
+
+        #[cfg(target_arch = "wasm32")]
+        $crate::openapi::registry::inventory::submit! { $spec }
+    };
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -131,7 +131,7 @@
 
 use std::{fmt, sync::Arc};
 
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 use crate::openapi::RouteOpenApiEntry;
 #[cfg(feature = "ws")]
 use crate::websocket::{MaybeSend, MaybeSync, WebSocket};
@@ -432,14 +432,14 @@ impl Route {
     /// Generate an [`OpenApi`] document describing this route tree.
     #[must_use]
     pub fn openapi(&self) -> OpenApi {
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         {
             let mut entries = Vec::new();
             collect_openapi_entries("", &self.nodes, &mut entries);
             OpenApi::from_entries(&entries)
         }
 
-        #[cfg(not(all(feature = "openapi", not(target_arch = "wasm32"))))]
+        #[cfg(not(feature = "openapi"))]
         {
             OpenApi::default()
         }
@@ -943,7 +943,7 @@ pub(crate) fn join_path(prefix: &str, segment: &str) -> String {
     collapsed
 }
 
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 fn collect_openapi_entries(
     path_prefix: &str,
     nodes: &[RouteNode],
@@ -971,7 +971,7 @@ fn collect_openapi_entries(
 }
 
 /// A mounted router's operations, re-pathed under the prefix it is mounted at.
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 pub(crate) fn prefixed_openapi_entries(prefix: &str, router: &Router) -> Vec<RouteOpenApiEntry> {
     router
         .openapi_entries()

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -10,7 +10,7 @@ use super::{
     join_path, BoxEndpoint, EndpointFactory, MethodFilter, NestedRouter, Params, Route, RouteNode,
     RouteNodeType,
 };
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 use crate::openapi::RouteOpenApiEntry;
 use crate::{header, openapi::OpenApi, Body, Endpoint, Method, Request, Response, StatusCode};
 
@@ -102,7 +102,7 @@ pub struct Router {
     already_router_enabled: bool,
     /// Optional alarm handler for Durable Object alarm events.
     pub(crate) alarm_handler: Option<EndpointFactory>,
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     openapi_entries: Arc<Vec<RouteOpenApiEntry>>,
 }
 
@@ -117,7 +117,7 @@ impl Debug for Router {
             .field("has_method_not_allowed", &self.method_not_allowed.is_some())
             .field("already_router_enabled", &self.already_router_enabled)
             .field("has_alarm_handler", &self.alarm_handler.is_some());
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         {
             debug_struct.field("openapi_entries", &self.openapi_entries.len());
         }
@@ -337,19 +337,19 @@ impl Router {
     /// Build an [`OpenApi`] definition containing every route registered on this router.
     #[must_use]
     pub fn openapi(&self) -> OpenApi {
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         {
             OpenApi::from_entries(&self.openapi_entries)
         }
 
-        #[cfg(not(all(feature = "openapi", not(target_arch = "wasm32"))))]
+        #[cfg(not(feature = "openapi"))]
         {
             OpenApi::default()
         }
     }
 
     /// The `OpenAPI` entries this router was built from, for re-export by a router that mounts it.
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     pub(crate) fn openapi_entries(&self) -> &[RouteOpenApiEntry] {
         &self.openapi_entries
     }
@@ -548,9 +548,7 @@ fn flatten(
     path_prefix: &str,
     nodes: Vec<RouteNode>,
     buf: &mut FlattenBuf,
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))] openapi_entries: &mut Vec<
-        RouteOpenApiEntry,
-    >,
+    #[cfg(feature = "openapi")] openapi_entries: &mut Vec<RouteOpenApiEntry>,
 ) -> Result<(), RouteBuildError> {
     for node in nodes {
         let path = join_path(path_prefix, &node.path);
@@ -561,7 +559,7 @@ fn flatten(
                     &path,
                     route.into_mounted_nodes(),
                     buf,
-                    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+                    #[cfg(feature = "openapi")]
                     openapi_entries,
                 )?;
             }
@@ -576,7 +574,7 @@ fn flatten(
                     return Err(RouteBuildError::InvalidPath { path });
                 }
 
-                #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+                #[cfg(feature = "openapi")]
                 if let (Some(openapi), MethodFilter::Exact(exact)) = (openapi, &method) {
                     openapi_entries.push(RouteOpenApiEntry::new(
                         path.clone(),
@@ -584,7 +582,7 @@ fn flatten(
                         openapi,
                     ));
                 }
-                #[cfg(not(all(feature = "openapi", not(target_arch = "wasm32"))))]
+                #[cfg(not(feature = "openapi"))]
                 let _ = openapi;
 
                 buf.entry(path).or_default().push(FlatEndpoint {
@@ -604,7 +602,7 @@ fn flatten(
                     return Err(RouteBuildError::NestedPatternPrefix { path });
                 }
 
-                #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+                #[cfg(feature = "openapi")]
                 openapi_entries.extend(super::prefixed_openapi_entries(&path, &router));
 
                 let nested = NestedRouter::new(&path, router);
@@ -642,13 +640,13 @@ pub fn build(route: Route) -> Result<Router, RouteBuildError> {
     } = route;
 
     let mut buf = FlattenBuf::new();
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     let mut openapi_entries = Vec::new();
     flatten(
         "",
         nodes,
         &mut buf,
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         &mut openapi_entries,
     )?;
 
@@ -686,7 +684,7 @@ pub fn build(route: Route) -> Result<Router, RouteBuildError> {
         routes: Arc::new(routes),
         already_router_enabled: false,
         alarm_handler: None,
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         openapi_entries: Arc::new(openapi_entries),
     })
 }

--- a/src/runtime/cf.rs
+++ b/src/runtime/cf.rs
@@ -269,7 +269,7 @@ mod tests {
         // voided the entire `request.cf` decode before the tolerant deserializer.
         let bm: CfBotManagement =
             serde_json::from_str(r#"{"score":99,"detectionIds":{}}"#).unwrap();
-        assert!(bm.detection_ids.is_empty());
+        assert_eq!(bm.detection_ids, Vec::<u32>::new());
 
         let bm: CfBotManagement =
             serde_json::from_str(r#"{"detectionIds":{"a":3,"b":5}}"#).unwrap();

--- a/tests/migrations.rs
+++ b/tests/migrations.rs
@@ -117,7 +117,7 @@ async fn status_reports_the_set_as_fully_applied() {
         status.applied[0].checksum,
         MIGRATIONS.as_slice()[0].checksum_hex()
     );
-    assert!(!status.applied[0].applied_at.is_empty());
+    assert_ne!(status.applied[0].applied_at, "");
 }
 
 /// The attribute argument: the database a test receives is already migrated when the body starts.


### PR DESCRIPTION
Fixes #46.

OpenAPI now produces the same document on a native server, in Lambda, in Azure Functions and inside
a Cloudflare Worker — in release as in debug. **No public API change:** `#[skyzen::openapi]` is
still an attribute on an ordinary `async fn`, handlers stay callable, route registration is
untouched.

## Why `debug_assertions` was there

The old gate was `cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))`,
repeated ~25 times. `debug_assertions` was not a size decision — it was **standing in for a switch
that could not be read**. Macro output expands in the *application's* crate, so a
`cfg(feature = "openapi")` inside the expansion asks about the application's features, not skyzen's,
and there was no feature to test (`src/openapi/mod.rs:108-114` documented exactly this).

`skyzen-macros` now has its own `openapi` feature, turned on by `skyzen/openapi`, and
`expand_openapi_fn` decides with `cfg!(feature = "openapi")` at expansion time — in its own
compilation, where the answer is right. Feature off emits **nothing at all**, on any target: a
better size story than the `debug_assertions` proxy, because it holds for native release builds too.

## Why two registry backends, and not one

They do not cost the same, so the cheap one stays where it works.

| | Native | wasm32 |
|---|---|---|
| Backend | `linkme` | `inventory` |
| Mechanism | linker-section data | one life-before-main ctor per handler |
| Runtime cost | **none** — nothing runs before `main` | a few pointer pushes at isolate start |

`linkme` has no WebAssembly backend (its platform table is Linux/macOS/Windows/FreeBSD/OpenBSD/
illumos; the wasm32 PR was abandoned), so the edge has to pay for constructors. That price buys a
document where the alternative is a `501`, and it is worth paying *only* there — hence
`src/openapi/registry.rs`, the one file in the workspace that names either crate or asks what target
it is. `__register_handler_spec!` hides the shape difference (a named `static` vs. an expression) so
the proc macro emits one call and never learns which backend exists. Everything else collapses to
`cfg(feature = "openapi")`.

`cargo tree` enforces the split: no `inventory` on the host, no `linkme` on wasm.

## Verified

- `cargo test -p skyzen --all-features` — 348 pass, including `exposes_api_docs_at_root` and the
  four `openapi_schemas` tests **unchanged**, which is the no-API-break check.
- `cargo clippy --all-features --all-targets` clean.
- `cargo check -p skyzen --target wasm32-unknown-unknown` passes — `utoipa`, `utoipa-scalar` and
  `utoipa-redoc` all build for wasm, retiring the one risk that could have sunk this.
- `cargo test -p skyzen-cli` — 176 pass, `scaffolded_templates_compile` included (host + wasm32).
- **`wrangler dev` against a scaffolded `-t api` project**, which is the only evidence that
  actually settles whether inventory's constructors fire in an isolate:

  ```
  GET /greet/{name} -> operationId=apidemo::app::greet
                       summary='Greet a caller by name, remembering whether they have been greeted before.'
  GET /             -> operationId=app::root      summary='app::root'
  GET /health       -> operationId=app::health    summary='app::health'
  components: ['Greeting']
  ```

  That summary exists nowhere but the `HandlerSpec` `inventory::submit!` registered. Had the ctor not
  run, `greet` would have degraded to a bare `operationId` with no summary — exactly like `root` and
  `health`, the two undocumented handlers beside it, which serve as the built-in control.

## Also here

- The `api` template documents its handler and mounts `/api-docs`. Not cosmetic: it is what makes
  the wasm expansion permanently covered, since `scaffolded_templates_compile` already checks every
  template for wasm32. A template named "api" that derived `ToSchema` and documented nothing was
  under-delivering anyway.
- Two pre-existing `clippy::assert_is_empty` warnings fixed — they fail CI's `-D warnings` on `dev`
  and would have blocked this PR.

## Noticed, not fixed here

- `OpenApi::default_info` titles **every** user's document `skyzen 0.2.1`: `src/openapi/mod.rs:600`
  is `Info::new(env!("CARGO_PKG_NAME"), …)` expanded inside skyzen. Visible in the Worker output
  above. Fixed by #47.
- `skyzen new` stamps `compatibility_date` with today's date, which a slightly older wrangler
  refuses outright (`newest date supported by this server binary is "2026-07-15"`). I overrode it
  locally to finish the test above. Separate scaffold defect.
