### PR TITLE
fix(cli): pin the scaffolded compatibility_date instead of reading the clock

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,7 +45,6 @@ skyzen-manifest.workspace = true
 # links the same runner and the same sqlx drivers the application would use. `runtime-tokio-rustls`
 # picks sqlx's primary runtime; the CLI drives it on a current-thread runtime of its own.
 skyzen-services = { workspace = true, features = ["runtime-tokio-rustls"] }
-time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1.49", features = ["rt", "net", "time"] }
 toml = "1.0"
 toml_edit = "0.22"

--- a/cli/src/providers/mod.rs
+++ b/cli/src/providers/mod.rs
@@ -824,6 +824,22 @@ fn check_cloudflare_manifest(manifest: &Manifest, environment: Option<&str>) -> 
         }
     }
 
+    if let Some(config) = config {
+        match compatibility_date_problem(config.compatibility_date.as_deref()) {
+            None => output::ok(format!(
+                "cloudflare: compatibility_date is within what this CLI targets ({})",
+                crate::scaffold::COMPATIBILITY_DATE
+            )),
+            Some(problem) => {
+                // A warning, not a failure: a newer date is exactly right for someone running a
+                // newer wrangler than this CLI was released against, and doctor cannot ask
+                // workerd what it supports. Saying so beats either staying silent until
+                // `wrangler dev` fails, or refusing a configuration that may be correct.
+                output::warn(format!("cloudflare: {problem}"));
+            }
+        }
+    }
+
     match Project::load(manifest.root_dir())
         .and_then(|project| cloudflare::build::check_wasm_bindgen_agreement(&project))
     {
@@ -838,6 +854,27 @@ fn check_cloudflare_manifest(manifest: &Manifest, environment: Option<&str>) -> 
     }
 
     failures
+}
+
+/// Say whether a project's `compatibility_date` is likely to outrun the local Workers runtime.
+///
+/// `workerd` refuses a date newer than its own binary knows, and reports that as a startup failure
+/// naming wrangler rather than the manifest. Nothing here can ask workerd what it supports, so the
+/// comparison is against the date this CLI is released against — a date beyond it is not wrong,
+/// but it is the shape of the configuration that fails, and worth saying before `wrangler dev`
+/// says it less clearly.
+///
+/// ISO-8601 dates compare correctly as strings, so this needs no date library — and the CLI no
+/// longer carries one now that `skyzen new` stamps a pinned date rather than reading the clock.
+fn compatibility_date_problem(declared: Option<&str>) -> Option<String> {
+    let declared = declared?;
+    let targeted = crate::scaffold::COMPATIBILITY_DATE;
+    (declared > targeted).then(|| {
+        format!(
+            "compatibility_date {declared} is newer than the {targeted} this CLI targets; if \
+             `wrangler dev` refuses to start, that is why \u{2014} lower it, or update wrangler"
+        )
+    })
 }
 
 /// The runtime variables one provider needs, resolved, plus the environment its child gets.
@@ -926,6 +963,28 @@ fn ensure_declared_secret(manifest: &SkyzenManifest, name: &VarName) -> Result<(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_compatibility_date_within_what_the_cli_targets_is_not_reported() {
+        use super::compatibility_date_problem;
+        assert!(compatibility_date_problem(None).is_none());
+        assert!(compatibility_date_problem(Some(crate::scaffold::COMPATIBILITY_DATE)).is_none());
+        assert!(compatibility_date_problem(Some("2024-01-01")).is_none());
+    }
+
+    #[test]
+    fn a_compatibility_date_beyond_it_says_why_wrangler_would_refuse_to_start() {
+        use super::compatibility_date_problem;
+        // The shape of #51: a date past what the local runtime knows, which workerd rejects with
+        // an error naming its own binary rather than the manifest.
+        let problem = compatibility_date_problem(Some("2099-01-01")).expect("should be reported");
+        assert!(problem.contains("2099-01-01"), "{problem}");
+        assert!(
+            problem.contains(crate::scaffold::COMPATIBILITY_DATE),
+            "{problem}"
+        );
+        assert!(problem.contains("wrangler dev"), "{problem}");
+    }
     use super::{Action, CommandPlan, CommandStdin};
     use crate::cli::Provider;
     use skyzen_manifest::VarName;

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -17,7 +17,6 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use time::{macros::format_description, OffsetDateTime};
 
 /// The values every scaffold template substitutes.
 #[derive(Debug)]
@@ -262,6 +261,24 @@ pub struct ScaffoldRequest<'a> {
     pub install_dependencies: bool,
 }
 
