### PR TITLE
Merge main back into dev after the v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zen-rs/skyzen/compare/v0.2.1...v0.3.0) - 2026-09-05
+
+### Added
+
+- *(openapi)* [**breaking**] serve Scalar as the default API docs UI
+
+### Fixed
+
+- *(cloudflare)* send queue messages as a Uint8Array view
+- *(wasm)* omit bodies for null-body responses
+- *(azure)* [**breaking**] speak the Service Bus REST API directly, dropping legacy azure_core
+
+### Other
+
+- Merge pull request #50 from zen-rs/feat/skyzen-openapi-command
+- Merge pull request #48 from zen-rs/feat/openapi-on-wasm
+- Merge pull request #38 from zen-rs/fix/issue-37-null-body-response
+- Merge pull request #41 from zen-rs/feat/unified-secrets
+- *(readme)* add GitHub Secrets and .env integration
+- Revert "docs(readme): add GitHub Secrets and .env integration"
+- *(readme)* add GitHub Secrets and .env integration
+
 ## [0.2.1](https://github.com/zen-rs/skyzen/compare/v0.2.0...v0.2.1) - 2026-08-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,20 +6,20 @@ default-members = ["core", "hyper", "lambda", "macros", "manifest", "services", 
 resolver = "2"
 
 [workspace.dependencies]
-skyzen-core = { path = "core", version = "0.2.0" }
-skyzen-macros = { path = "macros", version = "0.2.1" }
-skyzen-manifest = { path = "manifest", version = "0.1.1" }
-skyzen-services = { path = "services", version = "0.2.0" }
-skyzen-test = { path = "test", version = "0.2.0" }
-skyzen-redis = { path = "redis", version = "0.2.0" }
-skyzen-s3 = { path = "s3", version = "0.2.0" }
+skyzen-core = { path = "core", version = "0.2.1" }
+skyzen-macros = { path = "macros", version = "0.3.0" }
+skyzen-manifest = { path = "manifest", version = "0.2.0" }
+skyzen-services = { path = "services", version = "0.2.1" }
+skyzen-test = { path = "test", version = "0.2.1" }
+skyzen-redis = { path = "redis", version = "0.2.1" }
+skyzen-s3 = { path = "s3", version = "0.2.1" }
 
 http-kit = "0.4.2"
 executor-core = { version = "0.7.1", default-features = false, features = ["std", "async-executor"] }
-skyzen-hyper = { path = "hyper", version = "0.2.0" }
-skyzen-lambda = { path = "lambda", version = "0.1.0" }
+skyzen-hyper = { path = "hyper", version = "0.2.1" }
+skyzen-lambda = { path = "lambda", version = "0.1.1" }
 tracing = "0.1.44"
-skyzen = { path = ".", version = "0.2.1" }
+skyzen = { path = ".", version = "0.3.0" }
 smol = "2.0"
 async-executor = "1.13"
 async-io = "2.6"
@@ -43,7 +43,7 @@ clippy.multiple_crate_versions = { level = "allow", priority = 1 }
 
 [package]
 name = "skyzen"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "A fast, ergonomic HTTP framework that works everywhere"
 license = "MIT OR Apache-2.0"

--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-aws-v0.2.0...skyzen-aws-v0.2.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-services, skyzen-s3
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-aws-v0.1.0...skyzen-aws-v0.2.0) - 2026-08-27
 
 ### Added

--- a/aws/Cargo.toml
+++ b/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-aws"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "AWS service implementations for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ keywords = ["aws", "dynamodb", "sqs", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services", version = "0.2.0" }
-skyzen-s3 = { path = "../s3", version = "0.2.0", optional = true }
+skyzen-services = { path = "../services", version = "0.2.1" }
+skyzen-s3 = { path = "../s3", version = "0.2.1", optional = true }
 aws-config = "1"
 # Disable the SDK default `rustls` feature: it pulls the legacy `tls-rustls` connector
 # (rustls 0.21 / hyper-rustls 0.24), which is redundant with the modern `default-https-client`

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zen-rs/skyzen/compare/skyzen-azure-v0.2.0...skyzen-azure-v0.3.0) - 2026-09-05
+
+### Fixed
+
+- *(azure)* [**breaking**] speak the Service Bus REST API directly, dropping legacy azure_core
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-azure-v0.1.0...skyzen-azure-v0.2.0) - 2026-08-27
 
 ### Added

