### PR TITLE
feat(cli): add `skyzen openapi`, and title documents by registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,23 @@ remain Cloudflare-only, because nothing else has those events.
   the `.env` precedence rule and the per-provider delivery table, is
   `docs/skyzen-toml-reference.md#secrets`.
 
+### 5c. OpenAPI
+- The document is target-independent. `#[skyzen::openapi]` collects a `HandlerSpec` per handler and
+  `describe_handler` resolves it by `type_name` when the route is built — on a server, in Lambda, in
+  Azure Functions and inside a Worker alike, in release as in debug.
+- **The `openapi` cargo feature is the only switch**, and the decision is made in `skyzen-macros`,
+  not in the expansion. Macro output lands in the *application's* crate, where
+  `cfg(feature = "openapi")` would ask about the application's features; so `skyzen/openapi` enables
+  `skyzen-macros/openapi` and `expand_openapi_fn` checks `cfg!(feature = "openapi")` at expansion
+  time. Feature off ⇒ nothing is emitted at all. This replaced `debug_assertions`, which used to
+  stand in for a switch that was not readable and left release builds with an empty document.
+- **`src/openapi/registry.rs` is the only file that asks what target it is.** Native registers into a
+  `linkme` distributed slice — linker-section data, nothing before `main`, free at runtime. wasm32
+  has no such linker support, so it uses `inventory`: one life-before-main constructor per handler,
+  pushing onto a list at isolate start. The cost difference is the entire reason for two backends,
+  and `__register_handler_spec!` hides the shape difference from the macro. Do not spread either
+  crate's name beyond that file, and do not adopt `inventory` natively.
+
 ### 6. Error Handling & Log Security
 - `#[skyzen::error]` generates `Display`, `Error`, and `HttpError` implementations with status code attributes.
 - **4xx errors** return formatted JSON messages to clients.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,20 @@ remain Cloudflare-only, because nothing else has those events.
   `skyzen-macros/openapi` and `expand_openapi_fn` checks `cfg!(feature = "openapi")` at expansion
   time. Feature off ⇒ nothing is emitted at all. This replaced `debug_assertions`, which used to
   stand in for a switch that was not readable and left release builds with an empty document.
+- **The document names the application, and no API carries that name.** `env!("CARGO_PKG_NAME")`
+  expands where it is written, so `OpenApi::default_info` used to title every user's document
+  `skyzen 0.2.1`. The fix is not an argument on `enable_api_doc`: `#[skyzen::main]` expands in the
+  application's crate, so it registers an `AppInfo` into `registry::APP_INFO` exactly as
+  `#[skyzen::openapi]` registers a `HandlerSpec`, and `OpenApi::info` reads it. One per binary,
+  because one attribute defines a binary. `OpenApi::with_info` overrides it; with neither, the title
+  is an anonymous `API 0.0.0`, since naming skyzen is worse. **Do not add a name parameter to a
+  routing method** — that was tried and reverted; the registry is why it is not needed.
+- **`skyzen openapi` runs the application, and that is the only way.** Only the compiled binary
+  knows what was collected. `SKYZEN_OPENAPI_DUMP` (defined once in `skyzen-core`, so the CLI and the
+  runtime cannot spell it differently) makes `#[skyzen::main]` print the document and exit *before*
+  the factory's service wiring — which is what lets the command work with no credentials, no
+  reachable backend and an incomplete `.env`, where `skyzen dev` refuses to start. Keep the dump
+  ahead of the wiring; moving it after would quietly reintroduce that requirement.
 - **`src/openapi/registry.rs` is the only file that asks what target it is.** Native registers into a
   `linkme` distributed slice — linker-section data, nothing before `main`, free at runtime. wasm32
   has no such linker support, so it uses `inventory`: one life-before-main constructor per handler,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ futures-lite = "2.6"
 serial_test = "3.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# The wasm half of the OpenAPI handler registry; see `src/openapi/registry.rs` for why
+# native uses `linkme` and only wasm pays for `inventory`.
+inventory = "0.3"
 wasm-bindgen = { version = "0.2.110", features = ["spans"] }
 wasm-bindgen-futures = "0.4.60"
 js-sys = "0.3.87"
@@ -169,7 +172,7 @@ optional = true
 
 [features]
 default = ["json", "form", "query", "multipart", "sse", "rt", "openapi", "ws", "static-files", "runtime-async-std-native-tls"]
-openapi = ["skyzen-core/openapi"]
+openapi = ["skyzen-core/openapi", "skyzen-macros/openapi"]
 auth = []
 jwt = ["auth", "dep:jsonwebtoken"]
 json = ["http-kit/json"]