+/// The Workers compatibility date `skyzen new` writes into a generated project.
+///
+/// Pinned, not "today". `workerd` refuses any date newer than the one its own binary knows, so
+/// stamping `now_utc()` here made a freshly scaffolded project fail the first time it ran unless
+/// the user's wrangler happened to be released that same day — on the `skyzen new` → `skyzen dev`
+/// path, with an error naming wrangler's binary rather than the file skyzen wrote.
+///
+/// This is the newest date the wrangler generation this CLI targets is known to accept: wrangler
+/// 4.110.0's `workerd` reports it as the newest it supports. Bump it alongside a release, exactly
+/// as `wasm-bindgen` is pinned to the generator this binary embeds — the same class of value, and
+/// the same reason for pinning it.
+///
+/// A fixed date is also the more honest semantic. `compatibility_date` records the behaviour a
+/// project was *written against*, not the day its skeleton happened to be generated; deriving it
+/// from the clock additionally meant two `skyzen new` runs on different days produced different
+/// projects from identical inputs.
+pub const COMPATIBILITY_DATE: &str = "2026-07-15";
+
 /// Generate a project.
 ///
 /// # Errors
@@ -277,9 +294,7 @@ pub fn create_project(request: &ScaffoldRequest<'_>) -> Result<()> {
     let ctx = ScaffoldContext {
         worker_name: package_name.replace('_', "-"),
         package_name,
-        compatibility_date: OffsetDateTime::now_utc()
-            .format(&format_description!("[year]-[month]-[day]"))
-            .context("failed to format the Workers compatibility date")?,
+        compatibility_date: COMPATIBILITY_DATE.to_owned(),
         wasm_bindgen_version: embedded_wasm_bindgen_version(),
     };
 

--- a/cli/src/scaffold/tests.rs
+++ b/cli/src/scaffold/tests.rs
@@ -484,6 +484,25 @@ fn the_env_example_lists_what_the_template_manifest_declares() {
 }
 
 #[test]
+fn a_scaffolded_project_pins_its_compatibility_date_instead_of_reading_the_clock() {
+    // #51: `now_utc()` here produced a project workerd refused to start, because it rejects any
+    // date newer than its own binary knows — on the `skyzen new` → `skyzen dev` path. Deriving it
+    // from the clock also made two runs on different days produce different projects.
+    let dir = temp_dir();
+    let path = project_dir(&dir);
+    create_project(&request(&path, Template::Api)).expect("template generation should succeed");
+
+    let manifest = std::fs::read_to_string(path.join("Skyzen.toml")).unwrap();
+    let declared = manifest
+        .lines()
+        .find_map(|line| line.strip_prefix("compatibility_date = "))
+        .expect("the api template declares a compatibility date")
+        .trim_matches('"');
+
+    assert_eq!(declared, crate::scaffold::COMPATIBILITY_DATE);
+}
+
+#[test]
 fn scaffolded_templates_compile() {
     let dir = temp_dir();
     let root = dir.path().to_path_buf();


### PR DESCRIPTION
Fixes #51. Independent of #48/#50 — branches off `dev`.

`skyzen new` stamped `OffsetDateTime::now_utc()` into the generated `Skyzen.toml`, so a project
declared **today's** date. workerd refuses any date newer than its own binary knows, so a freshly
scaffolded project failed the first time it ran:

```
$ skyzen new apidemo -t api
$ skyzen dev --provider cloudflare
✘ [ERROR] service core:user:apidemo: This Worker requires compatibility date "2026-09-02",
  but the newest date supported by this server binary is "2026-07-15".
```

That is the `skyzen new` → `skyzen dev` path, and the error names wrangler's binary rather than the
file skyzen wrote, so it does not point at the fix.

## Why pinning, and not something cleverer

The same class of value one field away in the same `ScaffoldContext` is already pinned rather than
floating. `wasm_bindgen_version` is `embedded_wasm_bindgen_version()` — the version the CLI's own
generator agrees with — because leaving it loose "makes the first Cloudflare build fail with an
opaque error", in the template's own words. `compatibility_date` has exactly that shape and was the
one that got `now_utc()`.

A fixed date is also the more honest semantic: `compatibility_date` records the behaviour a project
was *written against*, not the day its skeleton happened to be generated. Reading the clock
additionally meant two `skyzen new` runs on different days produced different projects from
identical inputs.

## `skyzen doctor`

Now warns when a project's date is beyond what this CLI targets. A **warning, not a failure** — a
newer date is exactly right for someone running a newer wrangler than this CLI was released
against, and doctor has no way to ask workerd what it supports. Saying so beats either staying
silent until `wrangler dev` fails, or refusing a configuration that may well be correct.

## Verified

The check that matters is that a pristine scaffold now starts, since that is what failed:

```
$ skyzen new fixdemo -t api            # no hand-editing of anything
$ skyzen build --provider cloudflare   # rc=0
$ wrangler dev --local ...
$ curl localhost:8788/health
OK
```

No compatibility error in wrangler's output. Previously this needed the generated
`.skyzen/gen/wrangler.toml` edited by hand.

Also: `cargo test -p skyzen-cli` (179 pass), `cargo clippy -p skyzen-cli --all-targets` clean, and
`cargo machete` clean — dropping `now_utc()` left `time` unused in the CLI, so it goes too. The
doctor comparison needs no date library: ISO-8601 dates compare correctly as strings.

Three tests pin the behaviour, including one asserting a scaffolded project's declared date equals
the pinned constant rather than anything clock-derived.