--- a/azure/Cargo.toml
+++ b/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-azure"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Azure service implementations for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["azure", "cosmos", "blob", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services", version = "0.2.0" }
+skyzen-services = { path = "../services", version = "0.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zen-rs/skyzen/compare/skyzen-cli-v0.2.1...skyzen-cli-v0.3.0) - 2026-09-05
+
+### Added
+
+- *(cli)* [**breaking**] deliver runtime variables to Azure app settings
+- *(cli)* deliver runtime variables to Lambda through the SDK
+- *(cli)* deliver [[secret]] values to Cloudflare over stdin
+- *(manifest)* [**breaking**] make secrets a portable capability with `[[secret]]`
+
+### Fixed
+
+- *(cli)* pin the scaffolded compatibility_date instead of reading the clock
+
+### Other
+
+- Merge pull request #50 from zen-rs/feat/skyzen-openapi-command
+- Merge pull request #48 from zen-rs/feat/openapi-on-wasm
+- *(cli)* join the wrangler config path the way the plan does
+- describe the unified secret system
+- *(cli)* plans are ordered steps with typed stdin
+- *(cli)* resolve runtime variables through one Environment
+
 ## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-cli-v0.2.0...skyzen-cli-v0.2.1) - 2026-08-29
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Unified local emulation and deployment CLI for Skyzen"
 license = "MIT OR Apache-2.0"

--- a/cloudflare-admin/CHANGELOG.md
+++ b/cloudflare-admin/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zen-rs/skyzen/compare/skyzen-cloudflare-admin-v0.2.0...skyzen-cloudflare-admin-v0.3.0) - 2026-09-05
+
+### Added
+
+- *(cli)* add `skyzen openapi`, and title documents by registration
+- *(openapi)* [**breaking**] serve the same document on every target
+- *(openapi)* [**breaking**] serve Scalar as the default API docs UI
+
+### Other
+
+- Merge pull request #41 from zen-rs/feat/unified-secrets
+- *(readme)* add GitHub Secrets and .env integration
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-cloudflare-admin-v0.1.1...skyzen-cloudflare-admin-v0.2.0) - 2026-08-27
 
 ### Added

--- a/cloudflare-admin/Cargo.toml
+++ b/cloudflare-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-cloudflare-admin"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Shared Cloudflare API response envelope types and token-source configuration for building Cloudflare control-plane tooling"
 license = "MIT OR Apache-2.0"

--- a/cloudflare/CHANGELOG.md
+++ b/cloudflare/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zen-rs/skyzen/compare/skyzen-cloudflare-v0.2.1...skyzen-cloudflare-v0.3.0) - 2026-09-05
+
+### Fixed
+
+- *(cloudflare)* send queue messages as a Uint8Array view
+
+### Other
+
+- describe the unified secret system
+- *(cloudflare)* [**breaking**] expose CfSecret returning skyzen::Secret
+
 ## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-cloudflare-v0.2.0...skyzen-cloudflare-v0.2.1) - 2026-08-29
 
 ### Other

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-cloudflare"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Cloudflare Workers service implementations for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ keywords = ["cloudflare", "workers", "skyzen", "services"]
 categories = ["web-programming::http-server", "wasm"]
 
 [dependencies]
-skyzen = { path = "..", version = "0.2.1", default-features = false, features = ["ws"] }
-skyzen-services = { path = "../services", version = "0.2.0" }
+skyzen = { path = "..", version = "0.3.0", default-features = false, features = ["ws"] }
+skyzen-services = { path = "../services", version = "0.2.1" }
 worker-sys = { version = "0.7", features = ["d1", "queue"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/core-v0.2.0...core-v0.2.1) - 2026-09-05
+
+### Added
+
+- *(cli)* add `skyzen openapi`, and title documents by registration
+- *(core)* add the redacting Secret type
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/core-v0.1.1...core-v0.2.0) - 2026-08-27
 
 ### Added

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Foundational extractor/responder traits for the Skyzen framework"
 license = "MIT OR Apache-2.0"

--- a/hyper/CHANGELOG.md
+++ b/hyper/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/hyper-v0.2.0...hyper-v0.2.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-core
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/hyper-v0.1.1...hyper-v0.2.0) - 2026-08-27
 
 ### Added

--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-hyper"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Hyper server backend for the Skyzen framework"
 license = "MIT OR Apache-2.0"

--- a/lambda/CHANGELOG.md
+++ b/lambda/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/zen-rs/skyzen/compare/lambda-v0.1.0...lambda-v0.1.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-core, skyzen-services
+
 ## [0.1.0](https://github.com/zen-rs/skyzen/releases/tag/lambda-v0.1.0) - 2026-08-27
 
 ### Added