--- a/README.md
+++ b/README.md
@@ -842,8 +842,16 @@ fn router() -> Router {
 
 `Route::enable_api_doc()` mounts the same Scalar UI at `/api-docs`. `.redoc()` / `.redoc_route()` remain available if you want Redoc instead.
 
-*Schema generation is gated to debug builds and native targets, so release binaries and edge wasm
-bundles stay small.*
+The document is the same on every target — a native server, Lambda, Azure Functions and a
+Cloudflare Worker all serve what `#[skyzen::openapi]` collected, in release as in debug. The
+`openapi` cargo feature is the only switch, and it is on by default; a bundle that has no use for a
+schema turns it off with `skyzen = { version = "0.2", default-features = false, features = [...] }`
+and pays for nothing — no specs, no schema functions, no registration.
+
+*How the metadata is collected differs by target, and only in cost. Natively it is linker-section
+data, so nothing runs before `main`. WebAssembly has no such linker support, so there it rides one
+life-before-main constructor per documented handler — a few pointer pushes at isolate start, paid
+only on the edge. See `src/openapi/registry.rs`.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -870,6 +870,8 @@ skyzen add redis postgres             # `cargo add` the crates a capability need
 skyzen doctor                         # toolchain, wasm target, manifest, bindings, auth
 skyzen dev                            # native, restarts on change
 skyzen dev --provider cloudflare      # workerd, rebuilding the wasm on change
+skyzen openapi                        # open the API reference in a browser
+skyzen openapi --print                # the raw document, for a client generator
 skyzen build --provider cloudflare    # artifacts only; prints raw and gzipped wasm size
 skyzen provision                      # create the KV/D1 resources the manifest has no id for
 skyzen migrate                        # apply pending SQL migrations
@@ -883,6 +885,43 @@ skyzen completions fish
 
 `--env <name>` selects a `[cloudflare.env.<name>]` overlay, `--dry-run` prints the plan without
 running it, and `--manifest` points at a `Skyzen.toml` elsewhere.
+
+### `skyzen openapi`
+
+Only the compiled application knows what `#[skyzen::openapi]` collected, so the document comes from
+running it: `SKYZEN_OPENAPI_DUMP` makes a Skyzen binary print its document and exit. That happens
+*before* it wires any service, which is what makes the command cheap to reach for — it needs no
+credentials, no reachable backend and no complete `.env`, and works in a project whose resources are
+not provisioned yet. It also never leaves a server running: the page is a local file, and Scalar
+renders an embedded document as happily as a fetched one.
+
+```sh
+skyzen openapi                  # render .skyzen/gen/openapi.html and open it
+skyzen openapi --json api.json  # write the document there, no browser
+skyzen openapi --print          # the document on stdout, for `| jq` or a generator
+skyzen openapi --no-open        # render the page, print its path
+```
+
+The rendered page loads Scalar from jsDelivr, so it wants a network; `--json` and `--print` do not.
+
+A document is titled after the application, and you pass nothing to get that. Skyzen cannot read
+`CARGO_PKG_NAME` on your behalf — `env!` expands where it is *written*, so asking inside skyzen would
+name skyzen in everyone's document — but `#[skyzen::main]` expands in *your* crate, so it registers
+your identity there, the same way `#[skyzen::openapi]` registers a handler. Nothing has to carry a
+name through the routing API:
+
+```rust
+Route::new((/* ... */))
+    .enable_api_doc()   // Scalar at /api-docs, titled after your crate
+    .build();
+
+// mounted where you choose, alongside the raw document for a client generator
+let docs = api.openapi();
+Route::new((api, docs.scalar_route("/docs"), docs.json_route("/openapi.json"))).build()
+```
+
+Override it with `OpenApi::with_info` when the API's public name is not the crate's — `orders-service`
+the crate, "Orders API" the product.
 
 ---
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,6 +32,9 @@ dotenvy = "0.15"
 flate2 = "1.1"
 ignore = "0.4"
 notify-debouncer-full = "0.4"
+# `skyzen openapi` hands the rendered page to the user's browser. The page is a local file, so
+# this is the whole of the CLI's involvement with a browser: no server, no port.
+open = "5"
 pathdiff = "0.2"
 regex = "1"
 # The Azure app settings are read and written over ARM, which has no Rust SDK for the Web Apps
@@ -40,6 +43,9 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# For `OPENAPI_DUMP_ENV`, the contract between `skyzen openapi` and a running application.
+# Naming it from the crate that defines it is what keeps the two halves from drifting.
+skyzen-core.workspace = true
 skyzen-manifest.workspace = true
 # `skyzen migrate --provider native` applies migrations itself rather than shelling out, so the CLI
 # links the same runner and the same sqlx drivers the application would use. `runtime-tokio-rustls`

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -81,6 +81,26 @@ pub enum Command {
     },
 
     /// Build and deploy the project.
+    /// Open the application's API reference in a browser.
+    ///
+    /// Runs the application so it prints its own `OpenAPI` document and exits — before it wires any
+    /// service, so this needs no credentials and no reachable backend — then renders a Scalar page
+    /// around it as a local file. Nothing is served and no port is used.
+    // clap would derive `open-api` from the variant name; the command is one word.
+    #[command(name = "openapi")]
+    OpenApi {
+        /// Write the document here instead of rendering a page.
+        #[arg(long, value_name = "PATH", conflicts_with = "print")]
+        json: Option<PathBuf>,
+
+        /// Write the document to standard output instead of rendering a page.
+        #[arg(long, conflicts_with = "no_open")]
+        print: bool,
+
+        /// Render the page but print its path instead of opening a browser.
+        #[arg(long)]
+        no_open: bool,
+    },
     Deploy,
 
     /// Create the cloud resources the manifest declares but has no id for.
@@ -301,6 +321,44 @@ mod tests {
             panic!("expected `dev`");
         };
         assert_eq!(runner_args, vec!["--test-scheduled"]);
+    }
+
+    #[test]
+    fn the_openapi_command_is_one_word() {
+        // clap derives `open-api` from the variant name, which is not what any documentation says.
+        let Command::OpenApi {
+            json,
+            print,
+            no_open,
+        } = parse(&["skyzen", "openapi"]).command
+        else {
+            panic!("expected the openapi command");
+        };
+        assert_eq!(json, None);
+        assert!(!print);
+        assert!(!no_open);
+    }
+
+    #[test]
+    fn openapi_output_destinations_are_mutually_exclusive() {
+        // Each of these asks for the document in a different place; taking two silently would mean
+        // honouring one and dropping the other.
+        for args in [
+            vec!["skyzen", "openapi", "--print", "--json", "spec.json"],
+            vec!["skyzen", "openapi", "--print", "--no-open"],
+        ] {
+            assert!(Cli::try_parse_from(&args).is_err(), "{args:?}");
+        }
+    }
+
+    #[test]
+    fn openapi_writes_the_document_where_asked() {
+        let Command::OpenApi { json, .. } =
+            parse(&["skyzen", "openapi", "--json", "spec.json"]).command
+        else {
+            panic!("expected the openapi command");
+        };
+        assert_eq!(json, Some(std::path::PathBuf::from("spec.json")));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod dev;
 mod environment;
 mod migrate;
+mod openapi;
 mod output;
 mod project;
 mod providers;
@@ -67,6 +68,17 @@ fn run() -> Result<()> {
             providers::provision(&cli.manifest, cli.provider, cli.env.as_deref(), cli.dry_run)
         }
         Command::Doctor => providers::doctor(&cli.manifest, cli.provider, cli.env.as_deref()),
+        Command::OpenApi {
+            json,
+            print,
+            no_open,
+        } => openapi::run(&openapi::Request {
+            manifest: &cli.manifest,
+            json: json.as_deref(),
+            print: *print,
+            no_open: *no_open,
+            dry_run: cli.dry_run,
+        }),
         // `migrate` is the one action with two genuinely different implementations rather than two
         // renderings of one plan: the Cloudflare path shells out to wrangler and is planned like
         // everything else, while the native path opens a connection and applies the files itself.
@@ -139,6 +151,7 @@ fn action_for(command: &Command) -> Result<Action> {
         | Command::Provision
         | Command::Doctor
         | Command::Migrate { .. }
+        | Command::OpenApi { .. }
         | Command::Completions { .. } => {
             unreachable!("handled before dispatch")
         }

--- a/cli/src/openapi.rs
+++ b/cli/src/openapi.rs
@@ -1,0 +1,227 @@
+//! `skyzen openapi` — open the application's API reference in a browser.
+//!
+//! The document is produced by the application itself, not by the CLI: only the compiled binary
+//! knows what `#[skyzen::openapi]` collected. Running it with `SKYZEN_OPENAPI_DUMP` set makes it
+//! print the document and exit, which happens *before* it wires any service, so this command needs
+//! no credentials, no reachable backend and no port — and never leaves a server running.
+//!
+//! The page is then a local file. Scalar renders an embedded document just as happily as a fetched
+//! one, so there is nothing here to serve and nothing to shut down.
+
+use crate::{output, providers};
+use anyhow::{bail, Context, Result};
+use askama::Template;
+use std::path::Path;
+
+/// Where the dumped document and the rendered page are written, alongside the other files the CLI
+/// generates for a project.
+const GENERATED_DIR: &str = ".skyzen/gen";
+const SPEC_FILE: &str = "openapi.json";
+const PAGE_FILE: &str = "openapi.html";
+
+/// What `skyzen openapi` was asked to produce.
+#[derive(Debug)]
+pub struct Request<'a> {
+    /// Path to the project manifest, from the global `--manifest`.
+    pub manifest: &'a Path,
+    /// Write the document here and stop, instead of rendering a page.
+    pub json: Option<&'a Path>,
+    /// Write the document to standard output and stop.
+    pub print: bool,
+    /// Render the page but do not open a browser.
+    pub no_open: bool,
+    /// Describe the work without doing any of it.
+    pub dry_run: bool,
+}
+
+/// Produce the document and, unless asked otherwise, open it.
+///
+/// # Errors
+///
+/// Fails when the manifest cannot be read, when the application does not build or exits non-zero,
+/// or when the document cannot be written or opened.
+pub fn run(request: &Request<'_>) -> Result<()> {
+    let manifest = providers::load_or_empty(request.manifest)?;
+    let root_dir = manifest.root_dir().to_path_buf();
+    let generated = root_dir.join(GENERATED_DIR);
+    let spec_path = generated.join(SPEC_FILE);
+
+    if request.dry_run {
+        describe(request, &spec_path, &generated.join(PAGE_FILE));
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&generated)
+        .with_context(|| format!("failed to create {}", generated.display()))?;
+    let report = if request.print {
+        output::step_aside
+    } else {
+        output::step
+    };
+    let spec = dump(&root_dir, &spec_path, report)?;
+
+    if request.print {
+        // The document *is* this command's output here, so it goes to stdout unprefixed —
+        // `skyzen openapi --print | jq` has to be a document and nothing else.
+        println!("{spec}");
+        return Ok(());
+    }
+
+    if let Some(destination) = request.json {
+        std::fs::write(destination, &spec)
+            .with_context(|| format!("failed to write {}", destination.display()))?;
+        report(format!("write {}", destination.display()));
+        return Ok(());
+    }
+
+    let page_path = generated.join(PAGE_FILE);
+    let page = render_page(&manifest_title(&root_dir), &spec)?;
+    std::fs::write(&page_path, page)
+        .with_context(|| format!("failed to write {}", page_path.display()))?;
+    report(format!("write {}", page_path.display()));
+
+    let url = format!("file://{}", page_path.display());
+    if request.no_open {
+        report(url);
+        return Ok(());
+    }
+
+    report(format!("open {url}"));
+    open::that(&page_path).with_context(|| format!("failed to open {}", page_path.display()))
+}
+
+/// Say what would happen, writing nothing and building nothing.
+fn describe(request: &Request<'_>, spec_path: &Path, page_path: &Path) {
+    output::dry_run(format!(
+        "cargo run ({}={})",
+        skyzen_core::OPENAPI_DUMP_ENV,
+        spec_path.display()
+    ));
+    if request.print {
+        output::dry_run("write the document to stdout");
+    } else if let Some(destination) = request.json {
+        output::dry_run(format!("write {}", destination.display()));
+    } else {
+        output::dry_run(format!("write {}", page_path.display()));
+        if !request.no_open {
+            output::dry_run(format!("open file://{}", page_path.display()));
+        }
+    }
+}
+
+/// Run the application so it prints its own document, and read the result back.
+///
+/// No child environment is prepared, unlike `skyzen dev`: the document is built from the router
+/// before any service is wired, so a connection string this command would have had to demand is a
+/// connection string it would never use.
+fn dump(root_dir: &Path, spec_path: &Path, report: fn(String)) -> Result<String> {
+    report(format!(
+        "cargo run ({}={})",
+        skyzen_core::OPENAPI_DUMP_ENV,
+        spec_path.display()
+    ));
+
+    let command = providers::CommandPlan {
+        program: "cargo".to_owned(),
+        args: vec!["run".to_owned()],
+        cwd: Some(root_dir.to_path_buf()),
+        stdin: providers::CommandStdin::Inherit,
+    };
+    let env = vec![(
+        skyzen_core::OPENAPI_DUMP_ENV.to_owned(),
+        spec_path.display().to_string(),
+    )];
+
+    let status = providers::spawn_command(&command, &env)?
+        .wait()
+        .context("failed to wait for cargo run")?;
+    if !status.success() {
+        bail!("the application exited with {status} instead of printing its OpenAPI document");
+    }
+
+    let spec = std::fs::read_to_string(spec_path).with_context(|| {
+        format!(
+            "the application exited successfully but wrote no document to {}; is it built with \
+             skyzen's `openapi` feature?",
+            spec_path.display()
+        )
+    })?;
+    report(format!(
+        "write {} ({} operations)",
+        spec_path.display(),
+        operation_count(&spec)
+    ));
+    Ok(spec)
+}
+
+/// How many operations the document describes, for the progress line.
+///
+/// A path item holds one entry per method, so this counts methods rather than paths — the number a
+/// reader will actually see listed.
+fn operation_count(spec: &str) -> usize {
+    serde_json::from_str::<serde_json::Value>(spec)
+        .ok()
+        .and_then(|document| document.get("paths")?.as_object().cloned())
+        .map_or(0, |paths| {
+            paths
+                .values()
+                .filter_map(|item| item.as_object().map(serde_json::Map::len))
+                .sum()
+        })
+}
+
+/// The browser tab's title, which is the project directory's name.
+///
+/// The document's own `info.title` is what the page displays; this only has to distinguish one
+/// open tab from another.
+fn manifest_title(root_dir: &Path) -> String {
+    root_dir.file_name().map_or_else(
+        || "API reference".to_owned(),
+        |name| format!("{} — API reference", name.to_string_lossy()),
+    )
+}
+
+/// Render the Scalar page around an embedded document.
+fn render_page(title: &str, spec: &str) -> Result<String> {
+    ScalarPageTemplate { title, spec }
+        .render()
+        .context("failed to render the API reference page")
+}
+
+#[derive(Template)]
+#[template(path = "scalar.html.tmpl", escape = "none")]
+struct ScalarPageTemplate<'a> {
+    title: &'a str,
+    /// The document, embedded verbatim as the JSON literal Scalar is handed.
+    spec: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{operation_count, render_page};
+
+    const SPEC: &str = r#"{"openapi":"3.1.0","info":{"title":"apidemo","version":"0.1.0"},
+        "paths":{"/a":{"get":{},"post":{}},"/b":{"get":{}}}}"#;
+
+    #[test]
+    fn the_page_embeds_the_document_rather_than_linking_to_it() {
+        let page = render_page("apidemo — API reference", SPEC).unwrap();
+        assert!(page.contains("@scalar/api-reference"), "{page}");
+        assert!(page.contains("apidemo — API reference"), "{page}");
+        // Embedded, not linked: the page is opened over `file://`, where fetching a sibling file
+        // is blocked by the browser's origin rules.
+        assert!(page.contains("content:"), "{page}");
+        assert!(page.contains(r#""title":"apidemo""#), "{page}");
+        assert!(!page.contains(super::SPEC_FILE), "{page}");
+    }
+
+    #[test]
+    fn the_progress_line_counts_methods_not_paths() {
+        assert_eq!(operation_count(SPEC), 3);
+    }
+
+    #[test]
+    fn an_unreadable_document_counts_nothing_rather_than_panicking() {
+        assert_eq!(operation_count("not json"), 0);
+    }
+}

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -15,6 +15,15 @@ pub fn step(message: impl Display) {
     println!("{PREFIX} {message}");
 }
 
+/// Report an action on stderr, for a command whose stdout is a payload rather than a transcript.
+///
+/// `skyzen openapi --print` writes the document to stdout, so its progress cannot go there too:
+/// `skyzen openapi --print | jq` has to receive a document and nothing else. A person watching a
+/// terminal still sees these lines; a pipe does not.
+pub fn step_aside(message: impl Display) {
+    eprintln!("{PREFIX} {message}");
+}
+
 /// Report an action the CLI would take, but is not taking because of `--dry-run`.
 pub fn dry_run(message: impl Display) {
     println!("[dry-run] {message}");

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -427,7 +427,7 @@ pub fn prepare(
 /// had one. An empty manifest declares no capabilities and no environment variables, which is
 /// exactly right for the native path; the Cloudflare path then fails with "missing [cloudflare]
 /// section", which says what to do, rather than with a file-not-found.
-fn load_or_empty(manifest_path: &Path) -> Result<Manifest> {
+pub fn load_or_empty(manifest_path: &Path) -> Result<Manifest> {
     if manifest_path.exists() {
         return environment::load_manifest(manifest_path);
     }

--- a/cli/templates/api/src/app.rs.tmpl
+++ b/cli/templates/api/src/app.rs.tmpl
@@ -23,6 +23,12 @@ async fn health() -> &'static str {
     "OK"
 }
 
+/// Greet a caller by name, remembering whether they have been greeted before.
+///
+/// `#[skyzen::openapi]` reads this doc comment, the extractor types and the responder type, and
+/// registers the operation the `/api-docs` page below renders. It costs nothing at runtime on a
+/// server and works the same inside a Worker isolate.
+///
 /// Skyzen.toml declares `[[service]] name = "cache"` and `[[database]] name = "journal"`, so
 /// `#[skyzen::main]` generates a `Cache` extractor around the portable `Kv`, a `JournalDb`
 /// extractor around the portable `Db`, and injects both into every request.
@@ -30,6 +36,7 @@ async fn health() -> &'static str {
 /// This handler is the whole point of the framework: it runs unchanged against the in-process mock
 /// and SQLite during `skyzen dev`, and against a Cloudflare KV namespace and a D1 database after
 /// `skyzen deploy`. Changing backends is a Skyzen.toml edit, never a code edit.
+#[skyzen::openapi]
 async fn greet(cache: Cache, journal: JournalDb, params: Params) -> Result<Json<Greeting>> {
     let name = params.get("name")?.to_owned();
     // `Cache` derefs to `Kv`, so every `Kv` method is reachable through it.
@@ -64,5 +71,8 @@ pub fn router() -> Router {
         "/health".at(health),
         "/greet".route(("/{name}".at(greet),)),
     ))
+    // Serves the interactive Scalar reference at `/api-docs`, built from whatever
+    // `#[skyzen::openapi]` documented. `skyzen openapi` opens the same document without a server.
+    .enable_api_doc()
     .build()
 }

--- a/cli/templates/api/src/app.rs.tmpl
+++ b/cli/templates/api/src/app.rs.tmpl
@@ -72,7 +72,8 @@ pub fn router() -> Router {
         "/greet".route(("/{name}".at(greet),)),
     ))
     // Serves the interactive Scalar reference at `/api-docs`, built from whatever
-    // `#[skyzen::openapi]` documented. `skyzen openapi` opens the same document without a server.
+    // `#[skyzen::openapi]` documented, titled after this crate. `skyzen openapi` opens the same
+    // document without running a server.
     .enable_api_doc()
     .build()
 }

--- a/cli/templates/scalar.html.tmpl
+++ b/cli/templates/scalar.html.tmpl
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script>
+      // The document is embedded rather than fetched: the page is opened over `file://`, where a
+      // `url:` would be blocked by the browser's origin rules and would need a server this command
+      // deliberately does not run.
+      Scalar.createApiReference('#app', {
+        content: {{ spec }},
+      })
+    </script>
+  </body>
+</html>

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,6 +54,17 @@ pub use secret::Secret;
 #[cfg(feature = "openapi")]
 pub mod openapi;
 
+/// Asks a Skyzen binary to print its `OpenAPI` document to this path — or to standard output, when
+/// the value is `-` — and exit without serving anything.
+///
+/// The contract between `skyzen openapi` and `#[skyzen::main]`, defined here because it is the one
+/// crate both the runtime and the CLI depend on; neither gets to spell it independently.
+///
+/// An environment variable rather than a command-line flag for the same reason
+/// `AWS_LAMBDA_RUNTIME_API` and `FUNCTIONS_CUSTOMHANDLER_PORT` are: the application owns its argv,
+/// and a flag skyzen reserved could collide with one the application already defines.
+pub const OPENAPI_DUMP_ENV: &str = "SKYZEN_OPENAPI_DUMP";
+
 pub use http_kit::{
     endpoint, header, method, uri, version, Body, BodyError, Endpoint, Extensions, Method, Request,
     Response, StatusCode, Uri, Version,

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,6 +21,17 @@ quote = "1"
 skyzen-manifest.workspace = true
 syn = { version = "2", features = ["full"] }
 
+[features]
+# Whether `#[skyzen::openapi]` emits handler metadata at all.
+#
+# The metadata has to be gated where the decision is actually visible. Macro output expands in
+# the *downstream* crate, so a `#[cfg(feature = "openapi")]` in the expansion would ask about the
+# application's features, not skyzen's. Asking here instead — at expansion time, in this crate's
+# own compilation — is the only place the answer is right, so `skyzen/openapi` turns this on and
+# a `default-features = false` build emits no specs, no schema functions and no registrations on
+# any target.
+openapi = []
+
 [dev-dependencies]
 
 [lints]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -99,8 +99,12 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
         .as_ref()
         .map_or_else(|| quote! { || async {} }, |path| quote! { || #path() });
 
+    let register_app_info = app_info_registration();
+
     let output = quote! {
         ::skyzen::import_config!();
+
+        #register_app_info
 
         #function
 
@@ -108,6 +112,13 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[allow(clippy::redundant_clone)]
         fn main() {
             #init_logging
+            // Answers `SKYZEN_OPENAPI_DUMP` before anything binds or connects. The document is
+            // built from the router the entry function returns, ahead of the service wiring the
+            // factory does, so `skyzen openapi` works in a project whose backends do not exist
+            // yet.
+            if ::skyzen::runtime::native::dump_openapi_if_requested(|| async { #entry_call }) {
+                return;
+            }
             ::skyzen::runtime::native::launch(
                 ::skyzen::runtime::native::LaunchOptions {
                     listen: ::skyzen::runtime::native::apply_cli_overrides(::std::env::args()),
@@ -2365,6 +2376,30 @@ fn service_wrapper_path(service_type: ServiceType) -> proc_macro2::TokenStream {
         ServiceType::Kv => quote! { ::skyzen::__services::Kv },
         ServiceType::Storage => quote! { ::skyzen::__services::Storage },
         ServiceType::Queue => quote! { ::skyzen::__services::Queue },
+    }
+}
+
+/// The application's identity, registered exactly as `#[skyzen::openapi]` registers a handler.
+///
+/// `env!` expands in the application's crate, which is the only place it reads the application's
+/// own name rather than skyzen's — and registering it there means no document, and no routing call
+/// that builds one, has to carry the name as an argument. One per binary, because `#[skyzen::main]`
+/// is what defines a binary; emitted at item level rather than inside `main` so the wasm build,
+/// which has no `main`, registers it too.
+fn app_info_registration() -> proc_macro2::TokenStream {
+    if !cfg!(feature = "openapi") {
+        return quote! {};
+    }
+
+    quote! {
+        ::skyzen::__register_app_info!(
+            __SKYZEN_APP_INFO,
+            ::skyzen::openapi::AppInfo {
+                name: env!("CARGO_PKG_NAME"),
+                version: env!("CARGO_PKG_VERSION"),
+                description: option_env!("CARGO_PKG_DESCRIPTION"),
+            }
+        );
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -772,37 +772,40 @@ fn expand_openapi_fn(mut function: ItemFn) -> syn::Result<TokenStream> {
         fn_ident.to_string().to_uppercase()
     );
 
-    // All generated items are gated on `debug_assertions` + native targets only. The condition
-    // must not mention any cargo feature: these `cfg`s are evaluated against the *user's* crate
-    // features, and downstream crates have no feature named `openapi`. The referenced
-    // `::skyzen::openapi` symbols exist whenever skyzen itself is compiled for a native debug
-    // build, independent of skyzen's `openapi` feature.
+    // Whether to emit any of this is decided *here*, in this crate's own compilation, because
+    // this is the only place the question can be answered correctly. The expansion lands in the
+    // user's crate, so a `#[cfg(feature = "openapi")]` inside it would ask about the application's
+    // features rather than skyzen's — which is why this used to ride on `debug_assertions` as a
+    // stand-in switch, and why a release build had no document. `skyzen/openapi` turns on this
+    // crate's own `openapi` feature instead, so the real switch is finally readable.
+    if !cfg!(feature = "openapi") {
+        return Ok(quote! { #function }.into());
+    }
+
+    // Nothing below mentions a target: `__register_handler_spec!` owns that split, so a handler
+    // documents itself identically whether it is compiled for a server or for an isolate.
     Ok(quote! {
         #function
 
-        #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
         const _: fn() = || {
             #(#assertions)*
         };
 
-        #(
-            #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-            #schema_collector_defs
-        )*
+        #(#schema_collector_defs)*
 
-        #[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-        #[::skyzen::openapi::linkme::distributed_slice(::skyzen::openapi::HANDLER_SPECS)]
-        #[linkme(crate = ::skyzen::openapi::linkme)]
-        static #spec_ident: ::skyzen::openapi::HandlerSpec = ::skyzen::openapi::HandlerSpec {
-            type_name: #type_name_literal,
-            operation_name: #operation_name_literal,
-            docs: #doc_tokens,
-            deprecated: #deprecated,
-            parameters: #schema_array,
-            parameter_names: #parameter_names_array,
-            response: #response_schema_fn,
-            schemas: #schema_collectors,
-        };
+        ::skyzen::__register_handler_spec!(
+            #spec_ident,
+            ::skyzen::openapi::HandlerSpec {
+                type_name: #type_name_literal,
+                operation_name: #operation_name_literal,
+                docs: #doc_tokens,
+                deprecated: #deprecated,
+                parameters: #schema_array,
+                parameter_names: #parameter_names_array,
+                response: #response_schema_fn,
+                schemas: #schema_collectors,
+            }
+        );
     }
     .into())
 }

--- a/macros/src/sql.rs
+++ b/macros/src/sql.rs
@@ -307,7 +307,7 @@ mod tests {
     fn doubled_braces_are_literal_text() {
         let (sql, captures) = split("SELECT '{{\"kind\":\"email\"}}'::jsonb");
         assert_eq!(sql, "SELECT '{\"kind\":\"email\"}'::jsonb");
-        assert!(captures.is_empty());
+        assert_eq!(captures, Vec::<String>::new());
     }
 
     #[test]

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -426,9 +426,53 @@ impl RouteOpenApiEntry {
     }
 }
 
+/// Who the document is about: the application's own name, version and description.
+///
+/// Applications do not normally construct one. `#[skyzen::main]` expands in the application's
+/// crate, where `env!("CARGO_PKG_NAME")` reads the application rather than skyzen, and registers
+/// this there — so a document is titled correctly with nothing passed through the routing API.
+/// Build one by hand, or with [`app_info!`](crate::app_info), only to override that: see
+/// [`OpenApi::with_info`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppInfo {
+    /// The application's package name, shown as the document title.
+    pub name: &'static str,
+    /// The application's package version.
+    pub version: &'static str,
+    /// The application's package description, if it declares one.
+    pub description: Option<&'static str>,
+}
+
+/// Build an [`AppInfo`] describing the crate this macro is written in.
+///
+/// `#[skyzen::main]` already does this for the application it is attached to, so this is for the
+/// cases that have no `#[skyzen::main]` to do it — a document built in a test, or an application
+/// embedding skyzen behind its own runtime:
+///
+/// ```rust
+/// # use skyzen::routing::{CreateRouteNode, Route};
+/// # async fn health() -> &'static str { "OK" }
+/// let api = Route::new(("/health".at(health),));
+/// let docs = api
+///     .openapi()
+///     .with_info(skyzen::app_info!())
+///     .scalar_route("/docs");
+/// ```
+#[macro_export]
+macro_rules! app_info {
+    () => {
+        $crate::openapi::AppInfo {
+            name: env!("CARGO_PKG_NAME"),
+            version: env!("CARGO_PKG_VERSION"),
+            description: option_env!("CARGO_PKG_DESCRIPTION"),
+        }
+    };
+}
+
 /// Minimal `OpenAPI` representation for Skyzen routers.
 #[derive(Clone, Default)]
 pub struct OpenApi {
+    info: Option<AppInfo>,
     #[cfg(feature = "openapi")]
     operations: Vec<OpenApiOperation>,
     #[cfg(feature = "openapi")]
@@ -499,6 +543,7 @@ impl OpenApi {
             .collect();
         let schemas = schema_defs.into_iter().collect();
         Self {
+            info: None,
             operations,
             schemas,
         }
@@ -509,7 +554,7 @@ impl OpenApi {
     #[must_use]
     #[allow(dead_code)]
     pub(crate) const fn from_entries(_: &[()]) -> Self {
-        Self {}
+        Self { info: None }
     }
 
     /// Inspect the registered operations.
@@ -565,9 +610,49 @@ impl OpenApi {
         ui_route(self.redoc(), mount_path.into())
     }
 
+    /// Convert the collected spec to an endpoint serving the raw `OpenAPI` JSON document.
+    ///
+    /// The counterpart to [`scalar`](Self::scalar): the same document, for a client generator or
+    /// another tool rather than a reader.
+    ///
+    /// # Panics
+    ///
+    /// If the document cannot be serialized, which would mean `utoipa` produced a structure serde
+    /// cannot write — a bug in a dependency rather than anything an application can cause.
+    #[must_use]
+    pub fn json(&self) -> OpenApiUiEndpoint {
+        self.rendered(JSON_CONTENT_TYPE, || {
+            serde_json::to_string(&self.to_utoipa_spec())
+                .expect("an OpenAPI document is always serializable")
+        })
+    }
+
+    /// Build a [`RouteNode`] serving the raw `OpenAPI` JSON document at `mount_path`.
+    ///
+    /// Unlike [`scalar_route`](Self::scalar_route) this mounts one exact path, not a subtree: a
+    /// specification is a single file, and `/openapi.json/anything` is not it.
+    #[must_use]
+    pub fn json_route(&self, mount_path: impl Into<String>) -> RouteNode {
+        RouteNode::new_endpoint(
+            mount_path.into(),
+            MethodFilter::Exact(Method::GET),
+            self.json(),
+            None,
+            Vec::new(),
+        )
+    }
+
     fn ui_endpoint(&self, html: impl FnOnce() -> String) -> OpenApiUiEndpoint {
+        self.rendered(HTML_CONTENT_TYPE, html)
+    }
+
+    fn rendered(
+        &self,
+        content_type: &'static str,
+        body: impl FnOnce() -> String,
+    ) -> OpenApiUiEndpoint {
         if self.is_enabled() {
-            OpenApiUiEndpoint::enabled(html())
+            OpenApiUiEndpoint::enabled(body(), content_type)
         } else {
             OpenApiUiEndpoint::disabled()
         }
@@ -577,14 +662,46 @@ impl OpenApi {
     #[must_use]
     pub fn to_utoipa_spec(&self) -> UtoipaSpec {
         UtoipaSpec::builder()
-            .info(Self::default_info())
+            .info(self.info())
             .paths(self.build_paths())
             .components(Some(self.build_components()))
             .build()
     }
 
-    fn default_info() -> Info {
-        Info::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+    /// Name the application this document describes, overriding what `#[skyzen::main]` registered.
+    ///
+    /// Rarely needed: an application built the ordinary way is already titled after its own crate.
+    /// Reach for this when the API's public name is not the crate's — `orders-service` the crate,
+    /// "Orders API" the product — or when building a document outside an application entirely.
+    #[must_use]
+    pub const fn with_info(mut self, info: AppInfo) -> Self {
+        self.info = Some(info);
+        self
+    }
+
+    /// The application's identity: what [`with_info`](Self::with_info) was told, else what
+    /// `#[skyzen::main]` registered for this binary, else an anonymous placeholder.
+    ///
+    /// The placeholder is reached only by a document built outside an application — a library
+    /// under test, or a binary that embeds skyzen behind its own runtime. It is deliberately
+    /// anonymous rather than skyzen's own package metadata: a document announcing itself as
+    /// `skyzen 0.2.1` in every application is worse than one that admits it was never told.
+    fn info(&self) -> Info {
+        self.info
+            .or_else(|| registry::app_info().copied())
+            .map_or_else(
+                || Info::new("API", "0.0.0"),
+                |app| {
+                    let mut info = Info::new(app.name, app.version);
+                    // A package with no `description` still yields `Some("")` from `option_env!`, and
+                    // an empty description in the document is worse than none.
+                    info.description = app
+                        .description
+                        .filter(|text| !text.is_empty())
+                        .map(ToOwned::to_owned);
+                    info
+                },
+            )
     }
 
     fn build_paths(&self) -> Paths {
@@ -668,22 +785,33 @@ impl fmt::Debug for OpenApiOperation {
 }
 
 #[derive(Clone, Debug)]
-/// Endpoint that serves a pre-rendered `OpenAPI` documentation page.
+/// Endpoint that serves a pre-rendered `OpenAPI` document — a documentation page, or the raw
+/// specification.
+///
+/// The body is rendered once when the route is built, so serving it is a header and a `memcpy`.
 pub struct OpenApiUiEndpoint {
-    html: Option<Arc<String>>,
+    body: Option<Arc<String>>,
+    content_type: &'static str,
 }
 
 impl OpenApiUiEndpoint {
-    fn enabled(html: String) -> Self {
+    fn enabled(body: String, content_type: &'static str) -> Self {
         Self {
-            html: Some(Arc::new(html)),
+            body: Some(Arc::new(body)),
+            content_type,
         }
     }
 
     const fn disabled() -> Self {
-        Self { html: None }
+        Self {
+            body: None,
+            content_type: HTML_CONTENT_TYPE,
+        }
     }
 }
+
+const HTML_CONTENT_TYPE: &str = "text/html; charset=utf-8";
+const JSON_CONTENT_TYPE: &str = "application/json";
 
 http_error!(
     /// Error returned when OpenAPI support is disabled.
@@ -697,13 +825,14 @@ impl Endpoint for OpenApiUiEndpoint {
         &mut self,
         _request: &mut Request,
     ) -> impl Future<Output = Result<Response, Self::Error>> + Send {
-        ready(self.html.as_ref().map_or_else(
+        let content_type = self.content_type;
+        ready(self.body.as_ref().map_or_else(
             || Err(OpenApiUiDisabledError::new()),
-            |html| {
-                let mut response = Response::new(Body::from(html.as_bytes().to_vec()));
+            |body| {
+                let mut response = Response::new(Body::from(body.as_bytes().to_vec()));
                 response.headers_mut().insert(
                     header::CONTENT_TYPE,
-                    header::HeaderValue::from_static("text/html; charset=utf-8"),
+                    header::HeaderValue::from_static(content_type),
                 );
                 Ok(response)
             },
@@ -1032,5 +1161,26 @@ fn doc_summary(docs: &str) -> Option<String> {
         None
     } else {
         Some(paragraph.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OpenApi;
+
+    #[test]
+    fn a_document_with_no_registered_identity_is_anonymous_rather_than_skyzen() {
+        // Reachable from a library under test or a binary that embeds skyzen behind its own
+        // runtime — anything with no `#[skyzen::main]` to register an identity. This crate's own
+        // test binary is exactly that case.
+        //
+        // `default_info` used to answer with skyzen's own `CARGO_PKG_*` here, which titled every
+        // application's document `skyzen 0.2.1`. Admitting it was never told is better than
+        // confidently naming the wrong crate. `tests/openapi_app_info.rs` covers the other side.
+        let spec = OpenApi::default().to_utoipa_spec();
+
+        assert_eq!(spec.info.title, "API");
+        assert_eq!(spec.info.version, "0.0.0");
+        assert_ne!(spec.info.title, env!("CARGO_PKG_NAME"));
     }
 }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -513,17 +513,24 @@ impl OpenApi {
     }
 
     /// Inspect the registered operations.
+    ///
+    /// Empty without the `openapi` feature, which is the only thing that varies: the signature is
+    /// the same in every build, so calling code never has to be written twice.
     #[must_use]
-    #[cfg(feature = "openapi")]
+    // Deliberately not `const` in the feature-off arm. It could be, but then the two arms would
+    // differ in a way a caller can observe, and one signature everywhere is worth more than a
+    // `const fn` returning an empty slice.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn operations(&self) -> &[OpenApiOperation] {
-        &self.operations
-    }
+        #[cfg(feature = "openapi")]
+        {
+            &self.operations
+        }
 
-    /// Inspect the registered operations.
-    #[must_use]
-    #[cfg(not(feature = "openapi"))]
-    pub const fn operations(&self) -> &[OpenApiOperation] {
-        &[]
+        #[cfg(not(feature = "openapi"))]
+        {
+            &[]
+        }
     }
 
     /// Indicates whether `OpenAPI` instrumentation is active.

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -105,15 +105,7 @@ impl fmt::Debug for ResponseSchema {
 /// Function type that collects `OpenAPI` schemas into a definitions map.
 pub type SchemaCollector = fn(&mut BTreeMap<String, SchemaRef>);
 
-// Re-exported for macro-generated registrations without requiring downstream crates to depend on
-// `linkme` directly.
-//
-// NOTE: this and the `HANDLER_SPECS`/`HandlerSpec` items below are deliberately *not* gated on
-// the `openapi` feature: `#[skyzen::openapi]`-generated code in downstream crates references them
-// under `cfg(all(debug_assertions, not(target_arch = "wasm32")))` — a condition that cannot
-// depend on skyzen's features, because it is evaluated against the downstream crate.
-#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-pub use linkme;
+pub mod registry;
 
 mod builtins;
 pub use builtins::IgnoreOpenApi;
@@ -210,13 +202,6 @@ where
     }
 }
 
-#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
-/// Distributed registry containing handler specifications discovered via `#[skyzen::openapi]`.
-#[linkme::distributed_slice]
-#[linkme(crate = ::skyzen::openapi::linkme)]
-pub static HANDLER_SPECS: [HandlerSpec] = [..];
-
-#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 #[derive(Debug, Clone, Copy)]
 /// Metadata captured for every handler annotated with `#[skyzen::openapi]`.
 pub struct HandlerSpec {
@@ -238,11 +223,9 @@ pub struct HandlerSpec {
     pub schemas: &'static [SchemaCollector],
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 fn find_handler_spec(type_name: &str) -> Option<&'static HandlerSpec> {
-    HANDLER_SPECS
-        .iter()
-        .find(|spec| spec.type_name == type_name)
+    registry::iter().find(|spec| spec.type_name == type_name)
 }
 
 #[cfg(feature = "openapi")]
@@ -372,7 +355,7 @@ where
     }
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 fn collect_schemas(collectors: &[SchemaCollector], defs: &mut BTreeMap<String, SchemaRef>) {
     for collector in collectors {
         collector(defs);
@@ -382,19 +365,19 @@ fn collect_schemas(collectors: &[SchemaCollector], defs: &mut BTreeMap<String, S
 /// Handler metadata attached to each endpoint.
 #[derive(Clone, Copy, Debug)]
 pub struct RouteHandlerDoc {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     type_name: &'static str,
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     spec: Option<&'static HandlerSpec>,
 }
 
 impl RouteHandlerDoc {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     const fn new(type_name: &'static str, spec: Option<&'static HandlerSpec>) -> Self {
         Self { type_name, spec }
     }
 
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     const fn new() -> Self {
         Self {}
     }
@@ -404,21 +387,21 @@ impl RouteHandlerDoc {
 #[must_use]
 #[allow(clippy::missing_const_for_fn)]
 pub fn describe_handler<H: 'static>() -> RouteHandlerDoc {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     {
         let type_name = std::any::type_name::<H>();
         let spec = find_handler_spec(type_name);
         RouteHandlerDoc::new(type_name, spec)
     }
 
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     {
         let _ = ::core::marker::PhantomData::<H>;
         RouteHandlerDoc::new()
     }
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 #[derive(Debug, Clone)]
 /// Route metadata stored when `OpenAPI` instrumentation is enabled.
 pub struct RouteOpenApiEntry {
@@ -430,7 +413,7 @@ pub struct RouteOpenApiEntry {
     pub handler: RouteHandlerDoc,
 }
 
-#[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 impl RouteOpenApiEntry {
     #[must_use]
     /// Construct a new entry describing a route + handler pair.
@@ -446,9 +429,9 @@ impl RouteOpenApiEntry {
 /// Minimal `OpenAPI` representation for Skyzen routers.
 #[derive(Clone, Default)]
 pub struct OpenApi {
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     operations: Vec<OpenApiOperation>,
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     schemas: Vec<(String, SchemaRef)>,
 }
 
@@ -463,7 +446,7 @@ impl Debug for OpenApi {
 
 impl OpenApi {
     /// Build an [`OpenApi`] instance from the collected route metadata.
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     #[must_use]
     pub(crate) fn from_entries(entries: &[RouteOpenApiEntry]) -> Self {
         let mut schema_defs = BTreeMap::new();
@@ -522,7 +505,7 @@ impl OpenApi {
     }
 
     /// Build an empty `OpenAPI` definition when `OpenAPI` support is disabled.
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     #[must_use]
     #[allow(dead_code)]
     pub(crate) const fn from_entries(_: &[()]) -> Self {
@@ -531,14 +514,14 @@ impl OpenApi {
 
     /// Inspect the registered operations.
     #[must_use]
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     pub fn operations(&self) -> &[OpenApiOperation] {
         &self.operations
     }
 
     /// Inspect the registered operations.
     #[must_use]
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     pub const fn operations(&self) -> &[OpenApiOperation] {
         &[]
     }
@@ -546,11 +529,7 @@ impl OpenApi {
     /// Indicates whether `OpenAPI` instrumentation is active.
     #[must_use]
     pub const fn is_enabled(&self) -> bool {
-        cfg!(all(
-            debug_assertions,
-            feature = "openapi",
-            not(target_arch = "wasm32")
-        ))
+        cfg!(feature = "openapi")
     }
 
     /// Convert the collected spec to a [`Scalar`](utoipa_scalar::Scalar) endpoint.
@@ -618,7 +597,7 @@ impl OpenApi {
             .build()
     }
 
-    #[cfg(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     fn build_components(&self) -> utoipa::openapi::schema::Components {
         self.schemas
             .iter()
@@ -629,7 +608,7 @@ impl OpenApi {
             .build()
     }
 
-    #[cfg(not(all(debug_assertions, feature = "openapi", not(target_arch = "wasm32"))))]
+    #[cfg(not(feature = "openapi"))]
     #[allow(clippy::unused_self)]
     fn build_components(&self) -> utoipa::openapi::schema::Components {
         ComponentsBuilder::new().build()

--- a/src/openapi/registry.rs
+++ b/src/openapi/registry.rs
@@ -15,57 +15,82 @@
 //!   absorbs a handful of pointer pushes, and the alternative on the edge is having no document at
 //!   all.
 //!
-//! Both halves expose the same two things — [`iter`] and
-//! [`__register_handler_spec!`](crate::__register_handler_spec) — so nothing else in the workspace,
-//! the `#[skyzen::openapi]` expansion included, has to know which one it is talking to.
+//! **The public surface is identical on every target**: [`iter`], and
+//! [`__register_handler_spec!`](crate::__register_handler_spec) with one invocation shape. Which
+//! backend answers is a private matter of this file — the `#[skyzen::openapi]` expansion, the rest
+//! of the crate and an application's own code all name the same items whatever they compile for.
 
 use super::HandlerSpec;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub use linkme;
-
-#[cfg(target_arch = "wasm32")]
-pub use inventory;
-
-/// The linker-collected registry every native `#[skyzen::openapi]` handler registers into.
-#[cfg(not(target_arch = "wasm32"))]
-#[linkme::distributed_slice]
-#[linkme(crate = ::skyzen::openapi::registry::linkme)]
-pub static HANDLER_SPECS: [HandlerSpec] = [..];
-
-#[cfg(target_arch = "wasm32")]
-inventory::collect!(HandlerSpec);
 
 /// Every handler specification this binary registered, in no particular order.
 pub fn iter() -> impl Iterator<Item = &'static HandlerSpec> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        HANDLER_SPECS.iter()
+        backend::HANDLER_SPECS.iter()
     }
 
     #[cfg(target_arch = "wasm32")]
     {
-        inventory::iter::<HandlerSpec>()
+        backend::inventory::iter::<HandlerSpec>()
     }
 }
 
-/// Register one handler's specification with whichever registry this target uses.
+/// The chosen backend's plumbing.
+///
+/// Public because [`__register_handler_spec!`](crate::__register_handler_spec) expands in the
+/// application's crate and has to name it from there, and hidden because naming it from anywhere
+/// else is a mistake: these are the items that genuinely differ by target, and keeping them behind
+/// one door is what lets everything above be the same everywhere.
+#[doc(hidden)]
+pub mod backend {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use linkme;
+
+    #[cfg(target_arch = "wasm32")]
+    pub use inventory;
+
+    /// The linker section every native `#[skyzen::openapi]` handler's specification lands in.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[linkme::distributed_slice]
+    #[linkme(crate = ::skyzen::openapi::registry::backend::linkme)]
+    pub static HANDLER_SPECS: [super::HandlerSpec] = [..];
+
+    #[cfg(target_arch = "wasm32")]
+    inventory::collect!(super::HandlerSpec);
+}
+
+/// Register one handler's specification with the registry.
 ///
 /// Called only from the `#[skyzen::openapi]` expansion, which builds the [`HandlerSpec`] and knows
-/// nothing about how it is stored — the two backends differ in the *shape* of a registration (a
-/// named `static` for `linkme`, an expression for `inventory`), and that difference stops here.
+/// nothing about how it is stored.
+///
+/// Defined twice, once per target, rather than once emitting `#[cfg]`-guarded code: the two
+/// backends want genuinely different item shapes — a named `static` carrying attributes for
+/// `linkme`, a bare expression for `inventory` — and choosing here means the *caller* sees one
+/// macro with one invocation shape, and the code it expands to carries no `#[cfg]` of its own.
+#[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __register_handler_spec {
     ($ident:ident, $spec:expr) => {
-        #[cfg(not(target_arch = "wasm32"))]
-        #[$crate::openapi::registry::linkme::distributed_slice(
-            $crate::openapi::registry::HANDLER_SPECS
+        #[$crate::openapi::registry::backend::linkme::distributed_slice(
+            $crate::openapi::registry::backend::HANDLER_SPECS
         )]
-        #[linkme(crate = $crate::openapi::registry::linkme)]
+        #[linkme(crate = $crate::openapi::registry::backend::linkme)]
         static $ident: $crate::openapi::HandlerSpec = $spec;
+    };
+}
 
-        #[cfg(target_arch = "wasm32")]
-        $crate::openapi::registry::inventory::submit! { $spec }
+/// Register one handler's specification with the registry.
+///
+/// See the native definition above; this is the same macro for the target whose registry is
+/// `inventory`, and takes the same arguments. The identifier is unused here — `inventory` names
+/// its own shim — and is accepted so that one invocation compiles for both.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_handler_spec {
+    ($ident:ident, $spec:expr) => {
+        $crate::openapi::registry::backend::inventory::submit! { $spec }
     };
 }

--- a/src/openapi/registry.rs
+++ b/src/openapi/registry.rs
@@ -20,7 +20,7 @@
 //! backend answers is a private matter of this file — the `#[skyzen::openapi]` expansion, the rest
 //! of the crate and an application's own code all name the same items whatever they compile for.
 
-use super::HandlerSpec;
+use super::{AppInfo, HandlerSpec};
 
 /// Every handler specification this binary registered, in no particular order.
 pub fn iter() -> impl Iterator<Item = &'static HandlerSpec> {
@@ -35,12 +35,35 @@ pub fn iter() -> impl Iterator<Item = &'static HandlerSpec> {
     }
 }
 
+/// The identity `#[skyzen::main]` registered for this binary, if it was built with one.
+///
+/// This is how a document learns whose it is without anybody passing it along. Skyzen cannot read
+/// `CARGO_PKG_NAME` on an application's behalf — `env!` expands where it is *written*, so asking
+/// inside skyzen names skyzen — but `#[skyzen::main]` expands in the application's crate, where
+/// the answer is right, and registers it here exactly as `#[skyzen::openapi]` registers a handler.
+///
+/// One per binary, because `#[skyzen::main]` defines the entry point and there is only one of
+/// those. `None` for a library under test, or an application that embeds skyzen behind its own
+/// runtime; both can still name themselves with [`OpenApi::with_info`](super::OpenApi::with_info).
+#[must_use]
+pub fn app_info() -> Option<&'static AppInfo> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        backend::APP_INFO.first()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        backend::inventory::iter::<AppInfo>().next()
+    }
+}
+
 /// The chosen backend's plumbing.
 ///
 /// Public because [`__register_handler_spec!`](crate::__register_handler_spec) expands in the
 /// application's crate and has to name it from there, and hidden because naming it from anywhere
-/// else is a mistake: these are the items that genuinely differ by target, and keeping them behind
-/// one door is what lets everything above be the same everywhere.
+/// else is a mistake: these are the two items that genuinely differ by target, and keeping them
+/// behind one door is what lets everything above be the same everywhere.
 #[doc(hidden)]
 pub mod backend {
     #[cfg(not(target_arch = "wasm32"))]
@@ -55,8 +78,17 @@ pub mod backend {
     #[linkme(crate = ::skyzen::openapi::registry::backend::linkme)]
     pub static HANDLER_SPECS: [super::HandlerSpec] = [..];
 
+    /// The same, for the one identity `#[skyzen::main]` registers per binary.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[linkme::distributed_slice]
+    #[linkme(crate = ::skyzen::openapi::registry::backend::linkme)]
+    pub static APP_INFO: [super::AppInfo] = [..];
+
     #[cfg(target_arch = "wasm32")]
     inventory::collect!(super::HandlerSpec);
+
+    #[cfg(target_arch = "wasm32")]
+    inventory::collect!(super::AppInfo);
 }
 
 /// Register one handler's specification with the registry.
@@ -92,5 +124,34 @@ macro_rules! __register_handler_spec {
 macro_rules! __register_handler_spec {
     ($ident:ident, $spec:expr) => {
         $crate::openapi::registry::backend::inventory::submit! { $spec }
+    };
+}
+
+/// Register this binary's identity, so a document can be titled without anybody passing a name
+/// down through the routing API.
+///
+/// Emitted once by `#[skyzen::main]`, in the application's crate, where `env!("CARGO_PKG_NAME")`
+/// reads the application rather than skyzen.
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_app_info {
+    ($ident:ident, $info:expr) => {
+        #[$crate::openapi::registry::backend::linkme::distributed_slice(
+            $crate::openapi::registry::backend::APP_INFO
+        )]
+        #[linkme(crate = $crate::openapi::registry::backend::linkme)]
+        static $ident: $crate::openapi::AppInfo = $info;
+    };
+}
+
+/// Register this binary's identity. See the native definition above; same arguments, same one
+/// invocation, for the target whose registry is `inventory`.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_app_info {
+    ($ident:ident, $info:expr) => {
+        $crate::openapi::registry::backend::inventory::submit! { $info }
     };
 }

--- a/src/openapi/registry.rs
+++ b/src/openapi/registry.rs
@@ -1,0 +1,71 @@
+//! Where every `#[skyzen::openapi]` handler's metadata is collected, and the only place in the
+//! crate that asks what target it is building for.
+//!
+//! Two backends, chosen by target, because they do not cost the same:
+//!
+//! - **Native uses [`linkme`], and pays nothing.** A [`HandlerSpec`] is a `static` placed in a
+//!   dedicated linker section; the linker lays the section out, no code runs before `main`, and
+//!   reading the registry is reading a slice. Registration is free at runtime and the specs of
+//!   handlers nothing routes are still just data the linker already had to place.
+//! - **wasm32 uses [`inventory`], and pays for it.** `linkme` has no WebAssembly backend — its
+//!   supported-platform table is Linux, macOS, Windows, FreeBSD, OpenBSD and illumos — so the edge
+//!   has to fall back on life-before-main constructors, one per documented handler, each pushing
+//!   onto a linked list when the module initializes. That is real startup work and real code size,
+//!   which is why it is confined here rather than adopted everywhere: an isolate's cold start
+//!   absorbs a handful of pointer pushes, and the alternative on the edge is having no document at
+//!   all.
+//!
+//! Both halves expose the same two things — [`iter`] and
+//! [`__register_handler_spec!`](crate::__register_handler_spec) — so nothing else in the workspace,
+//! the `#[skyzen::openapi]` expansion included, has to know which one it is talking to.
+
+use super::HandlerSpec;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use linkme;
+
+#[cfg(target_arch = "wasm32")]
+pub use inventory;
+
+/// The linker-collected registry every native `#[skyzen::openapi]` handler registers into.
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice]
+#[linkme(crate = ::skyzen::openapi::registry::linkme)]
+pub static HANDLER_SPECS: [HandlerSpec] = [..];
+
+#[cfg(target_arch = "wasm32")]
+inventory::collect!(HandlerSpec);
+
+/// Every handler specification this binary registered, in no particular order.
+pub fn iter() -> impl Iterator<Item = &'static HandlerSpec> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        HANDLER_SPECS.iter()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        inventory::iter::<HandlerSpec>()
+    }
+}
+
+/// Register one handler's specification with whichever registry this target uses.
+///
+/// Called only from the `#[skyzen::openapi]` expansion, which builds the [`HandlerSpec`] and knows
+/// nothing about how it is stored — the two backends differ in the *shape* of a registration (a
+/// named `static` for `linkme`, an expression for `inventory`), and that difference stops here.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_handler_spec {
+    ($ident:ident, $spec:expr) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        #[$crate::openapi::registry::linkme::distributed_slice(
+            $crate::openapi::registry::HANDLER_SPECS
+        )]
+        #[linkme(crate = $crate::openapi::registry::linkme)]
+        static $ident: $crate::openapi::HandlerSpec = $spec;
+
+        #[cfg(target_arch = "wasm32")]
+        $crate::openapi::registry::inventory::submit! { $spec }
+    };
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -171,17 +171,34 @@ pub use nest::{NestedPathError, NestedRouter};
 pub trait ServedRoutes {
     /// Every `(method, path)` pair this endpoint answers, in `matchit` path syntax.
     fn served_routes(&self) -> &[(MethodFilter, String)];
+
+    /// The `OpenAPI` document these routes describe.
+    ///
+    /// Defaulted so that a hand-written implementation — a test stub standing in for a router —
+    /// does not have to invent one. [`Router`] and every wrapper the framework puts around one
+    /// override it, so an ordinary application always gets the real document.
+    fn openapi_document(&self) -> OpenApi {
+        OpenApi::default()
+    }
 }
 
 impl ServedRoutes for Router {
     fn served_routes(&self) -> &[(MethodFilter, String)] {
         self.routes()
     }
+
+    fn openapi_document(&self) -> OpenApi {
+        self.openapi()
+    }
 }
 
 impl<E: ServedRoutes> ServedRoutes for crate::middleware::Layered<E> {
     fn served_routes(&self) -> &[(MethodFilter, String)] {
         self.endpoint().served_routes()
+    }
+
+    fn openapi_document(&self) -> OpenApi {
+        self.endpoint().openapi_document()
     }
 }
 
@@ -446,6 +463,12 @@ impl Route {
     }
 
     /// Enable the Scalar API documentation endpoint at `/api-docs`.
+    ///
+    /// The document is titled after the application, which it learns from what `#[skyzen::main]`
+    /// registered rather than from an argument — see [`AppInfo`](openapi::AppInfo). Override that
+    /// with [`OpenApi::with_info`](openapi::OpenApi::with_info) and
+    /// [`scalar_route`](openapi::OpenApi::scalar_route) when the API's public name is not the
+    /// crate's.
     #[must_use]
     pub fn enable_api_doc(mut self) -> Self {
         let openapi = self.openapi();
@@ -509,6 +532,8 @@ impl RouteWithAlarm {
     }
 
     /// Enable the Scalar API documentation endpoint at `/api-docs`.
+    ///
+    /// Titled the same way [`Route::enable_api_doc`] is.
     #[must_use]
     pub fn enable_api_doc(mut self) -> Self {
         let openapi = self.route.openapi();

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -131,7 +131,7 @@
 
 use std::{fmt, sync::Arc};
 
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 use crate::openapi::RouteOpenApiEntry;
 #[cfg(feature = "ws")]
 use crate::websocket::{MaybeSend, MaybeSync, WebSocket};
@@ -432,14 +432,14 @@ impl Route {
     /// Generate an [`OpenApi`] document describing this route tree.
     #[must_use]
     pub fn openapi(&self) -> OpenApi {
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         {
             let mut entries = Vec::new();
             collect_openapi_entries("", &self.nodes, &mut entries);
             OpenApi::from_entries(&entries)
         }
 
-        #[cfg(not(all(feature = "openapi", not(target_arch = "wasm32"))))]
+        #[cfg(not(feature = "openapi"))]
         {
             OpenApi::default()
         }
@@ -943,7 +943,7 @@ pub(crate) fn join_path(prefix: &str, segment: &str) -> String {
     collapsed
 }
 
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 fn collect_openapi_entries(
     path_prefix: &str,
     nodes: &[RouteNode],
@@ -971,7 +971,7 @@ fn collect_openapi_entries(
 }
 
 /// A mounted router's operations, re-pathed under the prefix it is mounted at.
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 pub(crate) fn prefixed_openapi_entries(prefix: &str, router: &Router) -> Vec<RouteOpenApiEntry> {
     router
         .openapi_entries()

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -10,7 +10,7 @@ use super::{
     join_path, BoxEndpoint, EndpointFactory, MethodFilter, NestedRouter, Params, Route, RouteNode,
     RouteNodeType,
 };
-#[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+#[cfg(feature = "openapi")]
 use crate::openapi::RouteOpenApiEntry;
 use crate::{header, openapi::OpenApi, Body, Endpoint, Method, Request, Response, StatusCode};
 
@@ -102,7 +102,7 @@ pub struct Router {
     already_router_enabled: bool,
     /// Optional alarm handler for Durable Object alarm events.
     pub(crate) alarm_handler: Option<EndpointFactory>,
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     openapi_entries: Arc<Vec<RouteOpenApiEntry>>,
 }
 
@@ -117,7 +117,7 @@ impl Debug for Router {
             .field("has_method_not_allowed", &self.method_not_allowed.is_some())
             .field("already_router_enabled", &self.already_router_enabled)
             .field("has_alarm_handler", &self.alarm_handler.is_some());
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         {
             debug_struct.field("openapi_entries", &self.openapi_entries.len());
         }
@@ -337,19 +337,19 @@ impl Router {
     /// Build an [`OpenApi`] definition containing every route registered on this router.
     #[must_use]
     pub fn openapi(&self) -> OpenApi {
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         {
             OpenApi::from_entries(&self.openapi_entries)
         }
 
-        #[cfg(not(all(feature = "openapi", not(target_arch = "wasm32"))))]
+        #[cfg(not(feature = "openapi"))]
         {
             OpenApi::default()
         }
     }
 
     /// The `OpenAPI` entries this router was built from, for re-export by a router that mounts it.
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     pub(crate) fn openapi_entries(&self) -> &[RouteOpenApiEntry] {
         &self.openapi_entries
     }
@@ -548,9 +548,7 @@ fn flatten(
     path_prefix: &str,
     nodes: Vec<RouteNode>,
     buf: &mut FlattenBuf,
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))] openapi_entries: &mut Vec<
-        RouteOpenApiEntry,
-    >,
+    #[cfg(feature = "openapi")] openapi_entries: &mut Vec<RouteOpenApiEntry>,
 ) -> Result<(), RouteBuildError> {
     for node in nodes {
         let path = join_path(path_prefix, &node.path);
@@ -561,7 +559,7 @@ fn flatten(
                     &path,
                     route.into_mounted_nodes(),
                     buf,
-                    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+                    #[cfg(feature = "openapi")]
                     openapi_entries,
                 )?;
             }
@@ -576,7 +574,7 @@ fn flatten(
                     return Err(RouteBuildError::InvalidPath { path });
                 }
 
-                #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+                #[cfg(feature = "openapi")]
                 if let (Some(openapi), MethodFilter::Exact(exact)) = (openapi, &method) {
                     openapi_entries.push(RouteOpenApiEntry::new(
                         path.clone(),
@@ -584,7 +582,7 @@ fn flatten(
                         openapi,
                     ));
                 }
-                #[cfg(not(all(feature = "openapi", not(target_arch = "wasm32"))))]
+                #[cfg(not(feature = "openapi"))]
                 let _ = openapi;
 
                 buf.entry(path).or_default().push(FlatEndpoint {
@@ -604,7 +602,7 @@ fn flatten(
                     return Err(RouteBuildError::NestedPatternPrefix { path });
                 }
 
-                #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+                #[cfg(feature = "openapi")]
                 openapi_entries.extend(super::prefixed_openapi_entries(&path, &router));
 
                 let nested = NestedRouter::new(&path, router);
@@ -642,13 +640,13 @@ pub fn build(route: Route) -> Result<Router, RouteBuildError> {
     } = route;
 
     let mut buf = FlattenBuf::new();
-    #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+    #[cfg(feature = "openapi")]
     let mut openapi_entries = Vec::new();
     flatten(
         "",
         nodes,
         &mut buf,
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         &mut openapi_entries,
     )?;
 
@@ -686,7 +684,7 @@ pub fn build(route: Route) -> Result<Router, RouteBuildError> {
         routes: Arc::new(routes),
         already_router_enabled: false,
         alarm_handler: None,
-        #[cfg(all(feature = "openapi", not(target_arch = "wasm32")))]
+        #[cfg(feature = "openapi")]
         openapi_entries: Arc::new(openapi_entries),
     })
 }

--- a/src/runtime/cf.rs
+++ b/src/runtime/cf.rs
@@ -269,7 +269,7 @@ mod tests {
         // voided the entire `request.cf` decode before the tolerant deserializer.
         let bm: CfBotManagement =
             serde_json::from_str(r#"{"score":99,"detectionIds":{}}"#).unwrap();
-        assert!(bm.detection_ids.is_empty());
+        assert_eq!(bm.detection_ids, Vec::<u32>::new());
 
         let bm: CfBotManagement =
             serde_json::from_str(r#"{"detectionIds":{"a":3,"b":5}}"#).unwrap();

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -433,6 +433,70 @@ enum Platform {
     },
 }
 
+pub use skyzen_core::OPENAPI_DUMP_ENV;
+
+/// Print the application's `OpenAPI` document and report that the process should now exit, if
+/// [`OPENAPI_DUMP_ENV`] asked for it.
+///
+/// Returns `false` — having touched nothing, not even `factory` — when the variable is unset, so
+/// the ordinary startup path pays a single `getenv` for this.
+///
+/// `#[skyzen::main]` calls this *before* wiring services into the router, which is the whole point:
+/// a document describes the shape of an API, not a connection to anything, so producing one must
+/// not require credentials, a reachable database or a provisioned queue. `skyzen openapi` relies on
+/// that — it runs the binary in a project whose backends may not exist yet.
+///
+/// # Panics
+///
+/// Never returns on a failure: an unwritable path or a build with the `openapi` feature off exits
+/// non-zero, because a caller asked for a document and a silent empty one is worse than no answer.
+pub fn dump_openapi_if_requested<Fut, E>(factory: impl FnOnce() -> Fut) -> bool
+where
+    Fut: Future<Output = E>,
+    E: ServedRoutes,
+{
+    let Some(target) = std::env::var_os(OPENAPI_DUMP_ENV) else {
+        return false;
+    };
+
+    let document = smol::block_on(factory()).openapi_document();
+    if !document.is_enabled() {
+        error!(
+            "{OPENAPI_DUMP_ENV} was set, but this binary was built without skyzen's `openapi` \
+             feature, so it has no document to print"
+        );
+        std::process::exit(1);
+    }
+
+    let json = match serde_json::to_string_pretty(&document.to_utoipa_spec()) {
+        Ok(json) => json,
+        Err(error) => {
+            error!("Failed to serialize the OpenAPI document: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let path = std::path::Path::new(&target);
+    if path == std::path::Path::new("-") {
+        // The one place a Skyzen binary writes to stdout: the caller asked for the document *as*
+        // this process's output, so a logger would put it in the wrong stream.
+        use std::io::Write as _;
+        let mut stdout = std::io::stdout().lock();
+        if let Err(error) = writeln!(stdout, "{json}").and_then(|()| stdout.flush()) {
+            error!("Failed to write the OpenAPI document to stdout: {error}");
+            std::process::exit(1);
+        }
+    } else if let Err(error) = std::fs::write(path, &json) {
+        error!(
+            "Failed to write the OpenAPI document to {}: {error}",
+            path.display()
+        );
+        std::process::exit(1);
+    }
+
+    true
+}
+
 /// Set by the AWS Lambda execution environment, and by nothing else.
 const LAMBDA_RUNTIME_API_ENV: &str = "AWS_LAMBDA_RUNTIME_API";
 

--- a/tests/migrations.rs
+++ b/tests/migrations.rs
@@ -117,7 +117,7 @@ async fn status_reports_the_set_as_fully_applied() {
         status.applied[0].checksum,
         MIGRATIONS.as_slice()[0].checksum_hex()
     );
-    assert!(!status.applied[0].applied_at.is_empty());
+    assert_ne!(status.applied[0].applied_at, "");
 }
 
 /// The attribute argument: the database a test receives is already migrated when the body starts.

--- a/tests/openapi_app_info.rs
+++ b/tests/openapi_app_info.rs
@@ -1,0 +1,59 @@
+//! The identity a document is titled with comes from a registration, not from an argument.
+//!
+//! `#[skyzen::main]` emits `__register_app_info!` in the application's crate, where
+//! `env!("CARGO_PKG_NAME")` reads the application rather than skyzen. This file stands in for that
+//! application: it registers an identity the same way, and checks the document picks it up with
+//! nothing passed through the routing API.
+//!
+//! It is a file of its own because a registration is per *binary*. The anonymous fallback — what a
+//! library under test or an embedded runtime gets — can only be observed in a binary that
+//! registered nothing, and is asserted in the crate's own unit tests instead.
+
+use skyzen::{
+    openapi::AppInfo,
+    routing::{CreateRouteNode, Route},
+};
+
+skyzen::__register_app_info!(
+    APP_INFO,
+    AppInfo {
+        name: "orders-service",
+        version: "4.2.0",
+        description: Some("Order placement and fulfilment"),
+    }
+);
+
+async fn health() -> &'static str {
+    "OK"
+}
+
+#[test]
+fn a_document_is_titled_by_what_was_registered_not_by_an_argument() {
+    let spec = Route::new(("/health".at(health),))
+        .openapi()
+        .to_utoipa_spec();
+
+    assert_eq!(spec.info.title, "orders-service");
+    assert_eq!(spec.info.version, "4.2.0");
+    assert_eq!(
+        spec.info.description.as_deref(),
+        Some("Order placement and fulfilment")
+    );
+}
+
+#[test]
+fn with_info_overrides_the_registration() {
+    // For an API whose public name is not its crate's.
+    let spec = Route::new(("/health".at(health),))
+        .openapi()
+        .with_info(AppInfo {
+            name: "Orders API",
+            version: "2",
+            description: None,
+        })
+        .to_utoipa_spec();
+
+    assert_eq!(spec.info.title, "Orders API");
+    assert_eq!(spec.info.version, "2");
+    assert_eq!(spec.info.description, None);
+}


### PR DESCRIPTION
Fixes #47. **Stacked on #48** — review that first; this branch contains its commits until it merges.

```
$ skyzen openapi
[skyzen] cargo run (SKYZEN_OPENAPI_DUMP=.skyzen/gen/openapi.json)
[skyzen] write .skyzen/gen/openapi.json (3 operations)
[skyzen] write .skyzen/gen/openapi.html
[skyzen] open file:///…/.skyzen/gen/openapi.html
```

## How it gets the document

Only the compiled binary knows what `#[skyzen::openapi]` collected, so the application prints its
own: `SKYZEN_OPENAPI_DUMP` makes `#[skyzen::main]` write the document and exit. An environment
variable rather than a flag because the application owns its argv — the same reasoning
`AWS_LAMBDA_RUNTIME_API` already follows.

The dump runs **before the factory wires any service**, and that is the feature, not an
implementation detail: the command needs no credentials, no reachable backend and no complete
`.env`. Proven by contrast rather than asserted — in a scaffolded project with `JOURNAL_URL` unset:

```
$ skyzen dev
error: Skyzen.toml declares environment variables that are not set and are in no .env file:
  JOURNAL_URL (declared by [native.database.journal].url_env)

$ skyzen openapi --print | jq .info
{ "title": "apidemo", "version": "0.1.0" }
```

The page is a local file with the document embedded rather than fetched, so nothing is served and no
port is used — which matters, because the CLI has no HTTP server and never learns the application's
port (the native runtime binds `127.0.0.1:0` by default).

`OPENAPI_DUMP_ENV` is defined once, in `skyzen-core` — the one crate the CLI and the runtime already
share. The CLI does not depend on `skyzen` (that would drag hyper and sqlx into it), and making the
root crate depend on `skyzen-manifest` would put a TOML parser in every wasm bundle.

## Titling the document, without touching the routing API

`OpenApi::default_info` is `Info::new(env!("CARGO_PKG_NAME"), …)` expanded *inside skyzen*, so every
document anyone generates today is titled `skyzen 0.2.1`.

The obvious fix — a parameter on `enable_api_doc` — is not the one here. `env!` expands where it is
written, and `#[skyzen::main]` expands in the **application's** crate, so it registers an `AppInfo`
into `registry::APP_INFO` exactly as `#[skyzen::openapi]` registers a `HandlerSpec`. `OpenApi::info`
reads it. One per binary, because one attribute defines a binary.

So `enable_api_doc()` keeps its signature, nothing carries a name through the routing API, and the
cost is a handler spec's: nothing natively, one ctor on wasm. Verified with no argument anywhere in
the source, on **both targets**:

| | `info` |
|---|---|
| `skyzen openapi` (native) | `{"title": "apidemo", "version": "0.1.0"}` |
| `GET /api-docs` in `wrangler dev` | `{"title": "apidemo", "version": "0.1.0"}` |

`OpenApi::with_info` overrides it, for an API whose public name is not its crate's — `orders-service`
the crate, "Orders API" the product. With neither, the title is an anonymous `API 0.0.0`, reachable
only outside an application (a library under test, or an embedded runtime), and better than
confidently naming the wrong crate.

## Also here

- **`OpenApi::json_route`** — there was no raw-spec endpoint anywhere in the repo, so a deployed
  application could not serve its own `/openapi.json`. `OpenApiUiEndpoint` now carries a content
  type instead of hardcoding `text/html`, so the JSON route reuses the same pre-rendered machinery.
- **`--print` writes progress to stderr.** The first run of `skyzen openapi --print | jq` failed:
  `[skyzen] …` lines were landing in the pipe. When stdout is the payload, progress belongs beside it.

## Verified

- `cargo clippy --workspace --all-targets --all-features` clean; full workspace suite passes.
- `cargo check -p skyzen` for `wasm32-unknown-unknown` and with `--no-default-features`.
- `tests/openapi_app_info.rs` registers an identity and asserts the document picks it up — its own
  test binary, because registration is per-binary — plus a unit test pinning the anonymous fallback
  so a regression cannot quietly go back to claiming to be skyzen.
- `cargo test -p skyzen-cli`: parse tests for the subcommand (including `--print` conflicting with
  `--json`), and a render test asserting the page embeds the document rather than linking to it.
- Rendered page opened in a browser: Scalar loads, three operations, the `Greeting` model.
- Every output path exercised end to end against a scaffolded project: default, `--json`, `--print`,
  `--no-open`, `--dry-run` (writes nothing).