--- a/lambda/Cargo.toml
+++ b/lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-lambda"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "AWS Lambda runtime adapter for the Skyzen HTTP framework"
 license = "MIT OR Apache-2.0"

--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zen-rs/skyzen/compare/macros-v0.2.1...macros-v0.3.0) - 2026-09-05
+
+### Added
+
+- *(cli)* add `skyzen openapi`, and title documents by registration
+- *(openapi)* [**breaking**] serve the same document on every target
+- *(macros)* generate a named Secret extractor per [[secret]]
+- *(manifest)* [**breaking**] make secrets a portable capability with `[[secret]]`
+
+### Other
+
+- *(openapi)* keep the registry's public surface the same on every target
+
 ## [0.2.1](https://github.com/zen-rs/skyzen/compare/macros-v0.2.0...macros-v0.2.1) - 2026-08-29
 
 ### Other

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-macros"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "Procedural macros powering the Skyzen web framework"
 license = "MIT OR Apache-2.0"

--- a/manifest/CHANGELOG.md
+++ b/manifest/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-manifest-v0.1.1...skyzen-manifest-v0.2.0) - 2026-09-05
+
+### Added
+
+- *(cli)* [**breaking**] deliver runtime variables to Azure app settings
+- *(cli)* deliver [[secret]] values to Cloudflare over stdin
+- *(manifest)* [**breaking**] make secrets a portable capability with `[[secret]]`
+
+### Other
+
+- describe the unified secret system
+
 ## [0.1.1](https://github.com/zen-rs/skyzen/compare/skyzen-manifest-v0.1.0...skyzen-manifest-v0.1.1) - 2026-08-29
 
 ### Added

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-manifest"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Typed Skyzen.toml schema shared by the Skyzen CLI and the Skyzen procedural macros"
 license = "MIT OR Apache-2.0"

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-redis-v0.2.0...skyzen-redis-v0.2.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-services
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-redis-v0.1.0...skyzen-redis-v0.2.0) - 2026-08-27
 
 ### Added

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-redis"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Redis implementation of KeyValueStore for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["redis", "key-value", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services", version = "0.2.0" }
+skyzen-services = { path = "../services", version = "0.2.1" }
 # `script` is what `compare_and_swap` runs on: Redis has no compare-and-swap command, and a
 # GET/SET pair is not atomic. It brings in `sha1_smol` for the EVALSHA cache key.
 redis = { version = "1", default-features = false, features = ["aio", "connection-manager", "script"], optional = true }

--- a/s3/CHANGELOG.md
+++ b/s3/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-s3-v0.2.0...skyzen-s3-v0.2.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-services
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-s3-v0.1.0...skyzen-s3-v0.2.0) - 2026-08-27
 
 ### Added

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-s3"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "S3-compatible ObjectStorage implementation for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["s3", "object-storage", "skyzen", "services"]
 categories = ["web-programming::http-server", "database"]
 
 [dependencies]
-skyzen-services = { path = "../services", version = "0.2.0" }
+skyzen-services = { path = "../services", version = "0.2.1" }
 # Disable the SDK default `rustls` feature: it pulls the legacy `tls-rustls` connector
 # (rustls 0.21 / hyper-rustls 0.24), which is redundant with the modern `default-https-client`
 # (rustls-aws-lc) and carries unpatched RustSec advisories. The default HTTPS client is unaffected.

--- a/services/CHANGELOG.md
+++ b/services/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-services-v0.2.0...skyzen-services-v0.2.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-core
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-services-v0.1.0...skyzen-services-v0.2.0) - 2026-08-27
 
 ### Added

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-services"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Portable service abstractions for the Skyzen framework"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["http", "web", "framework", "services"]
 categories = ["web-programming::http-server"]
 
 [dependencies]
-skyzen-core = { path = "../core", version = "0.2.0" }
+skyzen-core = { path = "../core", version = "0.2.1" }
 http-kit.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/test/CHANGELOG.md
+++ b/test/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/zen-rs/skyzen/compare/skyzen-test-v0.2.0...skyzen-test-v0.2.1) - 2026-09-05
+
+### Other
+
+- updated the following local packages: skyzen-core, skyzen-services
+
 ## [0.2.0](https://github.com/zen-rs/skyzen/compare/skyzen-test-v0.1.0...skyzen-test-v0.2.0) - 2026-08-27
 
 ### Added

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyzen-test"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Testing utilities and mock implementations for the Skyzen framework"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The v0.3.0 release commit (#56) never came back to `dev`, so `dev` still carries the 0.2.1 versions and `main` refuses the release PR #63 as behind. A true merge of `main` into `dev`; no source change.